### PR TITLE
feat: add husky for git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run format

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run format
+yarn format

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
 		"build": "vite build",
 		"preview": "vite preview",
 		"lint": "prettier --check .",
-		"format": "prettier --write ."
+		"format": "prettier --write .",
+		"prepare": "husky install"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^1.0.0-next.80",
 		"@sveltejs/adapter-node": "^1.0.0-next.96",
 		"@sveltejs/kit": "1.0.0-next.504",
 		"autoprefixer": "^10.4.12",
+		"husky": "^8.0.1",
 		"postcss": "^8.4.16",
 		"prettier": "^2.6.2",
 		"prettier-plugin-svelte": "^2.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,10 @@ https-proxy-agent@^5.0.0:
   dependencies:
     agent-base "6"
     debug "4"
+husky@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
 
 inflight@^1.0.4:
   version "1.0.6"


### PR DESCRIPTION


**A description of the changes proposed in the pull request**

Adds the [husky](https://www.npmjs.com/package/husky) dependency with automated prettier formatting for consistency and increased maintainability. This can easily be extended to include any scripts we want to run prior to committing (such as ESLint, tests, or Typescript checks if we choose to add)

<img width="467" alt="Screen Shot 2022-09-23 at 3 35 51 PM" src="https://user-images.githubusercontent.com/38222767/192044151-1a88b045-c245-408f-87d3-4e109e781236.png">
