### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/src/lib/map/setup.js
+++ b/src/lib/map/setup.js
@@ -71,7 +71,7 @@ export const toggleMapButtons = () => {
 export const layers = (leaflet, map) => {
 	const theme = detectTheme();
 
-	const osm = leaflet.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+	const osm = leaflet.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
 		noWrap: true,
 		maxZoom: 19
 	});


### PR DESCRIPTION
I would like to suggest using the now preferred https://tile.openstreetmap.org URL instead of the current one (`{s}`), see

https://github.com/openstreetmap/operations/issues/737