### PR TITLE
add borders to control-icons to fix shadow

### DIFF
--- a/src/lib/map/setup.ts
+++ b/src/lib/map/setup.ts
@@ -404,6 +404,7 @@ export const changeDefaultIcons = (
 		};
 	}
 	fullscreenButton.classList.add('dark:!bg-dark', 'dark:hover:!bg-dark/75', 'dark:border');
+	fullscreenButton.style.borderBottom = '1px solid #ccc';
 
 	leafletBar?.append(fullscreenButton);
 
@@ -433,6 +434,7 @@ export const geolocate = (L: Leaflet, map: Map) => {
 	);
 	if (locateButton) {
 		locateButton.style.borderRadius = '8px';
+		locateButton.style.borderBottom = '1px solid #ccc';
 		if (theme === 'light') {
 			const locateIcon: HTMLImageElement | null = document.querySelector('#locatebutton');
 			if (locateIcon) {
@@ -540,6 +542,7 @@ export const homeMarkerButtons = (
 					};
 				}
 				communityMapButton.classList.add('dark:!bg-dark', 'dark:hover:!bg-dark/75', 'dark:border');
+				communityMapButton.style.borderBottom = '1px solid #ccc';
 
 				addControlDiv.append(communityMapButton);
 			} else {

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -465,6 +465,7 @@
 								: '/icons/boost.svg'
 					} alt='boost' class='inline' id='boost-layer'/>`;
 					boostLayerButton.style.borderRadius = '0 0 8px 8px';
+					boostLayerButton.style.borderBottom = '1px solid #ccc';
 					boostLayerButton.onclick = function toggleLayer() {
 						if (boosts) {
 							$page.url.searchParams.delete('boosts');


### PR DESCRIPTION
**Does this PR address a related issue?**
https://github.com/teambtcmap/btcmap.org/issues/82

**A description of the changes proposed in the pull request**
It makes sure the border: none property is not applied, by setting the border bottom to '1px solid #ccc' on the icons. Currently the borders at the bottom don't look right.

**Screenshots**
<img width="48" alt="image" src="https://github.com/user-attachments/assets/b5de7ac6-f23b-4e7e-96a3-62558d1cdf37" />

**Additional context**
