### PR TITLE
chore: add playwright setup and basic test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,25 @@
+name: Playwright Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install -g yarn && yarn
+      - name: Install Playwright Browsers
+        run: yarn playwright install --with-deps
+      - name: Run Playwright tests
+        run: yarn playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .netlify
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ _NOTE:_ BTC Map uses the latest LTS version of [node](https://nodejs.org/). If y
 - [vite-plugin-icons-spritesheet](https://github.com/forge-42/vite-plugin-icons-spritesheet): for individual icons (i.e. apps) spritesheets are automatically generated  
   During development the spritsheets might not update. Use a private-tab to check the latest version.
 
+### E2E tests
+
+```sh
+  yarn playwright test
+    Runs the end-to-end tests.
+
+  yarn playwright test --ui
+    Starts the interactive UI mode.
+
+  yarn playwright test --project=chromium
+    Runs the tests only on Desktop Chrome.
+
+  yarn playwright test example
+    Runs the tests in a specific file.
+
+  yarn playwright test --debug
+    Runs the tests in debug mode.
+
+  yarn playwright codegen
+    Auto generate tests with Codegen.
+```
+
 ## PWA
 
 This website is a progressive web app, meaning you can install it on your mobile device and use it like a native application. Just look for the **Add to home screen** or **Install** option in your browser while visiting [btcmap.org](https://btcmap.org).

--- a/README.md
+++ b/README.md
@@ -41,9 +41,6 @@ _NOTE:_ BTC Map uses the latest LTS version of [node](https://nodejs.org/). If y
 
   yarn playwright test --debug
     Runs the tests in debug mode.
-
-  yarn playwright codegen
-    Auto generate tests with Codegen.
 ```
 
 ## PWA

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	"devDependencies": {
 		"@eslint/js": "^9.24.0",
 		"@iconify/svelte": "^4.2.0",
+		"@playwright/test": "^1.50.1",
 		"@sveltejs/adapter-netlify": "^4.4.0",
 		"@sveltejs/kit": "^2.15.2",
 		"@sveltejs/vite-plugin-svelte": "^3.1.0",
@@ -27,6 +28,7 @@
 		"@types/leaflet.featuregroup.subgroup": "^1.0.3",
 		"@types/leaflet.locatecontrol": "^0.74.6",
 		"@types/leaflet.markercluster": "^1.5.5",
+		"@types/node": "^22.13.5",
 		"@types/qrcode": "^1.5.5",
 		"@typescript-eslint/eslint-plugin": "^8.29.1",
 		"@typescript-eslint/parser": "^8.29.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -68,12 +68,12 @@ export default defineConfig({
 		//   name: 'Google Chrome',
 		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
 		// },
-	]
+	],
 
 	/* Run your local dev server before starting the tests */
-	// webServer: {
-	// 	command: 'yarn dev',
-	// 	url: 'http://127.0.0.1:5173',
-	// 	reuseExistingServer: !process.env.CI
-	// }
+	webServer: {
+		command: 'yarn dev',
+		url: 'http://127.0.0.1:5173',
+		reuseExistingServer: !process.env.CI
+	}
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+	testDir: './tests',
+	/* Run tests in files in parallel */
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: !!process.env.CI,
+	/* Retry on CI only */
+	retries: process.env.CI ? 2 : 0,
+	/* Opt out of parallel tests on CI. */
+	workers: process.env.CI ? 1 : undefined,
+	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
+	reporter: 'html',
+	/* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+	use: {
+		/* Base URL to use in actions like `await page.goto('/')`. */
+		// baseURL: 'http://127.0.0.1:3000',
+
+		/* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+		trace: 'on-first-retry'
+	},
+
+	/* Configure projects for major browsers */
+	projects: [
+		{
+			name: 'chromium',
+			use: { ...devices['Desktop Chrome'] }
+		}
+
+		// {
+		// 	name: 'firefox',
+		// 	use: { ...devices['Desktop Firefox'] }
+		// },
+
+		// {
+		// 	name: 'webkit',
+		// 	use: { ...devices['Desktop Safari'] }
+		// }
+
+		/* Test against mobile viewports. */
+		// {
+		//   name: 'Mobile Chrome',
+		//   use: { ...devices['Pixel 5'] },
+		// },
+		// {
+		//   name: 'Mobile Safari',
+		//   use: { ...devices['iPhone 12'] },
+		// },
+
+		/* Test against branded browsers. */
+		// {
+		//   name: 'Microsoft Edge',
+		//   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+		// },
+		// {
+		//   name: 'Google Chrome',
+		//   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+		// },
+	]
+
+	/* Run your local dev server before starting the tests */
+	// webServer: {
+	// 	command: 'yarn dev',
+	// 	url: 'http://127.0.0.1:5173',
+	// 	reuseExistingServer: !process.env.CI
+	// }
+});

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('open map', async ({ page }) => {
+	await page.goto('http://127.0.0.1:5173');
+
+	await expect(page).toHaveTitle(/BTC Map/);
+
+	await page.getByRole('link', { name: 'Open Map' }).click();
+	await expect(page).toHaveURL(/map/);
+});
+
+test('add location', async ({ page }) => {
+	await page.goto('http://127.0.0.1:5173');
+
+	await page.waitForLoadState('domcontentloaded');
+
+	const heading = page.getByRole('heading', {
+		name: 'Easily find places to spend sats anywhere on the planet.'
+	});
+	await heading.waitFor({ state: 'visible' });
+	await expect(heading).toBeTruthy();
+
+	await page.getByRole('button', { name: 'Contribute' }).click();
+
+	await page.getByRole('link', { name: 'Add Location' }).click();
+
+	await expect(page.getByRole('heading', { name: 'Accept bitcoin? Get found.' })).toBeTruthy();
+});

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,28 +1,29 @@
 import { test, expect } from '@playwright/test';
+import { describe } from 'node:test';
 
-test('open map', async ({ page }) => {
-	await page.goto('http://127.0.0.1:5173');
+describe('Home Page', () => {
+	test('opens map', async ({ page }) => {
+		await page.goto('http://127.0.0.1:5173');
 
-	await expect(page).toHaveTitle(/BTC Map/);
+		await expect(page).toHaveTitle(/BTC Map/);
 
-	await page.getByRole('link', { name: 'Open Map' }).click();
-	await expect(page).toHaveURL(/map/);
-});
-
-test('add location', async ({ page }) => {
-	await page.goto('http://127.0.0.1:5173');
-
-	await page.waitForLoadState('domcontentloaded');
-
-	const heading = page.getByRole('heading', {
-		name: 'Easily find places to spend sats anywhere on the planet.'
+		await page.getByRole('link', { name: 'Open Map' }).click();
+		await expect(page).toHaveURL(/map/);
 	});
-	await heading.waitFor({ state: 'visible' });
-	await expect(heading).toBeTruthy();
 
-	await page.getByRole('button', { name: 'Contribute' }).click();
+	test('add location opens', async ({ page }) => {
+		await page.goto('http://127.0.0.1:5173');
 
-	await page.getByRole('link', { name: 'Add Location' }).click();
+		await page.waitForLoadState('domcontentloaded');
 
-	await expect(page.getByRole('heading', { name: 'Accept bitcoin? Get found.' })).toBeTruthy();
+		const heading = page.getByRole('heading', {
+			name: 'Find places to spend sats wherever you are.'
+		});
+		await heading.waitFor({ state: 'visible' });
+		await expect(heading).toBeTruthy();
+
+		await page.getByRole('link', { name: 'Add Location' }).click();
+
+		await expect(page.getByRole('heading', { name: 'Accept bitcoin? Get found.' })).toBeTruthy();
+	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.50.1":
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.51.1.tgz#75357d513221a7be0baad75f01e966baf9c41a2e"
+  integrity sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==
+  dependencies:
+    playwright "1.51.1"
+
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.28"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.28.tgz#d45e01c4a56f143ee69c54dd6b12eade9e270a73"
@@ -803,6 +810,13 @@
   integrity sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@^22.13.5":
+  version "22.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.14.0.tgz#d3bfa3936fef0dbacd79ea3eb17d521c628bb47e"
+  integrity sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/pbf@*", "@types/pbf@^3.0.5":
   version "3.0.5"
@@ -1702,6 +1716,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -2487,6 +2506,20 @@ pirates@^4.0.1:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
 
+playwright-core@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.51.1.tgz#d57f0393e02416f32a47cf82b27533656a8acce1"
+  integrity sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==
+
+playwright@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.51.1.tgz#ae1467ee318083968ad28d6990db59f47a55390f"
+  integrity sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==
+  dependencies:
+    playwright-core "1.51.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 pngjs@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
@@ -3134,6 +3167,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 update-browserslist-db@^1.1.1:
   version "1.1.2"


### PR DESCRIPTION
Adding basic e2e test setup

- using https://playwright.dev
- adding two minimal tests

In general this could cover basic main functionality in the future.  
e2e tests should not be used extensively. 