### PR TITLE
fix(icons): info is missing

### DIFF
--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -34,7 +34,8 @@
 						gate: 'material-symbols:gate',
 						cooking: 'material-symbols:cooking',
 						dentistry: 'material-symbols:dentistry',
-						sauna: 'material-symbols:sauna'
+						sauna: 'material-symbols:sauna',
+						info_outline: 'material-symbols:info-outline'
 					};
 
 					// Check if this icon has an exception


### PR DESCRIPTION
Found one more missing icon... as you do

Before:
<img width="1976" alt="image" src="https://github.com/user-attachments/assets/3df54a50-5c6e-4cbf-9af5-543f3871807f" />

After:
<img width="1977" alt="image" src="https://github.com/user-attachments/assets/4e8608f2-7767-4a02-8735-3b6d550f5a6d" />

https://deploy-preview-227--btcmap.netlify.app/merchant/node:9425965288