### PR TITLE
feat(merchant): display comments #229

### DIFF
--- a/src/components/MerchantComment.svelte
+++ b/src/components/MerchantComment.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
 	import Time from 'svelte-time';
+	import type { MerchantPageData } from '$lib/types';
 
-	export let text: string;
-	export let time: string;
+	export let text: MerchantPageData['comments'][number]['text'];
+	export let time: MerchantPageData['comments'][number]['created_at'];
 </script>
 
 <div

--- a/src/components/MerchantComment.svelte
+++ b/src/components/MerchantComment.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import Time from 'svelte-time';
+
+	export let text: string;
+	export let time: string;
+</script>
+
+<div
+	class="items-center space-y-2 p-5 text-center text-xl lg:flex lg:space-x-5 lg:space-y-0 lg:text-left"
+>
+	<div class="w-full flex-wrap items-center justify-between space-y-2 lg:flex lg:space-y-0">
+		<div class="space-y-2 lg:space-y-0">
+			<span class="text-primary dark:text-white lg:mr-5">
+				{text}
+			</span>
+
+			<span class="block text-center font-semibold text-taggerTime lg:inline">
+				<Time timestamp={time} />
+			</span>
+		</div>
+	</div>
+</div>

--- a/src/lib/comp.ts
+++ b/src/lib/comp.ts
@@ -50,6 +50,7 @@ export { default as MapLoadingEmbed } from '../components/MapLoadingEmbed.svelte
 export { default as MapLoadingMain } from '../components/MapLoadingMain.svelte';
 export { default as MerchantButton } from '../components/MerchantButton.svelte';
 export { default as MerchantCard } from '../components/MerchantCard.svelte';
+export { default as MerchantComment } from '../components/MerchantComment.svelte';
 export { default as MerchantEvent } from '../components/MerchantEvent.svelte';
 export { default as MerchantLink } from '../components/MerchantLink.svelte';
 export { default as NavDropdownDesktop } from '../components/NavDropdownDesktop.svelte';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,6 +5,7 @@ import type {
 	FeatureGroup,
 	LatLng,
 	LayerGroup,
+	// @ts-ignore
 	MaplibreGL,
 	Marker,
 	TileLayer

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -5,7 +5,6 @@ import type {
 	FeatureGroup,
 	LatLng,
 	LayerGroup,
-	// @ts-ignore
 	MaplibreGL,
 	Marker,
 	TileLayer
@@ -95,6 +94,20 @@ export type Element = {
 	updated_at: string;
 	deleted_at: string;
 };
+
+export interface MerchantComment {
+	id: number;
+	text: string;
+	created_at: string;
+}
+
+export interface MerchantPageData {
+	id: string;
+	name?: string;
+	lat: number;
+	lon: number;
+	comments: MerchantComment[];
+}
 
 export type RpcIssue = {
 	element_osm_type: string;

--- a/src/routes/merchant/[id]/+page.server.ts
+++ b/src/routes/merchant/[id]/+page.server.ts
@@ -3,11 +3,11 @@ import type { Element, MerchantPageData, MerchantComment } from '$lib/types';
 import { error } from '@sveltejs/kit';
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
-import type { PageLoad } from './$types';
+import type { PageServerLoad } from './$types';
 
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
 
-export const load: PageLoad<MerchantPageData> = async ({ params }) => {
+export const load: PageServerLoad<MerchantPageData> = async ({ params }) => {
 	const { id } = params;
 	try {
 		const response = await axios.get(`https://api.btcmap.org/v2/elements/${id}`);

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -734,6 +734,28 @@
 				</div>
 			</section>
 
+			<section id="comments">
+				<div class="w-full rounded-3xl border border-statBorder dark:bg-white/10">
+					<h3
+						class="border-b border-statBorder p-5 text-center text-lg font-semibold text-primary dark:text-white lg:text-left"
+					>
+						{name || 'Merchant'} Comments
+					</h3>
+
+					<div class="hide-scroll relative max-h-[375px] space-y-2 overflow-y-scroll">
+						<div class="relative space-y-2">
+							{#if data.comments && data.comments.length}
+								{#each [...data.comments].reverse() as comment}
+									<MerchantComment text={comment.text} time={comment['created_at']} />
+								{/each}
+							{:else}
+								<p class="p-5 text-body dark:text-white">No comments yet.</p>
+							{/if}
+						</div>
+					</div>
+				</div>
+			</section>
+
 			<section id="activity">
 				<div class="w-full rounded-3xl border border-statBorder dark:bg-white/10">
 					<h3
@@ -789,28 +811,6 @@
 						{:else}
 							<p class="p-5 text-body dark:text-white">No activity to display.</p>
 						{/if}
-					</div>
-				</div>
-			</section>
-
-			<section id="comments">
-				<div class="w-full rounded-3xl border border-statBorder dark:bg-white/10">
-					<h3
-						class="border-b border-statBorder p-5 text-center text-lg font-semibold text-primary dark:text-white lg:text-left"
-					>
-						{name || 'Merchant'} Comments
-					</h3>
-
-					<div class="hide-scroll relative max-h-[375px] space-y-2 overflow-y-scroll">
-						<div class="relative space-y-2">
-							{#if data.comments && data.comments.length}
-								{#each [...data.comments].reverse() as comment}
-									<MerchantComment text={comment.text} time={comment['created_at']} />
-								{/each}
-							{:else}
-								<p class="p-5 text-body dark:text-white">No comments yet.</p>
-							{/if}
-						</div>
 					</div>
 				</div>
 			</section>

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	export let data;
+	export let data: MerchantPageData;
 
 	import { browser } from '$app/environment';
 	import { goto } from '$app/navigation';
@@ -12,6 +12,7 @@
 		MapLoadingEmbed,
 		MerchantButton,
 		MerchantEvent,
+		MerchantComment,
 		MerchantLink,
 		PrimaryButton,
 		ShowTags,
@@ -54,7 +55,8 @@
 		Element,
 		Event,
 		Leaflet,
-		PayMerchant
+		PayMerchant,
+		MerchantPageData
 	} from '$lib/types.js';
 	import { detectTheme, errToast, successToast } from '$lib/utils';
 	import rewind from '@mapbox/geojson-rewind';
@@ -787,6 +789,28 @@
 						{:else}
 							<p class="p-5 text-body dark:text-white">No activity to display.</p>
 						{/if}
+					</div>
+				</div>
+			</section>
+
+			<section id="comments">
+				<div class="w-full rounded-3xl border border-statBorder dark:bg-white/10">
+					<h3
+						class="border-b border-statBorder p-5 text-center text-lg font-semibold text-primary dark:text-white lg:text-left"
+					>
+						{name || 'Merchant'} Comments
+					</h3>
+
+					<div class="hide-scroll relative max-h-[375px] space-y-2 overflow-y-scroll">
+						<div class="relative space-y-2">
+							{#if data.comments && data.comments.length}
+								{#each [...data.comments].reverse() as comment}
+									<MerchantComment text={comment.text} time={comment['created_at']} />
+								{/each}
+							{:else}
+								<p class="p-5 text-body dark:text-white">No comments yet.</p>
+							{/if}
+						</div>
 					</div>
 				</div>
 			</section>

--- a/src/routes/merchant/[id]/+page.ts
+++ b/src/routes/merchant/[id]/+page.ts
@@ -13,9 +13,6 @@ export const load: PageLoad<MerchantPageData> = async ({ params }) => {
 		const response = await axios.get(`https://api.btcmap.org/v2/elements/${id}`);
 
 		const data: Element = response.data;
-
-		console.log('Merchant Data:', data);
-
 		const lat = latCalc(data.osm_json);
 		const lon = longCalc(data.osm_json);
 

--- a/src/routes/merchant/[id]/+page.ts
+++ b/src/routes/merchant/[id]/+page.ts
@@ -1,5 +1,5 @@
 import { latCalc, longCalc } from '$lib/map/setup';
-import type { Element } from '$lib/types';
+import type { Element, MerchantPageData, MerchantComment } from '$lib/types';
 import { error } from '@sveltejs/kit';
 import axios from 'axios';
 import axiosRetry from 'axios-retry';
@@ -7,23 +7,37 @@ import type { PageLoad } from './$types';
 
 axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad<MerchantPageData> = async ({ params }) => {
 	const { id } = params;
 	try {
 		const response = await axios.get(`https://api.btcmap.org/v2/elements/${id}`);
 
 		const data: Element = response.data;
+
+		console.log('Merchant Data:', data);
+
 		const lat = latCalc(data.osm_json);
 		const lon = longCalc(data.osm_json);
 
 		if (data && data.id && lat && lon && !data['deleted_at']) {
+			let comments: MerchantComment[] = [];
+			try {
+				const commentsResponse = await axios.get(`https://api.btcmap.org/v4/places/${id}/comments`);
+				comments = commentsResponse.data;
+			} catch (commentErr) {
+				console.error('Failed to fetch comments:', commentErr);
+				comments = [];
+			}
+
 			return {
 				id: data.id,
 				name: data.osm_json.tags?.name,
 				lat,
-				lon
+				lon,
+				comments
 			};
 		}
+		error(404, 'Merchant Not Found');
 	} catch (err) {
 		console.error(err);
 		error(404, 'Merchant Not Found');


### PR DESCRIPTION
Resolves: #229

- copied `MerchantEvent` and adjusted it
- switch from client API call to server component
- added type for the pageload-data

Notes:
Not exactly sure about the design. I searched some merchants with more or longer comments but couldn't easily find one. Can adjust if needed/wanted.

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/8484b089-0721-408c-bf19-c9049def76cc" />

https://deploy-preview-239--btcmap.netlify.app/merchant/node:3708729816



