### PR TITLE
Chore: Resolve svelte/require-each-key Warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,6 @@ export default tseslint.config(
 			}
 		},
 		rules: {
-			'svelte/require-each-key': 'warn',
 			'svelte/no-dupe-style-properties': 'warn', // mainly because of tailwind (v4 will fix this)
 			'@typescript-eslint/no-unused-expressions': 'warn',
 			'@typescript-eslint/no-unused-vars': [

--- a/src/components/AboutCore.svelte
+++ b/src/components/AboutCore.svelte
@@ -25,7 +25,7 @@
 	</div>
 
 	<div class="flex justify-center space-x-2">
-		{#each member.socials as social}
+		{#each member.socials as social (social.url)}
 			<a
 				href={social.url}
 				target="_blank"

--- a/src/components/AreaActivity.svelte
+++ b/src/components/AreaActivity.svelte
@@ -30,7 +30,7 @@
 		<div bind:this={taggerDiv} class="hide-scroll max-h-[375px] overflow-scroll p-1">
 			{#if taggers && taggers.length}
 				<div class="flex flex-wrap items-center justify-center">
-					{#each taggersPaginated as tagger}
+					{#each taggersPaginated as tagger (tagger.id)}
 						<div class="m-4 space-y-1 transition-transform hover:scale-110">
 							<a href="/tagger/{tagger.id}">
 								<img
@@ -61,8 +61,7 @@
 				{/if}
 			{:else if !dataInitialized}
 				<div class="flex flex-wrap items-center justify-center">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(5) as tagger}
+					{#each Array(5) as _, index (index)}
 						<div class="m-4 space-y-1 transition-transform hover:scale-110">
 							<p class="mx-auto h-20 w-20 animate-pulse rounded-full bg-link/50" />
 							<p class="mx-auto h-5 w-28 animate-pulse rounded bg-link/50" />
@@ -94,7 +93,7 @@
 			}}
 		>
 			{#if eventElements && eventElements.length}
-				{#each eventElementsPaginated as event}
+				{#each eventElementsPaginated as event (event['created_at'])}
 					<LatestTagger
 						location={event.location}
 						action={event.type}
@@ -126,8 +125,7 @@
 					>
 				{/if}
 			{:else if !dataInitialized}
-				<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-				{#each Array(5) as skeleton}
+				{#each Array(5) as _, index (index)}
 					<TaggerSkeleton />
 				{/each}
 			{:else}

--- a/src/components/AreaLeaderboard.svelte
+++ b/src/components/AreaLeaderboard.svelte
@@ -116,7 +116,7 @@
 
 <section id="leaderboard" class="dark:lg:rounded dark:lg:bg-white/10 dark:lg:py-8">
 	<div class="mb-5 hidden grid-cols-5 text-center lg:grid">
-		{#each headings as heading}
+		{#each headings as heading (heading)}
 			<h3 class="text-lg font-semibold text-primary dark:text-white">
 				{heading}
 				{#if heading === 'Up-To-Date'}
@@ -148,7 +148,7 @@
 
 	<div>
 		{#if leaderboard && leaderboard.length && !loading}
-			{#each leaderboardPaginated as item, index}
+			{#each leaderboardPaginated as item, index (item.id)}
 				<AreaLeaderboardItem
 					{type}
 					position={index + 1}
@@ -171,8 +171,7 @@
 				>
 			{/if}
 		{:else}
-			<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-			{#each Array(50) as skeleton}
+			{#each Array(50) as _, index (index)}
 				<AreaLeaderboardSkeleton />
 			{/each}
 		{/if}

--- a/src/components/AreaLeaderboardItem.svelte
+++ b/src/components/AreaLeaderboardItem.svelte
@@ -62,7 +62,7 @@
 		{/if}
 	</div>
 
-	{#each stats as stat}
+	{#each stats as stat (stat.title)}
 		<span class="my-2 flex items-center justify-center lg:my-0 lg:inline-flex">
 			<span class="mr-1 text-primary dark:text-white lg:hidden">{stat.title}:</span>
 			{#if stat.title === 'Up-To-Date'}
@@ -76,13 +76,11 @@
 				</div>
 			{:else if stat.title === 'Grade'}
 				<div class="space-x-1">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(stat.stat) as star}
+					{#each Array(stat.stat) as _, index (index)}
 						<i class="fa-solid fa-star" />
 					{/each}
 
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(5 - stat.stat) as star}
+					{#each Array(5 - stat.stat) as _, index (index)}
 						<i class="fa-solid fa-star opacity-25" />
 					{/each}
 				</div>

--- a/src/components/AreaLeaderboardSkeleton.svelte
+++ b/src/components/AreaLeaderboardSkeleton.svelte
@@ -26,8 +26,7 @@
 		class="mx-auto my-2 block h-5 w-32 animate-pulse rounded-xl bg-link/50 lg:my-auto lg:inline-block lg:w-5 lg:rounded-full"
 	/>
 	<div class="my-2 flex items-center justify-center space-x-1 lg:my-0 lg:inline-flex">
-		<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-		{#each Array(5) as star}
+		{#each Array(5) as _, index (index)}
 			<i class="fa-solid fa-star animate-pulse text-lg text-link/50" />
 		{/each}
 	</div>

--- a/src/components/AreaMap.svelte
+++ b/src/components/AreaMap.svelte
@@ -244,22 +244,19 @@
 		<div class="flex items-center space-x-1 text-link">
 			{#if dataInitialized}
 				<div class="flex items-center space-x-1">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(grade) as star}
+					{#each Array(grade) as _, index (index)}
 						<i class="fa-solid fa-star" />
 					{/each}
 				</div>
 
 				<div class="flex items-center space-x-1">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(5 - grade) as star}
+					{#each Array(5 - grade) as _, index (index)}
 						<i class="fa-solid fa-star opacity-25" />
 					{/each}
 				</div>
 			{:else}
 				<div class="flex items-center space-x-1">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(5) as star}
+					{#each Array(5) as _, index (index)}
 						<i class="fa-solid fa-star animate-pulse text-link/50" />
 					{/each}
 				</div>

--- a/src/components/AreaMerchantHighlights.svelte
+++ b/src/components/AreaMerchantHighlights.svelte
@@ -33,14 +33,13 @@
 		<div class="w-full px-2 py-6 sm:px-5">
 			{#if !dataInitialized}
 				<div class="grid w-full grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(3) as skeleton}
+					{#each Array(3) as _, index (index)}
 						<div class="h-56 animate-pulse rounded-2xl bg-link/50" />
 					{/each}
 				</div>
 			{:else if boosts.length}
 				<div class="grid w-full grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
-					{#each boosts as merchant}
+					{#each boosts as merchant (merchant.id)}
 						<MerchantCard {merchant} />
 					{/each}
 				</div>
@@ -64,14 +63,13 @@
 		<div class="w-full px-2 py-6 sm:px-5">
 			{#if !dataInitialized}
 				<div class="grid w-full grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(3) as skeleton}
+					{#each Array(3) as _, index (index)}
 						<div class="h-56 animate-pulse rounded-2xl bg-link/50" />
 					{/each}
 				</div>
 			{:else if latest.length}
 				<div class="grid w-full grid-cols-1 gap-6 lg:grid-cols-2 xl:grid-cols-3">
-					{#each latest as merchant}
+					{#each latest as merchant (merchant.id)}
 						<MerchantCard {merchant} />
 					{/each}
 				</div>

--- a/src/components/AreaPage.svelte
+++ b/src/components/AreaPage.svelte
@@ -355,8 +355,7 @@
 				/>
 			{:else}
 				<div class="flex flex-wrap items-center justify-center">
-					<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-					{#each Array(3) as skeleton}
+					{#each Array(3) as _, index (index)}
 						<div class="m-1 h-10 w-10 animate-pulse rounded-full bg-link/50" />
 					{/each}
 				</div>
@@ -372,7 +371,7 @@
 		on:scroll={() => (scrolled = true)}
 		class="hide-scroll relative grid w-full auto-cols-[minmax(150px,_1fr)] grid-flow-col overflow-x-auto"
 	>
-		{#each sections as section}
+		{#each sections as section, index (index)}
 			<button
 				on:click={() => (activeSection = section)}
 				class="border-b-4 pb-3 text-center text-lg text-link transition-colors hover:border-link {activeSection ===

--- a/src/components/AreaTickets.svelte
+++ b/src/components/AreaTickets.svelte
@@ -44,7 +44,7 @@
 				/>
 			</h3>
 
-			{#each ticketTypes as type}
+			{#each ticketTypes as type (type)}
 				<button
 					class="mx-auto block w-40 border border-link py-2 text-center md:inline {type === 'Add'
 						? 'rounded-t md:rounded-l md:rounded-tr-none'
@@ -62,7 +62,7 @@
 		{#if filteredTickets.length && !ticketError}
 			{#if showType === 'Add'}
 				{#if add.length}
-					{#each add as ticket}
+					{#each add as ticket (ticket.number)}
 						<OpenTicket
 							assignees={ticket.assignees}
 							comments={ticket.comments}
@@ -81,7 +81,7 @@
 				{/if}
 			{:else if showType === 'Verify'}
 				{#if verify.length}
-					{#each verify as ticket}
+					{#each verify as ticket (ticket.number)}
 						<OpenTicket
 							assignees={ticket.assignees}
 							comments={ticket.comments}
@@ -100,7 +100,7 @@
 				{/if}
 			{:else if showType === 'Community'}
 				{#if community.length}
-					{#each community as ticket}
+					{#each community as ticket (ticket.number)}
 						<OpenTicket
 							assignees={ticket.assignees}
 							comments={ticket.comments}

--- a/src/components/Boost.svelte
+++ b/src/components/Boost.svelte
@@ -164,7 +164,7 @@
 					</div>
 
 					<div class="space-y-2 md:flex md:space-x-2 md:space-y-0">
-						{#each values as value}
+						{#each values as value, index (index)}
 							<button
 								on:click={() => {
 									if (!$exchangeRate) return;

--- a/src/components/Breadcrumbs.svelte
+++ b/src/components/Breadcrumbs.svelte
@@ -4,7 +4,7 @@
 </script>
 
 <div class="mx-auto flex w-full flex-wrap items-center gap-3 px-4 py-5 xl:w-[1200px] xl:px-0">
-	{#each routes as route, index}
+	{#each routes as route, index (index)}
 		<a
 			href={route.url}
 			class="text-sm text-link transition-colors hover:text-hover {index === routes.length - 1

--- a/src/components/CommunitySection.svelte
+++ b/src/components/CommunitySection.svelte
@@ -8,12 +8,11 @@
 <section>
 	<div class="grid gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 		{#if communities && communities.length}
-			{#each communities as community}
+			{#each communities as community (community.id)}
 				<CommunityCard id={community.id} tags={community.tags} />
 			{/each}
 		{:else}
-			<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-			{#each Array(4) as skeleton}
+			{#each Array(4) as _, index (index)}
 				<CommunitySkeleton />
 			{/each}
 		{/if}

--- a/src/components/CountrySection.svelte
+++ b/src/components/CountrySection.svelte
@@ -8,12 +8,11 @@
 <section>
 	<div class="grid gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 		{#if countries && countries.length}
-			{#each countries as country}
+			{#each countries as country (country.id)}
 				<CountryCard id={country.id} name={country.tags.name} />
 			{/each}
 		{:else}
-			<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-			{#each Array(4) as skeleton}
+			{#each Array(4) as _, index (index)}
 				<CountrySkeleton />
 			{/each}
 		{/if}

--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -24,7 +24,7 @@
 	</div>
 
 	<div class="flex flex-wrap justify-center xl:block">
-		{#each links as link}
+		{#each links as link (link.name)}
 			<a
 				href={link.link}
 				target={link.external ? '_blank' : null}

--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -47,7 +47,7 @@
 	</a>
 
 	<nav class="flex flex-wrap space-x-16">
-		{#each navLinks as link}
+		{#each navLinks as link (link.title)}
 			<!-- dropdown menu -->
 			{#if link.title === 'Maps'}
 				<NavDropdownDesktop
@@ -129,7 +129,7 @@
 			? 'left-0'
 			: 'left-[-100%]'} h-[calc(100dvh-122.45px)] w-full space-y-2 overflow-y-auto border-t border-[#BDD2D4] bg-teal p-8 transition-all ease-in-out dark:bg-dark"
 	>
-		{#each navLinks as link}
+		{#each navLinks as link (link.title)}
 			<!-- dropdown menu -->
 			{#if link.title === 'Maps'}
 				<NavDropdownMobile title={link.title} icon={link.icon} links={mapsDropdownLinks} />

--- a/src/components/IssuesTable.svelte
+++ b/src/components/IssuesTable.svelte
@@ -258,9 +258,9 @@
 				<div class="overflow-x-auto">
 					<table class="w-full whitespace-nowrap text-left text-primary dark:text-white">
 						<thead>
-							{#each $table.getHeaderGroups() as headerGroup}
+							{#each $table.getHeaderGroups() as headerGroup, index (index)}
 								<tr>
-									{#each headerGroup.headers as header}
+									{#each headerGroup.headers as header, index (index)}
 										<th colSpan={header.colSpan} class="px-5 pb-2.5 pt-5">
 											{#if !header.isPlaceholder}
 												<button
@@ -299,9 +299,9 @@
 							{/each}
 						</thead>
 						<tbody>
-							{#each $table.getRowModel().rows as row, index}
+							{#each $table.getRowModel().rows as row, index (index)}
 								<tr class={isEven(index) ? 'bg-primary/5 dark:bg-white/5' : ''}>
-									{#each row.getVisibleCells() as cell}
+									{#each row.getVisibleCells() as cell, index (index)}
 										<td class="px-5 py-2.5">
 											<svelte:component
 												this={flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -325,7 +325,7 @@
 						}}
 						class="cursor-pointer bg-transparent focus:outline-primary dark:focus:outline-white"
 					>
-						{#each pageSizes as pageSize}
+						{#each pageSizes as pageSize (pageSize)}
 							<option value={pageSize}>
 								Show {pageSize}
 							</option>

--- a/src/components/LeaderboardItem.svelte
+++ b/src/components/LeaderboardItem.svelte
@@ -57,7 +57,7 @@
 		>
 	</div>
 
-	{#each stats as stat}
+	{#each stats as stat (stat.title)}
 		<span class="mx-5 inline-block text-link lg:!my-auto lg:mx-0">
 			<span
 				class="mr-1 inline-block h-3 w-3 rounded-full {stat.title === 'C'

--- a/src/components/NavDropdownDesktop.svelte
+++ b/src/components/NavDropdownDesktop.svelte
@@ -29,7 +29,7 @@
 			on:outclick={() => (show = false)}
 		>
 			<div class="absolute right-0 top-8 z-50 w-[185px] rounded-2xl shadow-lg">
-				{#each links as link}
+				{#each links as link (link.url)}
 					<a
 						href={link.url}
 						target={link.external ? '_blank' : null}

--- a/src/components/NavDropdownMobile.svelte
+++ b/src/components/NavDropdownMobile.svelte
@@ -31,7 +31,7 @@
 		on:outclick={() => (show = false)}
 	>
 		<div class="ml-7 space-y-2">
-			{#each links as link}
+			{#each links as link (link.url)}
 				<a
 					href={link.url}
 					target={link.external ? '_blank' : null}

--- a/src/components/OpenTicket.svelte
+++ b/src/components/OpenTicket.svelte
@@ -30,7 +30,7 @@
 				>
 
 				<span class="block md:inline">
-					{#each labels || [] as label}
+					{#each labels || [] as label, index (index)}
 						<TicketLabel title={label?.name} tooltip={label?.description} />
 					{/each}
 				</span>
@@ -52,7 +52,7 @@
 
 	<div class="space-y-1 md:flex md:space-x-2 md:space-y-0">
 		<div class="flex flex-wrap justify-center md:justify-start">
-			{#each assignees || [] as assignee}
+			{#each assignees || [] as assignee, index (index)}
 				<a href={assignee?.html_url} target="_blank" rel="noreferrer" class="mb-1 mr-1">
 					<img
 						src={assignee?.avatar_url}

--- a/src/components/ShowTags.svelte
+++ b/src/components/ShowTags.svelte
@@ -16,7 +16,7 @@
 			<CloseButton on:click={closeModal} />
 
 			<div class="space-y-2">
-				{#each Object.entries($showTags) as tag}
+				{#each Object.entries($showTags) as tag, index (index)}
 					<div>
 						<span class="font-semibold text-primary dark:font-normal dark:text-white">{tag[0]}</span
 						><span class="dark:text-white">=</span><span

--- a/src/components/SupportSection.svelte
+++ b/src/components/SupportSection.svelte
@@ -8,7 +8,7 @@
 
 <div class="mt-4">
 	<div class="mx-auto w-full grid-cols-3 gap-10 space-y-10 lg:grid lg:w-[830px] lg:space-y-0">
-		{#each supporters as supporter}
+		{#each supporters as supporter (supporter.url)}
 			<a
 				href={supporter.url}
 				target="_blank"
@@ -28,9 +28,7 @@
 				{/if}
 			</a>
 		{/each}
-		<!-- supporter placeholders -->
-		<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-		{#each Array(placeholders) as placeholder}
+		{#each Array(placeholders) as _, index (index)}
 			<div
 				class="mx-auto flex h-[90px] w-full items-center justify-center self-center rounded-xl bg-supporter/50 drop-shadow-xl md:w-[250px]"
 			>

--- a/src/components/TaggingIssues.svelte
+++ b/src/components/TaggingIssues.svelte
@@ -18,7 +18,7 @@
 
 			<div class="space-y-2 text-primary dark:text-white">
 				{#if $taggingIssues.length}
-					{#each $taggingIssues as issue}
+					{#each $taggingIssues as issue, index (index)}
 						<div class="flex items-center space-x-2">
 							<IssueIcon icon={getIssueIcon(issue.type)} />
 							<p>{issue.description}</p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -47,7 +47,7 @@
 				<div
 					class="my-8 flex flex-wrap justify-center rounded-2xl bg-white/30 py-6 dark:bg-white/[0.15]"
 				>
-					{#each $apps as app}
+					{#each $apps as app (app.link)}
 						<div
 							class="mx-2 my-2 space-y-1 text-center font-semibold text-body dark:text-white md:my-0"
 						>

--- a/src/routes/about-us/+page.svelte
+++ b/src/routes/about-us/+page.svelte
@@ -269,7 +269,7 @@
 
 				<div class="flex grid-cols-3 flex-wrap justify-center gap-5 lg:grid">
 					{#if merchants.length}
-						{#each merchants as merchant}
+						{#each merchants as merchant (merchant.id)}
 							<AboutMerchant
 								id={merchant.id}
 								icon={merchant.tags['icon:android']}
@@ -278,7 +278,7 @@
 						{/each}
 					{:else}
 						<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-						{#each Array(6) as skeleton}
+						{#each Array(6) as _, index (index)}
 							<span class="h-24 w-24 animate-pulse rounded-full bg-link/50" />
 						{/each}
 					{/if}
@@ -299,12 +299,12 @@
 
 					<div class="flex flex-wrap justify-center gap-5">
 						{#if supertaggers.length}
-							{#each supertaggers.map((t) => ({ ...t, total: undefined })) as tagger}
+							{#each supertaggers.map((t) => ({ ...t, total: undefined })) as tagger (tagger.id)}
 								<AboutTagger {tagger} />
 							{/each}
 						{:else}
 							<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-							{#each Array(6) as skeleton}
+							{#each Array(6) as _, index (index)}
 								<span class="h-24 w-24 animate-pulse rounded-full bg-link/50" />
 							{/each}
 						{/if}
@@ -338,12 +338,12 @@
 				<div>
 					<div class="flex grid-cols-3 flex-wrap justify-center gap-5 lg:grid">
 						{#if communities.length}
-							{#each communities as community}
+							{#each communities as community (community.id)}
 								<AboutCommunity {community} />
 							{/each}
 						{:else}
 							<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-							{#each Array(6) as skeleton}
+							{#each Array(6) as _, index (index)}
 								<span class="h-24 w-24 animate-pulse rounded-full bg-link/50" />
 							{/each}
 						{/if}
@@ -371,7 +371,7 @@
 				</p>
 
 				<div class="flex flex-wrap justify-center gap-10">
-					{#each communityIntegrations as integration}
+					{#each communityIntegrations as integration (integration.url)}
 						<AboutIntegration {integration} />
 					{/each}
 					<AboutPlus />
@@ -384,7 +384,7 @@
 				</p>
 
 				<div class="flex flex-wrap justify-center gap-10">
-					{#each projectIntegrations as integration}
+					{#each projectIntegrations as integration (integration.url)}
 						<AboutIntegration {integration} />
 					{/each}
 					<AboutPlus />
@@ -409,7 +409,7 @@
 				</div>
 
 				<div class="flex grid-cols-3 flex-wrap justify-center gap-5 lg:grid">
-					{#each contributors as contributor}
+					{#each contributors as contributor (contributor.url)}
 						<AboutContributor {contributor} />
 					{/each}
 				</div>
@@ -449,7 +449,7 @@
 				</div>
 
 				<div class="flex grid-cols-2 flex-wrap items-center justify-center gap-10 lg:grid">
-					{#each coreTeam as member}
+					{#each coreTeam as member (member.name)}
 						<AboutCore {member} />
 					{/each}
 				</div>

--- a/src/routes/about-us/+page.svelte
+++ b/src/routes/about-us/+page.svelte
@@ -277,7 +277,6 @@
 							/>
 						{/each}
 					{:else}
-						<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
 						{#each Array(6) as _, index (index)}
 							<span class="h-24 w-24 animate-pulse rounded-full bg-link/50" />
 						{/each}
@@ -303,7 +302,6 @@
 								<AboutTagger {tagger} />
 							{/each}
 						{:else}
-							<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
 							{#each Array(6) as _, index (index)}
 								<span class="h-24 w-24 animate-pulse rounded-full bg-link/50" />
 							{/each}
@@ -342,7 +340,6 @@
 								<AboutCommunity {community} />
 							{/each}
 						{:else}
-							<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
 							{#each Array(6) as _, index (index)}
 								<span class="h-24 w-24 animate-pulse rounded-full bg-link/50" />
 							{/each}

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -128,7 +128,7 @@
 
 					<div class="space-y-5">
 						{#if latestTaggers}
-							{#each supertaggers as tagger}
+							{#each supertaggers as tagger (tagger['created_at'])}
 								<LatestTagger
 									location={tagger.location}
 									action={tagger.type}
@@ -140,7 +140,7 @@
 							{/each}
 						{:else}
 							<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
-							{#each Array(50) as skeleton}
+							{#each Array(50) as _, index (index)}
 								<TaggerSkeleton />
 							{/each}
 						{/if}

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -139,7 +139,6 @@
 								/>
 							{/each}
 						{:else}
-							<!-- eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -->
 							{#each Array(50) as _, index (index)}
 								<TaggerSkeleton />
 							{/each}

--- a/src/routes/apps/+page.svelte
+++ b/src/routes/apps/+page.svelte
@@ -42,7 +42,7 @@
 
 			<h3 class="text-2xl font-semibold text-primary dark:text-white md:text-left">Official</h3>
 			<section id="official-apps" class="grid gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-				{#each $apps as app}
+				{#each $apps as app (app.link)}
 					<AppCard image={app.icon} text={app.type} desc={app.desc} link={app.link} />
 				{/each}
 			</section>
@@ -52,7 +52,7 @@
 
 			<h3 class="text-2xl font-semibold text-primary dark:text-white md:text-left">Community</h3>
 			<section id="community-apps" class="grid gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-				{#each communityApps as app}
+				{#each communityApps as app (app.link)}
 					<AppCard image={app.icon} text={app.type} desc={app.desc} link={app.link} />
 				{/each}
 			</section>

--- a/src/routes/badges/+page.svelte
+++ b/src/routes/badges/+page.svelte
@@ -195,7 +195,7 @@
 				</h2>
 
 				<div class="grid gap-5 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					{#each achievements.reverse() as achievement}
+					{#each achievements.reverse() as achievement (achievement.title)}
 						<BadgeCard
 							icon={achievement.icon}
 							title={achievement.title}
@@ -212,7 +212,7 @@
 				</h2>
 
 				<div class="grid gap-5 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-					{#each contributions.reverse() as contribution}
+					{#each contributions.reverse() as contribution (contribution.title)}
 						<BadgeCard
 							icon={contribution.icon}
 							title={contribution.title}

--- a/src/routes/communities/add/+page.svelte
+++ b/src/routes/communities/add/+page.svelte
@@ -266,7 +266,7 @@
 									: ''} max-h-[300px] overflow-auto border-2 border-input"
 							>
 								{#if !location}
-									{#each searchResults as area, index}
+									{#each searchResults as area, index (area.display_name)}
 										<button
 											on:click={() => setLocation(area)}
 											class="{index !== searchResults.length - 1

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -641,7 +641,7 @@
 				<div
 					class="hide-scroll mt-0.5 max-h-[204px] w-full overflow-y-scroll rounded-lg bg-white drop-shadow-[0px_2px_6px_rgba(0,0,0,0.15)] dark:bg-dark"
 				>
-					{#each searchResults as result}
+					{#each searchResults as result (result.id)}
 						<button
 							on:click={() => searchSelect(result)}
 							class="block w-full justify-between px-4 py-2 hover:bg-searchHover dark:border-b dark:hover:bg-white/[0.15] md:flex md:text-left"


### PR DESCRIPTION
Related: https://github.com/teambtcmap/btcmap.org/issues/235

Resolved all `svelte/require-each-key` warnings

Note: I did check each component and page that was edited, however I was unable to verify some components like the table on the "Open Tickets" page due to not having the Gitea env variables. That said, the skeleton still loads and looks as expected.

These changes also passed `yarn format` and `yarn playwright test`



But I would appreciate if someone could check out these changes to make sure components / pages that require .env variables render correctly.


Before:

> ✖ 194 problems (0 errors, 194 warnings)

After:


> ✖ 127 problems (0 errors, 127 warnings)