### PR TITLE
fix(merchant): opening hours are now centred on smaller page widths #416

### DIFF
--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -514,7 +514,7 @@
 								Hours
 							</h4>
 
-							<div class="flex items-start justify-center md:justify-center">
+							<div class="flex items-start justify-center">
 								<!-- eslint-disable-next-line svelte/no-at-html-tags - we even sanitize the captcha content above -->
 								<time class="flex flex-col items-start">{@html formatOpeningHours(hours)}</time>
 							</div>


### PR DESCRIPTION
**Does this PR address a related issue?**
Yes — Fixes #416 

**A description of the changes proposed in the pull request**
Changed container layout classes to improve alignment and responsiveness

**Screenshots**

BEFORE:
<img width="382" height="880" alt="image" src="https://github.com/user-attachments/assets/d95fec91-d114-4884-a8e0-555f71013b39" />

AFTER:
<img width="385" height="877" alt="image" src="https://github.com/user-attachments/assets/c0a4b85c-57a5-4431-a2d8-148dab7b63de" />



**Additional context**
