### PR TITLE
fix(merchant): correct OG image URL to use OSM Element ID #442

### DIFF
--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -338,7 +338,7 @@
 		}
 	});
 
-	const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
+	const ogImage = `https://api.btcmap.org/og/element/${data.osmType}:${data.osmId}`;
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Fixes: #442

It now doing this (again): https://api.btcmap.org/og/element/node:2489155938