### PR TITLE
Add isToday check in formatVerifiedHuman to avoid “X hours ago” for verification dates that don’t include time.

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,7 +8,7 @@ import { get } from 'svelte/store';
 import rewind from '@mapbox/geojson-rewind';
 import { geoContains } from 'd3-geo';
 import DOMPurify from 'dompurify';
-import { parseISO, isThisYear, isAfter, subDays, format, formatDistanceToNow } from 'date-fns';
+import { parseISO, isThisYear, isAfter, subDays, format, formatDistanceToNow, isToday } from 'date-fns';
 
 export const errToast = (m: string) => {
 	toast.push(m, {
@@ -244,23 +244,28 @@ const isRecentDate = (date: Date, thresholdDays: number = RECENT_DATE_THRESHOLD_
 };
 
 export const formatVerifiedHuman = (isoDateString?: string): string => {
-	if (!isoDateString) return '';
+  if (!isoDateString) return '';
 
-	const parsedDate = parseDateSafely(isoDateString);
-	if (!parsedDate) return isoDateString;
+  const parsedDate = parseDateSafely(isoDateString);
+  if (!parsedDate) return isoDateString;
 
-	// Recent dates (≤30 days) → "3 days ago"
-	if (isRecentDate(parsedDate)) {
-		return formatDistanceToNow(parsedDate, { addSuffix: true });
-	}
+  // Today → "Today"
+  if (isToday(parsedDate)) {
+    return 'Today';
+  }
 
-	// Same year → "15 October"
-	if (isThisYear(parsedDate)) {
-		return format(parsedDate, 'd MMMM');
-	}
+  // Recent dates (≤30 days) → "3 days ago"
+  if (isRecentDate(parsedDate)) {
+    return formatDistanceToNow(parsedDate, { addSuffix: true });
+  }
 
-	// Different year → "15 October 2023"
-	return format(parsedDate, 'd MMMM yyyy');
+  // Same year → "15 October"
+  if (isThisYear(parsedDate)) {
+    return format(parsedDate, 'd MMMM');
+  }
+
+  // Different year → "15 October 2023"
+  return format(parsedDate, 'd MMMM yyyy');
 };
 
 // Cache for enhanced place data to avoid repeated API calls


### PR DESCRIPTION
Add isToday check in formatVerifiedHuman to avoid “X hours ago” for verification dates that don’t include time.

Logic:

Today → “Today”

≤30 days → relative (formatDistanceToNow)

Same year → d MMMM

Different year → d MMMM yyyy

Before:
<img width="485" height="284" alt="image" src="https://github.com/user-attachments/assets/0e2cbca6-044a-4de5-8b18-7f047c358fa5" />
After:
<img width="432" height="277" alt="image" src="https://github.com/user-attachments/assets/a92004f7-f919-4922-9e0a-5408a6e2dd4a" />
