### PR TITLE
feat: remove second_twitter references #429

### DIFF
--- a/src/components/AreaPage.svelte
+++ b/src/components/AreaPage.svelte
@@ -224,7 +224,6 @@
 			email = area['contact:email'];
 			nostr = area['contact:nostr'];
 			twitter = area['contact:twitter'];
-			secondTwitter = area['contact:second_twitter'];
 			meetup = area['contact:meetup'];
 			eventbrite = area['contact:eventbrite'];
 			telegram = area['contact:telegram'];
@@ -329,7 +328,6 @@
 	let email: string | undefined;
 	let nostr: string | undefined;
 	let twitter: string | undefined;
-	let secondTwitter: string | undefined;
 	let meetup: string | undefined;
 	let eventbrite: string | undefined;
 	let telegram: string | undefined;
@@ -412,7 +410,6 @@
 					{email}
 					{nostr}
 					{twitter}
-					{secondTwitter}
 					{meetup}
 					{eventbrite}
 					{telegram}

--- a/src/components/CommunityCard.svelte
+++ b/src/components/CommunityCard.svelte
@@ -15,7 +15,6 @@
 	$: email = tags['contact:email'] && tags['contact:email'];
 	$: nostr = tags['contact:nostr'] && tags['contact:nostr'];
 	$: twitter = tags['contact:twitter'] && tags['contact:twitter'];
-	$: secondTwitter = tags['contact:second_twitter'] && tags['contact:second_twitter'];
 	$: meetup = tags['contact:meetup'] && tags['contact:meetup'];
 	$: eventbrite = tags['contact:eventbrite'] && tags['contact:eventbrite'];
 	$: telegram = tags['contact:telegram'] && tags['contact:telegram'];
@@ -75,7 +74,6 @@
 		{email}
 		{nostr}
 		{twitter}
-		{secondTwitter}
 		{meetup}
 		{eventbrite}
 		{telegram}

--- a/src/components/Socials.svelte
+++ b/src/components/Socials.svelte
@@ -3,7 +3,6 @@
 	export let email: undefined | string = undefined;
 	export let nostr: undefined | string = undefined;
 	export let twitter: undefined | string = undefined;
-	export let secondTwitter: undefined | string = undefined;
 	export let meetup: undefined | string = undefined;
 	export let eventbrite: undefined | string = undefined;
 	export let telegram: undefined | string = undefined;
@@ -49,13 +48,6 @@
 	{/if}
 	{#if twitter}
 		<a href={twitter} target="_blank" rel="noreferrer" class="m-1">
-			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-black">
-				<Icon w="25" h="25" icon="x" type="socials" style="text-white" />
-			</span>
-		</a>
-	{/if}
-	{#if secondTwitter}
-		<a href={secondTwitter} target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-black">
 				<Icon w="25" h="25" icon="x" type="socials" style="text-white" />
 			</span>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,7 +58,6 @@ export type AreaTags = {
 	['contact:email']?: string;
 	['contact:nostr']?: string;
 	['contact:twitter']?: string;
-	['contact:second_twitter']?: string;
 	['contact:meetup']?: string;
 	['contact:eventbrite']?: string;
 	['contact:telegram']?: string;

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -137,7 +137,6 @@
 						email: community.tags['contact:email'],
 						nostr: community.tags['contact:nostr'],
 						twitter: community.tags['contact:twitter'],
-						secondTwitter: community.tags['contact:second_twitter'],
 						meetup: community.tags['contact:meetup'],
 						eventbrite: community.tags['contact:eventbrite'],
 						telegram: community.tags['contact:telegram'],


### PR DESCRIPTION
**Does this PR address a related issue?**

This PR addresses issue-429 in btcmap web app

Fixes: #429

**A description of the changes proposed in the pull request**

This PR removes references to second_twitter which is not needed now

**Screenshots**

No screenshots to take on this one as the logo wasn't being displayed

**Additional context**
