### PR TITLE
fix(sync): retain CDN data when API update fails on first load

### DIFF
--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -146,6 +146,17 @@ export const elementsSync = async () => {
 							}
 						});
 
+						// Validate parsed data
+						if (!Array.isArray(placesData) || placesData.length === 0) {
+							console.error('CDN data parsing failed:', {
+								isArray: Array.isArray(placesData),
+								length: placesData?.length
+							});
+							throw new Error('CDN data parsing returned invalid format');
+						}
+
+						console.info(`Successfully parsed ${placesData.length} places from CDN`);
+
 						placesLoadingProgress.set(PROGRESS_RANGES.PARSE_END);
 					} catch (error) {
 						placesError.set(
@@ -177,6 +188,14 @@ export const elementsSync = async () => {
 					);
 
 					const recentUpdates = apiResponse.data;
+
+					// Validate response is actually an array
+					if (!Array.isArray(recentUpdates)) {
+						console.error('API returned invalid data format:', typeof recentUpdates, recentUpdates);
+						throw new Error('API returned invalid data format');
+					}
+
+					console.info(`Fetched ${recentUpdates.length} updates from API since ${updatesSince}`);
 
 					if (recentUpdates.length > 0) {
 						placesLoadingStatus.set('Merging updates...');
@@ -249,6 +268,11 @@ export const elementsSync = async () => {
 
 					// Parse JSON in worker thread
 					const parsedPlaces = await parseJSON<Place[]>(staticResponse.data, 'places');
+
+					// Validate fallback CDN data
+					if (!Array.isArray(parsedPlaces) || parsedPlaces.length === 0) {
+						throw new Error('Fallback CDN data invalid');
+					}
 
 					if (parsedPlaces.length > 0) {
 						places.set(parsedPlaces);


### PR DESCRIPTION
Previously, when a first-time user loaded the app and the CDN download succeeded but the API update check failed, all downloaded data was discarded and the map would not load. This resulted in a poor user experience despite having valid baseline data.

Now, when the API fails to fetch recent updates, the app continues with the existing data (either from cache or freshly downloaded from CDN) and shows the same user-friendly toast message in both scenarios.

This ensures the map always works if baseline data can be downloaded, with graceful degradation when real-time updates are unavailable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

