### PR TITLE
fix: Adjust padding on community buttons mobile view

### DIFF
--- a/src/routes/communities/[section]/+page.svelte
+++ b/src/routes/communities/[section]/+page.svelte
@@ -298,16 +298,10 @@
 				</PrimaryButton>
 
 				<div class="flex flex-col items-center justify-center gap-5 md:flex-row">
-					<PrimaryButton
-						style="md:w-[200px] mx-auto md:mx-0 py-3 rounded-xl"
-						link="/communities/add"
-					>
+					<PrimaryButton style="md:w-[200px] py-3 rounded-xl w-full" link="/communities/add">
 						Add community
 					</PrimaryButton>
-					<PrimaryButton
-						style="md:w-[200px] mx-auto md:mx-0 py-3 rounded-xl"
-						link="/communities/map"
-					>
+					<PrimaryButton style="md:w-[200px] py-3 rounded-xl w-full" link="/communities/map">
 						View community map
 					</PrimaryButton>
 				</div>

--- a/src/routes/communities/leaderboard/+page.svelte
+++ b/src/routes/communities/leaderboard/+page.svelte
@@ -48,21 +48,15 @@
 			</h2>
 
 			<div>
-				<PrimaryButton style="md:w-[200px] mx-auto py-3 rounded-xl mb-5" link="/communities">
+				<PrimaryButton style="w-full md:w-[200px] mx-auto py-3 rounded-xl mb-5" link="/communities">
 					Directory
 				</PrimaryButton>
 
 				<div class="flex flex-col items-center justify-center gap-5 md:flex-row">
-					<PrimaryButton
-						style="md:w-[200px] mx-auto md:mx-0 py-3 rounded-xl"
-						link="/communities/add"
-					>
+					<PrimaryButton style="w-full md:w-[200px] py-3 rounded-xl" link="/communities/add">
 						Add community
 					</PrimaryButton>
-					<PrimaryButton
-						style="md:w-[200px] mx-auto md:mx-0 py-3 rounded-xl"
-						link="/communities/map"
-					>
+					<PrimaryButton style="w-full md:w-[200px] py-3 rounded-xl" link="/communities/map">
 						View community map
 					</PrimaryButton>
 				</div>


### PR DESCRIPTION
**Does this PR address a related issue?**

Fixes: https://github.com/teambtcmap/btcmap.org/issues/495

**A description of the changes proposed in the pull request**

The change adjusts the width to be handled with w-full instead of mx-auto due to margin not being set smaller than md

**Screenshots**

Before:

<img width="603" height="1311" alt="IMG_0020" src="https://github.com/user-attachments/assets/3f880517-cf7d-48f6-8e8a-d30c1fae2b31" />

After:

<img width="603" height="1311" alt="IMG_0019" src="https://github.com/user-attachments/assets/7fa9e765-9c49-4772-a25e-4c72b6216898" />


**Additional context**
