### PR TITLE
feat: boost amount in sats instead of fiat #469 

### DIFF
--- a/src/components/Boost.svelte
+++ b/src/components/Boost.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
 	import CloseButton from '$components/CloseButton.svelte';
-	import { boost, exchangeRate, resetBoost, lastUpdatedPlaceId } from '$lib/store';
+	import { boost, resetBoost, lastUpdatedPlaceId } from '$lib/store';
 	import OutClick from 'svelte-outclick';
 	import { fly } from 'svelte/transition';
 	import BoostContent from './BoostContent.svelte';
@@ -13,7 +13,6 @@
 			invalidateAll();
 		}
 		$boost = undefined;
-		$exchangeRate = undefined;
 		$resetBoost = $resetBoost + 1;
 		$lastUpdatedPlaceId = undefined;
 		boostComplete = false;
@@ -28,7 +27,7 @@
 	};
 </script>
 
-{#if $boost && $exchangeRate}
+{#if $boost}
 	<OutClick on:outclick={handleOutClick}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}

--- a/src/components/BoostButton.svelte
+++ b/src/components/BoostButton.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import Icon from '$components/Icon.svelte';
-	import { boost, exchangeRate, resetBoost } from '$lib/store';
+	import { boost, resetBoost } from '$lib/store';
 	import type { Place } from '$lib/types';
-	import { fetchExchangeRate } from '$lib/utils';
 	import axios from 'axios';
 	import axiosRetry from 'axios-retry';
 
@@ -28,12 +27,6 @@
 			name: merchant.name || '',
 			boost: boosted || ''
 		};
-
-		try {
-			$exchangeRate = await fetchExchangeRate();
-		} catch {
-			resetBoostLoading();
-		}
 	};
 
 	$: $resetBoost && resetBoostLoading();

--- a/src/components/BoostContent.svelte
+++ b/src/components/BoostContent.svelte
@@ -2,7 +2,7 @@
 	import Icon from '$components/Icon.svelte';
 	import PrimaryButton from '$components/PrimaryButton.svelte';
 	import { PAYMENT_ERROR_MESSAGE, STATUS_CHECK_ERROR_MESSAGE } from '$lib/constants';
-	import { boost, boostHash, exchangeRate, lastUpdatedPlaceId } from '$lib/store';
+	import { boost, boostHash, lastUpdatedPlaceId } from '$lib/store';
 	import { updateSinglePlace } from '$lib/sync/places';
 	import { errToast, warningToast } from '$lib/utils';
 	import axios from 'axios';
@@ -17,13 +17,13 @@
 	let stage = 0;
 
 	const values = [
-		{ fiat: 5, time: 1 },
-		{ fiat: 10, time: 3 },
-		{ fiat: 30, time: 12 }
+		{ sats: 5000, time: 1 },
+		{ sats: 10000, time: 3 },
+		{ sats: 30000, time: 12 }
 	];
 
 	let tooltip = false;
-	let selectedBoost: { fiat: number; sats: string; time: number; expires: Date } | undefined;
+	let selectedBoost: { sats: number; time: number; expires: Date } | undefined;
 	let invoice = '';
 	let invoiceId = '';
 	let loading = false;
@@ -151,16 +151,13 @@
 			{#each values as value, index (index)}
 				<button
 					on:click={() => {
-						if (!$exchangeRate) return;
-
 						let dateNow = new Date();
 						let currentBoost =
 							$boost && $boost.boost && new Date($boost.boost) > dateNow
 								? new Date($boost.boost)
 								: undefined;
 						selectedBoost = {
-							fiat: value.fiat,
-							sats: (value.fiat / ($exchangeRate / 100000000)).toFixed(0),
+							sats: value.sats,
 							time: value.time,
 							expires: currentBoost
 								? new Date(currentBoost.setMonth(currentBoost.getMonth() + value.time))
@@ -176,21 +173,14 @@
 						<img src="/icons/star.svg" alt="star" class="absolute top-1 right-1" />
 					{/if}
 
-					<p>${value.fiat}</p>
-					<p class="text-xs">
-						{$exchangeRate ? (value.fiat / ($exchangeRate / 100000000)).toFixed(0) : '...'} sats
-					</p>
-					<p class="text-xs">{value.time} month</p>
+					<p class="text-xs">{value.time} month{value.time > 1 ? 's' : ''}</p>
+					<p class="font-bold">{value.sats.toLocaleString()} sats</p>
 				</button>
 			{/each}
 		</div>
 
 		<p class="text-xs text-body dark:text-white">
 			The fee is used to support the BTC Map open source project and continue it's development.
-		</p>
-
-		<p class="text-xs text-body dark:text-white">
-			*Fiat exchange rates may change during payment flow.
 		</p>
 
 		<PrimaryButton
@@ -212,7 +202,7 @@
 		onError={handlePaymentError}
 		onStatusCheckError={handleStatusCheckError}
 		description={selectedBoost
-			? `Boost this location for <strong>${selectedBoost.time} month${selectedBoost.time > 1 ? 's' : ''} <br /> $${selectedBoost.fiat}</strong> (<strong>${selectedBoost.sats} sats</strong>)`
+			? `Boost this location for <strong>${selectedBoost.time} month${selectedBoost.time > 1 ? 's' : ''} <br /> ${selectedBoost.sats.toLocaleString()} sats</strong>`
 			: ''}
 	/>
 {:else}

--- a/src/components/MerchantDrawerDesktop.svelte
+++ b/src/components/MerchantDrawerDesktop.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { boost, exchangeRate, resetBoost } from '$lib/store';
+	import { boost, resetBoost } from '$lib/store';
 	import CloseButton from '$components/CloseButton.svelte';
 	import Icon from '$components/Icon.svelte';
 	import { fly } from 'svelte/transition';
@@ -75,7 +75,7 @@
 	});
 
 	$: if (drawerView === 'boost' && merchant) {
-		ensureBoostData(merchant, $exchangeRate, $boost);
+		ensureBoostData(merchant, $boost);
 	}
 
 	export function openDrawer(id: number) {

--- a/src/components/MerchantDrawerMobile.svelte
+++ b/src/components/MerchantDrawerMobile.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
 	import { spring } from 'svelte/motion';
-	import { boost, exchangeRate, resetBoost } from '$lib/store';
+	import { boost, resetBoost } from '$lib/store';
 	import Icon from '$components/Icon.svelte';
 	import BoostContent from './BoostContent.svelte';
 	import MerchantDetailsContent from './MerchantDetailsContent.svelte';
@@ -193,7 +193,7 @@
 	});
 
 	$: if (drawerView === 'boost' && merchant) {
-		ensureBoostData(merchant, $exchangeRate, $boost);
+		ensureBoostData(merchant, $boost);
 	}
 
 	// Pointer event handlers for dragging

--- a/src/lib/merchantDrawerLogic.ts
+++ b/src/lib/merchantDrawerLogic.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store';
 import axios from 'axios';
-import { boost, exchangeRate } from '$lib/store';
-import { fetchExchangeRate, errToast } from '$lib/utils';
+import { boost } from '$lib/store';
+import { errToast } from '$lib/utils';
 import { updateMerchantHash } from '$lib/merchantDrawerHash';
 import type { Place, Boost } from '$lib/types';
 import type { Writable } from 'svelte/store';
@@ -34,7 +34,6 @@ export function isBoosted(merchant: Place | null): boolean {
 
 export function clearBoostState(): void {
 	boost.set(undefined);
-	exchangeRate.set(undefined);
 }
 
 function createBoostObject(merchant: Place) {
@@ -97,8 +96,6 @@ export async function handleBoost(
 	boost.set(createBoostObject(merchant));
 
 	try {
-		const rate = await fetchExchangeRate();
-		exchangeRate.set(rate);
 		updateMerchantHash(merchantId, 'boost');
 		setBoostLoading(false);
 	} catch (error) {
@@ -159,22 +156,10 @@ export function handleGoBack(
 	}
 }
 
-export async function ensureBoostData(
-	merchant: Place | null,
-	currentExchangeRate: number | undefined,
-	currentBoost: Boost
-): Promise<void> {
-	if (!merchant || currentExchangeRate !== undefined) return;
+export async function ensureBoostData(merchant: Place | null, currentBoost: Boost): Promise<void> {
+	if (!merchant) return;
 
 	if (currentBoost === undefined) {
 		boost.set(createBoostObject(merchant));
-	}
-
-	try {
-		const rate = await fetchExchangeRate();
-		exchangeRate.set(rate);
-	} catch (error) {
-		console.error('Error ensuring boost data:', error);
-		// Don't show toast here as this is a background operation
 	}
 }

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -68,7 +68,6 @@ export const excludeLeader = readable([
 ]);
 
 export const boost: Writable<Boost> = writable();
-export const exchangeRate: Writable<number | undefined> = writable();
 export const resetBoost = writable(0);
 export const boostHash: Writable<string> = writable();
 export const lastUpdatedPlaceId: Writable<number | undefined> = writable();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -8,7 +8,6 @@ import { get } from 'svelte/store';
 import rewind from '@mapbox/geojson-rewind';
 import { geoContains } from 'd3-geo';
 import DOMPurify from 'dompurify';
-import axios from 'axios';
 import {
 	parseISO,
 	isThisYear,
@@ -61,17 +60,6 @@ export const successToast = (m: string) => {
 		}
 	});
 };
-
-export async function fetchExchangeRate(): Promise<number> {
-	try {
-		const response = await axios.get('https://blockchain.info/ticker');
-		return response.data['USD']['15m'];
-	} catch (error) {
-		console.error('Error fetching exchange rate:', error);
-		errToast('Could not fetch bitcoin exchange rate, please try again or contact BTC Map.');
-		throw error;
-	}
-}
 
 export function getRandomColor() {
 	const letters = '0123456789ABCDEF';

--- a/tests/boost-invoice.spec.ts
+++ b/tests/boost-invoice.spec.ts
@@ -38,7 +38,7 @@ test.describe('Boost Invoice Generation', () => {
 		await expect(page.locator('text=Boost Location')).toBeVisible({ timeout: 10000 });
 
 		// Select first boost option (30 days / $5)
-		const boostOption = page.locator('button').filter({ hasText: /\$5/ }).first();
+		const boostOption = page.locator('button').filter({ hasText: '5,000 sats' }).first();
 		await expect(boostOption).toBeVisible();
 		await boostOption.click({ force: true });
 


### PR DESCRIPTION
**Does this PR address a related issue?**
Fixes: #469 

**A description of the changes proposed in the pull request**
Boost amounts are changed from fiat to sats

I have not removed the sats price, but displayed it for information. It might be usefull for some people to know the corresponding value in dollars...
I'm not 100% convinced, if you still think fiat should disapear from the website, I'll update my PR!

I would like to try another UI for the "prefered option" too. I did let the star icon for the moment, but can suggest something else in this / a future PR.

**Screenshots**


Old version : 
<img width="423" height="423" alt="image" src="https://github.com/user-attachments/assets/5c7b845a-05d2-4f2e-9cc9-896ca0287024" />


New version : 
<img width="430" height="379" alt="image" src="https://github.com/user-attachments/assets/54f951b3-0375-400d-9db4-a614bec96658" />
