### PR TITLE
fix: add cursor-pointer in all button

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -15,6 +15,14 @@
 	::selection {
 		@apply bg-[#53c5d5] text-white;
 	}
+
+	button {
+		cursor: pointer;
+	}
+
+	button:disabled {
+		cursor: not-allowed;
+	}
 }
 
 @layer utilities {


### PR DESCRIPTION
In many places, there is no cursor-pointer when hovering buttons.