### PR TITLE
fix: boost message color in dark mode fix #292

### DIFF
--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -735,7 +735,7 @@
 							</p>
 
 							{#if boosted}
-								<p>
+								<p class="dark:text-white">
 									Boost Expires:
 									<span class="underline decoration-bitcoin decoration-4 underline-offset-8">
 										<Time live={3000} relative={true} timestamp={boosted} />


### PR DESCRIPTION
**Does this PR address a related issue?**
Fixes: #292 

**Screenshots**
Before
<img width="397" height="264" alt="image" src="https://github.com/user-attachments/assets/5c9706f0-0324-464e-b7ff-56c3afdbdb96" />

After
<img width="397" height="264" alt="image" src="https://github.com/user-attachments/assets/086b5a1d-c5cc-434e-ac41-4fd0cf7152d4" />
