### PR TITLE
feat(map): enable swipe-to-collapse from expanded drawer content #235

### DIFF
--- a/src/lib/drawerConfig.ts
+++ b/src/lib/drawerConfig.ts
@@ -1,0 +1,21 @@
+// Drawer gesture configuration constants
+// These values control the behavior of the mobile drawer's swipe gestures
+
+// Drawer height states
+export const PEEK_HEIGHT = 140; // Collapsed state height - shows merchant name and quick info
+
+// Gesture thresholds
+export const VELOCITY_THRESHOLD = 0.5; // px/ms - minimum velocity for flick gesture detection
+export const DISTANCE_THRESHOLD = 80; // px - minimum drag distance to trigger snap
+export const DISMISS_THRESHOLD = 60; // px - drag distance below peek to trigger dismiss
+export const POSITION_THRESHOLD_PERCENT = 0.3; // When to snap up vs down (30% of total height)
+
+// Velocity tracking
+export const VELOCITY_SAMPLE_COUNT = 5; // Number of velocity samples for smoothing
+
+// Spring animation config
+export const SPRING_CONFIG = { stiffness: 0.2, damping: 0.75 }; // Smooth but responsive feel
+
+// Scroll-aware drag thresholds (for expanded content swipe-to-collapse)
+export const SCROLL_DRAG_THRESHOLD = 10; // px to decide drag vs scroll
+export const SCROLL_TOP_THRESHOLD = 1; // px tolerance for scroll position (handles browser rounding)

--- a/src/lib/drawerGestureController.ts
+++ b/src/lib/drawerGestureController.ts
@@ -1,0 +1,284 @@
+// Store-based gesture controller for mobile drawer
+// Consolidates all gesture state and handlers in one place
+
+import { writable, derived, get } from 'svelte/store';
+import { spring } from 'svelte/motion';
+import {
+	PEEK_HEIGHT,
+	VELOCITY_THRESHOLD,
+	SPRING_CONFIG,
+	DISMISS_THRESHOLD,
+	SCROLL_DRAG_THRESHOLD,
+	SCROLL_TOP_THRESHOLD
+} from './drawerConfig';
+import {
+	determineSnapState,
+	updateVelocity,
+	createVelocityState,
+	type VelocityState
+} from './drawerGestureUtils';
+
+export interface DrawerGestureState {
+	expanded: boolean;
+	isDragging: boolean;
+	expandedHeight: number;
+}
+
+interface InternalGestureState {
+	activePointerId: number | null;
+	startY: number;
+	initialHeight: number;
+	velocityState: VelocityState;
+	touchStartY: number | null;
+	isInCollapseDrag: boolean;
+}
+
+function createDrawerGestureController() {
+	// Public state (exposed to component)
+	const expanded = writable(false);
+	const isDragging = writable(false);
+	const expandedHeight = writable(500);
+
+	// Spring-animated height
+	const drawerHeight = spring(PEEK_HEIGHT, SPRING_CONFIG);
+
+	// Internal gesture tracking (not exposed)
+	const internal: InternalGestureState = {
+		activePointerId: null,
+		startY: 0,
+		initialHeight: PEEK_HEIGHT,
+		velocityState: createVelocityState(0, 0),
+		touchStartY: null,
+		isInCollapseDrag: false
+	};
+
+	// Callbacks for external actions
+	let onDismiss: (() => void) | null = null;
+
+	// Reset internal state
+	function resetInternalState() {
+		internal.activePointerId = null;
+		internal.startY = 0;
+		internal.velocityState = createVelocityState(0, 0);
+		internal.touchStartY = null;
+		internal.isInCollapseDrag = false;
+		isDragging.set(false);
+	}
+
+	// Pointer event handlers (for handle/peek area)
+	function handlePointerDown(event: PointerEvent, captureTarget: HTMLElement | null) {
+		if (internal.activePointerId !== null) return;
+
+		internal.activePointerId = event.pointerId;
+		isDragging.set(true);
+		internal.startY = event.clientY;
+		internal.initialHeight = get(drawerHeight);
+		internal.velocityState = createVelocityState(event.clientY, event.timeStamp);
+
+		if (captureTarget) {
+			try {
+				captureTarget.setPointerCapture(event.pointerId);
+			} catch {
+				// Pointer capture not supported or failed
+			}
+		}
+	}
+
+	function handlePointerMove(event: PointerEvent) {
+		if (event.pointerId !== internal.activePointerId || !get(isDragging)) return;
+
+		const currentY = event.clientY;
+		internal.velocityState = updateVelocity(currentY, event.timeStamp, internal.velocityState);
+
+		const isExpanded = get(expanded);
+		const maxHeight = get(expandedHeight);
+		const deltaY = internal.startY - currentY;
+		const minHeight = isExpanded ? PEEK_HEIGHT : 0;
+		const newHeight = Math.max(minHeight, Math.min(maxHeight, internal.initialHeight + deltaY));
+
+		drawerHeight.set(newHeight, { hard: true });
+	}
+
+	function handlePointerUp(event: PointerEvent, capturedElement: HTMLElement | null) {
+		if (event.pointerId !== internal.activePointerId) return;
+
+		const finalHeight = get(drawerHeight);
+		const totalDelta = finalHeight - internal.initialHeight;
+		const isExpanded = get(expanded);
+		const maxHeight = get(expandedHeight);
+
+		// Release pointer capture safely
+		if (capturedElement) {
+			try {
+				capturedElement.releasePointerCapture(event.pointerId);
+			} catch {
+				// Already released or invalid
+			}
+		}
+
+		// Check for dismiss gesture when in peek state
+		const velocity = internal.velocityState.velocity;
+		const shouldDismiss =
+			!isExpanded &&
+			(velocity < -VELOCITY_THRESHOLD || finalHeight < PEEK_HEIGHT - DISMISS_THRESHOLD);
+
+		if (shouldDismiss) {
+			onDismiss?.();
+		} else {
+			const snapState = determineSnapState(velocity, totalDelta, finalHeight, maxHeight);
+			expanded.set(snapState.expanded);
+			drawerHeight.set(snapState.height);
+		}
+
+		resetInternalState();
+	}
+
+	function handlePointerCancel(event: PointerEvent) {
+		if (event.pointerId !== internal.activePointerId) return;
+
+		const isExpanded = get(expanded);
+		const maxHeight = get(expandedHeight);
+
+		// Snap back to previous state
+		drawerHeight.set(isExpanded ? maxHeight : PEEK_HEIGHT);
+		resetInternalState();
+	}
+
+	// Touch event handlers (for expanded content area - Google Maps style)
+	function handleContentTouchStart(event: TouchEvent) {
+		if (!get(expanded) || event.touches.length !== 1) return;
+		internal.touchStartY = event.touches[0].clientY;
+		internal.isInCollapseDrag = false;
+	}
+
+	function handleContentTouchMove(event: TouchEvent, scrollTop: number) {
+		if (!get(expanded) || internal.touchStartY === null || event.touches.length !== 1) return;
+
+		const touch = event.touches[0];
+		const deltaY = touch.clientY - internal.touchStartY;
+
+		// At scroll top AND dragging down → enter collapse drag mode
+		if (scrollTop <= SCROLL_TOP_THRESHOLD && deltaY > SCROLL_DRAG_THRESHOLD) {
+			event.preventDefault();
+
+			if (!internal.isInCollapseDrag) {
+				internal.isInCollapseDrag = true;
+				isDragging.set(true);
+				internal.startY = touch.clientY;
+				internal.touchStartY = touch.clientY;
+				internal.initialHeight = get(drawerHeight);
+				internal.velocityState = createVelocityState(touch.clientY, event.timeStamp);
+			} else {
+				const currentY = touch.clientY;
+				internal.velocityState = updateVelocity(currentY, event.timeStamp, internal.velocityState);
+
+				const maxHeight = get(expandedHeight);
+				const dragDelta = internal.startY - currentY;
+				const newHeight = Math.max(
+					PEEK_HEIGHT,
+					Math.min(maxHeight, internal.initialHeight + dragDelta)
+				);
+				drawerHeight.set(newHeight, { hard: true });
+			}
+		} else if (internal.isInCollapseDrag && scrollTop > SCROLL_TOP_THRESHOLD) {
+			// User scrolled back up during collapse drag - cancel it
+			internal.isInCollapseDrag = false;
+			isDragging.set(false);
+			internal.velocityState = createVelocityState(0, 0);
+			drawerHeight.set(get(expandedHeight));
+		}
+	}
+
+	function handleContentTouchEnd() {
+		if (internal.isInCollapseDrag) {
+			const finalHeight = get(drawerHeight);
+			const totalDelta = finalHeight - internal.initialHeight;
+			const maxHeight = get(expandedHeight);
+			const velocity = internal.velocityState.velocity;
+			const snapState = determineSnapState(velocity, totalDelta, finalHeight, maxHeight);
+			expanded.set(snapState.expanded);
+			drawerHeight.set(snapState.height);
+		}
+		resetInternalState();
+	}
+
+	// Public methods for drawer control
+	function expand() {
+		expanded.set(true);
+		drawerHeight.set(get(expandedHeight));
+	}
+
+	function collapse() {
+		expanded.set(false);
+		drawerHeight.set(PEEK_HEIGHT);
+	}
+
+	function toggle() {
+		if (get(expanded)) {
+			collapse();
+		} else {
+			expand();
+		}
+	}
+
+	function resetToPeek() {
+		expanded.set(false);
+		drawerHeight.set(PEEK_HEIGHT, { hard: true });
+		resetInternalState();
+	}
+
+	function setExpandedHeight(height: number) {
+		expandedHeight.set(height);
+		if (get(expanded)) {
+			drawerHeight.set(height);
+		}
+	}
+
+	function setDismissCallback(callback: (() => void) | null) {
+		onDismiss = callback;
+	}
+
+	// Derived store for component binding
+	const state = derived(
+		[expanded, isDragging, expandedHeight],
+		([$expanded, $isDragging, $expandedHeight]) => ({
+			expanded: $expanded,
+			isDragging: $isDragging,
+			expandedHeight: $expandedHeight
+		})
+	);
+
+	return {
+		// Stores
+		expanded,
+		isDragging,
+		expandedHeight,
+		drawerHeight,
+		state,
+
+		// Pointer handlers
+		handlePointerDown,
+		handlePointerMove,
+		handlePointerUp,
+		handlePointerCancel,
+
+		// Touch handlers
+		handleContentTouchStart,
+		handleContentTouchMove,
+		handleContentTouchEnd,
+
+		// Control methods
+		expand,
+		collapse,
+		toggle,
+		resetToPeek,
+		setExpandedHeight,
+		setDismissCallback
+	};
+}
+
+// Export singleton instance
+export const drawerGesture = createDrawerGestureController();
+
+// Export type for component usage
+export type DrawerGestureController = ReturnType<typeof createDrawerGestureController>;

--- a/src/lib/drawerGestureUtils.test.ts
+++ b/src/lib/drawerGestureUtils.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest';
+import {
+	determineSnapState,
+	updateVelocity,
+	createVelocityState,
+	resetVelocityState,
+	calculateDragHeight
+} from './drawerGestureUtils';
+import { PEEK_HEIGHT } from './drawerConfig';
+
+describe('determineSnapState', () => {
+	const EXPANDED = 667;
+
+	it('snaps to expanded on high upward velocity', () => {
+		const result = determineSnapState(0.6, 50, 300, EXPANDED);
+		expect(result).toEqual({ expanded: true, height: EXPANDED });
+	});
+
+	it('snaps to peek on high downward velocity', () => {
+		const result = determineSnapState(-0.6, -50, 300, EXPANDED);
+		expect(result).toEqual({ expanded: false, height: PEEK_HEIGHT });
+	});
+
+	it('snaps to expanded on large upward distance', () => {
+		const result = determineSnapState(0.1, 100, 400, EXPANDED);
+		expect(result).toEqual({ expanded: true, height: EXPANDED });
+	});
+
+	it('snaps to peek on large downward distance', () => {
+		const result = determineSnapState(0.1, -100, 200, EXPANDED);
+		expect(result).toEqual({ expanded: false, height: PEEK_HEIGHT });
+	});
+
+	it('snaps to nearest on small movement - above threshold', () => {
+		// threshold = 140 + (667-140)*0.3 = 298.1
+		const result = determineSnapState(0.1, 10, 350, EXPANDED);
+		expect(result).toEqual({ expanded: true, height: EXPANDED });
+	});
+
+	it('snaps to nearest on small movement - below threshold', () => {
+		const result = determineSnapState(0.1, -10, 200, EXPANDED);
+		expect(result).toEqual({ expanded: false, height: PEEK_HEIGHT });
+	});
+
+	it('velocity takes priority over distance', () => {
+		// High upward velocity should expand even with downward distance
+		const result = determineSnapState(0.6, -100, 200, EXPANDED);
+		expect(result).toEqual({ expanded: true, height: EXPANDED });
+	});
+
+	it('handles edge case at exact threshold', () => {
+		// At exactly the velocity threshold
+		const result = determineSnapState(0.5, 0, 300, EXPANDED);
+		// 0.5 is not > 0.5, so it falls through to distance check
+		// Distance is 0, which is not > 80 or < -80
+		// Falls through to position check: 300 > 298.1 → expanded
+		expect(result).toEqual({ expanded: true, height: EXPANDED });
+	});
+});
+
+describe('updateVelocity', () => {
+	it('returns new state with updated velocity', () => {
+		const initial = createVelocityState(100, 1000);
+		const result = updateVelocity(90, 1010, initial);
+
+		expect(result.lastY).toBe(90);
+		expect(result.lastTime).toBe(1010);
+		expect(result.samples.length).toBe(1);
+		expect(result.velocity).toBe(1); // (100-90)/10 = 1 px/ms
+	});
+
+	it('calculates negative velocity for downward movement', () => {
+		const initial = createVelocityState(100, 1000);
+		const result = updateVelocity(110, 1010, initial);
+
+		expect(result.velocity).toBe(-1); // (100-110)/10 = -1 px/ms
+	});
+
+	it('maintains rolling average of samples', () => {
+		let state = createVelocityState(100, 1000);
+		for (let i = 1; i <= 6; i++) {
+			state = updateVelocity(100 - i * 10, 1000 + i * 10, state);
+		}
+		// Should only keep last 5 samples
+		expect(state.samples.length).toBe(5);
+	});
+
+	it('does not update velocity if time delta is zero', () => {
+		const initial = createVelocityState(100, 1000);
+		const result = updateVelocity(90, 1000, initial);
+		expect(result.velocity).toBe(0);
+		expect(result.samples.length).toBe(0);
+		// But should still update position
+		expect(result.lastY).toBe(90);
+		expect(result.lastTime).toBe(1000);
+	});
+
+	it('does not mutate original state', () => {
+		const initial = createVelocityState(100, 1000);
+		const originalSamples = initial.samples;
+		updateVelocity(90, 1010, initial);
+
+		expect(initial.samples).toBe(originalSamples);
+		expect(initial.samples.length).toBe(0);
+		expect(initial.velocity).toBe(0);
+		expect(initial.lastY).toBe(100);
+	});
+
+	it('averages multiple velocity samples', () => {
+		let state = createVelocityState(100, 1000);
+		// First move: 10px in 10ms = 1 px/ms
+		state = updateVelocity(90, 1010, state);
+		// Second move: 20px in 10ms = 2 px/ms
+		state = updateVelocity(70, 1020, state);
+
+		expect(state.samples.length).toBe(2);
+		expect(state.velocity).toBe(1.5); // (1 + 2) / 2
+	});
+});
+
+describe('createVelocityState', () => {
+	it('creates state with given initial values', () => {
+		const state = createVelocityState(250, 12345);
+
+		expect(state.lastY).toBe(250);
+		expect(state.lastTime).toBe(12345);
+		expect(state.samples).toEqual([]);
+		expect(state.velocity).toBe(0);
+	});
+});
+
+describe('resetVelocityState', () => {
+	it('creates zeroed state', () => {
+		const state = resetVelocityState();
+
+		expect(state.lastY).toBe(0);
+		expect(state.lastTime).toBe(0);
+		expect(state.samples).toEqual([]);
+		expect(state.velocity).toBe(0);
+	});
+});
+
+describe('calculateDragHeight', () => {
+	it('calculates height within bounds', () => {
+		// Dragging up 100px from 200px height
+		expect(calculateDragHeight(500, 400, 200, 140, 667)).toBe(300);
+	});
+
+	it('clamps to minimum', () => {
+		// Trying to drag below minimum
+		expect(calculateDragHeight(500, 700, 200, 140, 667)).toBe(140);
+	});
+
+	it('clamps to maximum', () => {
+		// Trying to drag above maximum
+		expect(calculateDragHeight(500, 100, 200, 140, 667)).toBe(600);
+	});
+
+	it('handles negative delta (dragging down)', () => {
+		// Dragging down 50px from 300px height
+		expect(calculateDragHeight(500, 550, 300, 140, 667)).toBe(250);
+	});
+
+	it('handles zero delta', () => {
+		expect(calculateDragHeight(500, 500, 300, 140, 667)).toBe(300);
+	});
+});

--- a/src/lib/drawerGestureUtils.ts
+++ b/src/lib/drawerGestureUtils.ts
@@ -1,0 +1,115 @@
+// Pure utility functions for drawer gesture handling
+// All functions are side-effect free and easily testable
+
+import {
+	PEEK_HEIGHT,
+	VELOCITY_THRESHOLD,
+	DISTANCE_THRESHOLD,
+	POSITION_THRESHOLD_PERCENT,
+	VELOCITY_SAMPLE_COUNT
+} from './drawerConfig';
+
+export interface SnapState {
+	expanded: boolean;
+	height: number;
+}
+
+export interface VelocityState {
+	samples: number[];
+	velocity: number;
+	lastY: number;
+	lastTime: number;
+}
+
+// Determines the snap state based on gesture velocity and distance
+export function determineSnapState(
+	velocity: number,
+	totalDelta: number,
+	finalHeight: number,
+	expandedHeight: number
+): SnapState {
+	// Velocity takes priority - flick gestures feel responsive
+	if (Math.abs(velocity) > VELOCITY_THRESHOLD) {
+		if (velocity > 0) {
+			return { expanded: true, height: expandedHeight };
+		} else {
+			return { expanded: false, height: PEEK_HEIGHT };
+		}
+	}
+
+	// Then check distance for deliberate drags
+	if (totalDelta > DISTANCE_THRESHOLD) {
+		return { expanded: true, height: expandedHeight };
+	}
+	if (totalDelta < -DISTANCE_THRESHOLD) {
+		return { expanded: false, height: PEEK_HEIGHT };
+	}
+
+	// Small movement - snap to nearest based on current position
+	const threshold = PEEK_HEIGHT + (expandedHeight - PEEK_HEIGHT) * POSITION_THRESHOLD_PERCENT;
+	if (finalHeight > threshold) {
+		return { expanded: true, height: expandedHeight };
+	}
+	return { expanded: false, height: PEEK_HEIGHT };
+}
+
+// Updates velocity tracking state - returns new state without mutation
+export function updateVelocity(
+	currentY: number,
+	currentTime: number,
+	state: VelocityState
+): VelocityState {
+	const timeDelta = currentTime - state.lastTime;
+	if (timeDelta <= 0) {
+		return { ...state, lastY: currentY, lastTime: currentTime };
+	}
+
+	const yDelta = state.lastY - currentY; // positive = moving up
+	const instantVelocity = yDelta / timeDelta;
+
+	const samples = [...state.samples, instantVelocity];
+	if (samples.length > VELOCITY_SAMPLE_COUNT) {
+		samples.shift();
+	}
+
+	const velocity = samples.reduce((a, b) => a + b, 0) / samples.length;
+
+	return {
+		samples,
+		velocity,
+		lastY: currentY,
+		lastTime: currentTime
+	};
+}
+
+// Creates initial velocity tracking state
+export function createVelocityState(initialY: number, initialTime: number): VelocityState {
+	return {
+		samples: [],
+		velocity: 0,
+		lastY: initialY,
+		lastTime: initialTime
+	};
+}
+
+// Resets velocity tracking state (for reuse without allocation)
+export function resetVelocityState(): VelocityState {
+	return {
+		samples: [],
+		velocity: 0,
+		lastY: 0,
+		lastTime: 0
+	};
+}
+
+// Calculates new drawer height during drag
+export function calculateDragHeight(
+	startY: number,
+	currentY: number,
+	initialHeight: number,
+	minHeight: number,
+	maxHeight: number
+): number {
+	const deltaY = startY - currentY;
+	return Math.max(minHeight, Math.min(maxHeight, initialHeight + deltaY));
+}

--- a/src/routes/map/components/MerchantDrawerMobile.svelte
+++ b/src/routes/map/components/MerchantDrawerMobile.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { browser } from '$app/environment';
-	import { spring } from 'svelte/motion';
 	import { boost, resetBoost } from '$lib/store';
 	import Icon from '$components/Icon.svelte';
 	import BoostContent from '$components/BoostContent.svelte';
@@ -18,44 +17,7 @@
 		ensureBoostData,
 		clearBoostState
 	} from '$lib/merchantDrawerLogic';
-
-	// Gesture constants
-	const PEEK_HEIGHT = 140; // Collapsed state height - shows merchant name and quick info
-	const VELOCITY_THRESHOLD = 0.5; // px/ms - minimum velocity for flick gesture detection
-	const DISTANCE_THRESHOLD = 80; // px - minimum drag distance to trigger snap
-	const DISMISS_THRESHOLD = 60; // px - drag distance below peek to trigger dismiss
-	const POSITION_THRESHOLD_PERCENT = 0.3; // When to snap up vs down (30% of total height)
-	const VELOCITY_SAMPLE_COUNT = 5; // Number of velocity samples for smoothing
-	const SPRING_CONFIG = { stiffness: 0.2, damping: 0.75 }; // Animation feel - smooth but responsive
-
-	// Helper function to determine snap state based on gesture
-	function determineSnapState(
-		velocity: number,
-		totalDelta: number,
-		finalHeight: number,
-		EXPANDED_HEIGHT: number
-	): { expanded: boolean; height: number } {
-		// Snap decision based on velocity first, then distance
-		if (Math.abs(velocity) > VELOCITY_THRESHOLD) {
-			if (velocity > 0) {
-				return { expanded: true, height: EXPANDED_HEIGHT };
-			} else {
-				return { expanded: false, height: PEEK_HEIGHT };
-			}
-		} else if (totalDelta > DISTANCE_THRESHOLD) {
-			return { expanded: true, height: EXPANDED_HEIGHT };
-		} else if (totalDelta < -DISTANCE_THRESHOLD) {
-			return { expanded: false, height: PEEK_HEIGHT };
-		} else {
-			// Small movement - snap to nearest based on current position
-			const threshold = PEEK_HEIGHT + (EXPANDED_HEIGHT - PEEK_HEIGHT) * POSITION_THRESHOLD_PERCENT;
-			if (finalHeight > threshold) {
-				return { expanded: true, height: EXPANDED_HEIGHT };
-			} else {
-				return { expanded: false, height: PEEK_HEIGHT };
-			}
-		}
-	}
+	import { drawerGesture } from '$lib/drawerGestureController';
 
 	// Derive state from centralized store
 	$: isOpen = $merchantDrawer.isOpen;
@@ -64,22 +26,10 @@
 	$: merchant = $merchantDrawer.merchant;
 	$: fetchingMerchant = $merchantDrawer.isLoading;
 
-	// Bottom sheet state
-	let EXPANDED_HEIGHT = 500; // Initial value, updated to window.innerHeight on mount
-	let expanded = false; // Whether drawer is in expanded (full screen) state
-	let drawerHeight = spring(PEEK_HEIGHT, SPRING_CONFIG);
-	let isDragging = false;
+	// Get gesture state from controller
+	const { expanded, drawerHeight } = drawerGesture;
 
-	// Pointer tracking state
-	let activePointerId: number | null = null;
-	let startY = 0;
-	let initialHeight = PEEK_HEIGHT;
-	let lastY = 0;
-	let lastTime = 0;
-	let velocitySamples: number[] = [];
-	let velocity = 0;
-
-	// DOM reference
+	// DOM references
 	let drawerElement: HTMLDivElement;
 	let handleElement: HTMLDivElement;
 	let capturedElement: HTMLElement | null = null;
@@ -88,46 +38,20 @@
 	// Focus management for accessibility
 	let previouslyFocusedElement: HTMLElement | null = null;
 
-	// Scroll-aware drag state for expanded mode (touch-based for better control)
-	let touchStartY: number | null = null;
-	let isInCollapseDrag = false;
-	const SCROLL_DRAG_THRESHOLD = 10; // px to decide drag vs scroll
-	const SCROLL_TOP_THRESHOLD = 1; // px tolerance for scroll position (handles browser rounding)
-
-	// Shared velocity tracking helper to reduce duplication
-	function updateVelocityTracking(currentY: number, currentTime: number) {
-		const timeDelta = currentTime - lastTime;
-		if (timeDelta > 0) {
-			const yDelta = lastY - currentY; // positive = moving up
-			const instantVelocity = yDelta / timeDelta;
-			velocitySamples.push(instantVelocity);
-			if (velocitySamples.length > VELOCITY_SAMPLE_COUNT) {
-				velocitySamples.shift();
-			}
-			velocity = velocitySamples.reduce((a, b) => a + b, 0) / velocitySamples.length;
-		}
-		lastY = currentY;
-		lastTime = currentTime;
-	}
-
 	// Track previous state to reset drawer when merchant changes
 	let previousMerchantId: number | null = null;
 	$: if (isOpen && merchantId !== previousMerchantId) {
 		previousMerchantId = merchantId;
-		expanded = false;
-		drawerHeight.set(PEEK_HEIGHT, { hard: true });
+		drawerGesture.resetToPeek();
 	}
 
 	// Focus management: save/restore focus when expanding/collapsing
 	let wasExpanded = false;
-	$: if (expanded && !wasExpanded) {
-		// Expanding: save current focus and move to drawer
+	$: if ($expanded && !wasExpanded) {
 		previouslyFocusedElement = document.activeElement as HTMLElement;
-		// Use tick to ensure DOM is updated before focusing
 		setTimeout(() => handleElement?.focus(), 0);
 		wasExpanded = true;
-	} else if (!expanded && wasExpanded) {
-		// Collapsing: return focus to previously focused element
+	} else if (!$expanded && wasExpanded) {
 		if (previouslyFocusedElement && typeof previouslyFocusedElement.focus === 'function') {
 			previouslyFocusedElement.focus();
 		}
@@ -137,10 +61,9 @@
 
 	// Focus trap: keep focus inside drawer when expanded
 	function handleFocusOut(event: FocusEvent) {
-		if (expanded && drawerElement && event.relatedTarget) {
+		if ($expanded && drawerElement && event.relatedTarget) {
 			const focusMovingOutside = !drawerElement.contains(event.relatedTarget as Node);
 			if (focusMovingOutside) {
-				// Redirect focus back to handle
 				handleElement?.focus();
 			}
 		}
@@ -158,8 +81,7 @@
 	const closeDrawer = () => {
 		clearBoostState();
 		boostLoading = false;
-		expanded = false;
-		drawerHeight.set(PEEK_HEIGHT);
+		drawerGesture.collapse();
 		merchantDrawer.close();
 	};
 
@@ -185,62 +107,71 @@
 				event.preventDefault();
 				if (drawerView !== 'details') {
 					goBack();
-				} else if (expanded) {
-					expanded = false;
-					drawerHeight.set(PEEK_HEIGHT);
+				} else if ($expanded) {
+					drawerGesture.collapse();
 				} else {
 					closeDrawer();
 				}
 				break;
 			case 'ArrowUp':
 				event.preventDefault();
-				if (!expanded) {
-					expanded = true;
-					drawerHeight.set(EXPANDED_HEIGHT);
+				if (!$expanded) {
+					drawerGesture.expand();
 				}
 				break;
 			case 'ArrowDown':
 				event.preventDefault();
-				if (expanded) {
-					expanded = false;
-					drawerHeight.set(PEEK_HEIGHT);
+				if ($expanded) {
+					drawerGesture.collapse();
 				}
 				break;
 			case 'Enter':
 			case ' ':
-				// Only toggle if focus is on the handle element
 				if (document.activeElement === handleElement) {
 					event.preventDefault();
-					if (expanded) {
-						expanded = false;
-						drawerHeight.set(PEEK_HEIGHT);
-					} else {
-						expanded = true;
-						drawerHeight.set(EXPANDED_HEIGHT);
-					}
+					drawerGesture.toggle();
 				}
 				break;
 		}
 	}
 
+	// Wire up pointer event handlers with capture target
+	function onPointerDown(event: PointerEvent) {
+		const target = event.currentTarget as HTMLElement;
+		capturedElement = target;
+		drawerGesture.handlePointerDown(event, target);
+	}
+
+	function onPointerUp(event: PointerEvent) {
+		drawerGesture.handlePointerUp(event, capturedElement);
+		capturedElement = null;
+	}
+
+	// Wire up touch handler with scroll position
+	function onContentTouchMove(event: TouchEvent) {
+		const scrollTop = contentScrollElement?.scrollTop ?? 0;
+		drawerGesture.handleContentTouchMove(event, scrollTop);
+	}
+
 	onMount(() => {
+		// Set dismiss callback
+		drawerGesture.setDismissCallback(closeDrawer);
+
+		// Keyboard listener
 		window.addEventListener('keydown', handleKeydown);
 
+		// Window resize handler
 		let updateHeight: (() => void) | null = null;
-
 		if (browser) {
 			updateHeight = () => {
-				EXPANDED_HEIGHT = window.innerHeight;
-				if (expanded) {
-					drawerHeight.set(EXPANDED_HEIGHT);
-				}
+				drawerGesture.setExpandedHeight(window.innerHeight);
 			};
-
 			updateHeight();
 			window.addEventListener('resize', updateHeight);
 		}
 
 		return () => {
+			drawerGesture.setDismissCallback(null);
 			window.removeEventListener('keydown', handleKeydown);
 			if (updateHeight) {
 				window.removeEventListener('resize', updateHeight);
@@ -250,172 +181,6 @@
 
 	$: if (drawerView === 'boost' && merchant) {
 		ensureBoostData(merchant, $boost);
-	}
-
-	// Pointer event handlers for dragging
-	function handlePointerDown(event: PointerEvent) {
-		if (activePointerId !== null) return;
-
-		activePointerId = event.pointerId;
-		isDragging = true;
-		startY = event.clientY;
-		initialHeight = $drawerHeight;
-		lastY = event.clientY;
-		lastTime = Date.now();
-		velocitySamples = [];
-		velocity = 0;
-
-		const target = event.currentTarget as HTMLElement;
-		if (target) {
-			try {
-				target.setPointerCapture(event.pointerId);
-				capturedElement = target;
-			} catch {
-				// Pointer capture not supported or failed
-			}
-		}
-	}
-
-	function handlePointerMove(event: PointerEvent) {
-		if (event.pointerId !== activePointerId || !isDragging) return;
-
-		const currentY = event.clientY;
-		updateVelocityTracking(currentY, Date.now());
-
-		// Calculate new height - 1:1 tracking with finger
-		// Allow going below PEEK_HEIGHT when in peek state for dismiss gesture
-		const deltaY = startY - currentY;
-		const minHeight = expanded ? PEEK_HEIGHT : 0;
-		const newHeight = Math.max(minHeight, Math.min(EXPANDED_HEIGHT, initialHeight + deltaY));
-
-		drawerHeight.set(newHeight, { hard: true });
-	}
-
-	function handlePointerUp(event: PointerEvent) {
-		if (event.pointerId !== activePointerId) return;
-
-		const finalHeight = $drawerHeight;
-		const totalDelta = finalHeight - initialHeight;
-
-		// Release pointer capture safely
-		if (capturedElement) {
-			try {
-				capturedElement.releasePointerCapture(event.pointerId);
-			} catch {
-				// Already released or invalid
-			}
-		}
-		capturedElement = null;
-		activePointerId = null;
-		isDragging = false;
-
-		// Check for dismiss gesture when in peek state
-		const shouldDismiss =
-			!expanded &&
-			(velocity < -VELOCITY_THRESHOLD || finalHeight < PEEK_HEIGHT - DISMISS_THRESHOLD);
-
-		if (shouldDismiss) {
-			closeDrawer();
-		} else {
-			// Determine snap state using helper function
-			const snapState = determineSnapState(velocity, totalDelta, finalHeight, EXPANDED_HEIGHT);
-			expanded = snapState.expanded;
-			drawerHeight.set(snapState.height);
-		}
-
-		// Reset velocity
-		velocity = 0;
-		velocitySamples = [];
-	}
-
-	function handlePointerCancel(event: PointerEvent) {
-		if (event.pointerId !== activePointerId) return;
-
-		capturedElement = null;
-		activePointerId = null;
-		isDragging = false;
-
-		// Snap back to previous state
-		if (expanded) {
-			drawerHeight.set(EXPANDED_HEIGHT);
-		} else {
-			drawerHeight.set(PEEK_HEIGHT);
-		}
-	}
-
-	// Touch-based handlers for expanded content area (Google Maps style)
-	// Using touch events gives us control to preventDefault() and stop native scroll
-	function handleContentTouchStart(event: TouchEvent) {
-		if (!expanded || event.touches.length !== 1) return;
-		touchStartY = event.touches[0].clientY;
-		isInCollapseDrag = false;
-	}
-
-	function handleContentTouchMove(event: TouchEvent) {
-		if (!expanded || touchStartY === null || event.touches.length !== 1) return;
-
-		const touch = event.touches[0];
-		const scrollTop = contentScrollElement?.scrollTop ?? 0;
-		const deltaY = touch.clientY - touchStartY;
-
-		// At scroll top AND dragging down → enter collapse drag mode
-		if (scrollTop <= SCROLL_TOP_THRESHOLD && deltaY > SCROLL_DRAG_THRESHOLD) {
-			// Prevent native scroll/pull-to-refresh
-			event.preventDefault();
-
-			if (!isInCollapseDrag) {
-				// Initialize drag state
-				isInCollapseDrag = true;
-				isDragging = true;
-				startY = touch.clientY;
-				touchStartY = touch.clientY; // Sync to prevent height jump
-				initialHeight = $drawerHeight;
-				lastY = touch.clientY;
-				lastTime = Date.now();
-				velocitySamples = [];
-				velocity = 0;
-			} else {
-				// Continue drag - update velocity and height
-				const currentY = touch.clientY;
-				updateVelocityTracking(currentY, Date.now());
-
-				// Calculate new height
-				const dragDelta = startY - currentY;
-				const newHeight = Math.max(
-					PEEK_HEIGHT,
-					Math.min(EXPANDED_HEIGHT, initialHeight + dragDelta)
-				);
-				drawerHeight.set(newHeight, { hard: true });
-			}
-		} else if (isInCollapseDrag && scrollTop > SCROLL_TOP_THRESHOLD) {
-			// User scrolled back up during collapse drag - cancel it
-			isInCollapseDrag = false;
-			isDragging = false;
-			velocity = 0;
-			velocitySamples = [];
-			drawerHeight.set(EXPANDED_HEIGHT);
-		}
-	}
-
-	function handleContentTouchEnd() {
-		if (isInCollapseDrag) {
-			// Determine snap state
-			const finalHeight = $drawerHeight;
-			const totalDelta = finalHeight - initialHeight;
-			const snapState = determineSnapState(velocity, totalDelta, finalHeight, EXPANDED_HEIGHT);
-			expanded = snapState.expanded;
-			drawerHeight.set(snapState.height);
-
-			// Reset all shared state to prevent corruption with pointer handlers
-			isDragging = false;
-			velocity = 0;
-			velocitySamples = [];
-			activePointerId = null;
-			lastY = 0;
-			lastTime = 0;
-		}
-		touchStartY = null;
-		isInCollapseDrag = false;
 	}
 
 	export function openDrawer(id: number) {
@@ -430,26 +195,26 @@
 	<div
 		bind:this={drawerElement}
 		class="fixed right-0 bottom-0 left-0 z-[1002] flex flex-col bg-white shadow-2xl transition-shadow dark:bg-dark"
-		class:rounded-t-[10px]={!expanded}
+		class:rounded-t-[10px]={!$expanded}
 		style="height: {$drawerHeight}px; will-change: height;"
 		on:click|stopPropagation
 		on:focusout={handleFocusOut}
 		role="dialog"
-		aria-modal={expanded}
+		aria-modal="true"
 		aria-label="Merchant details"
 	>
 		<!-- Drag handle and header area -->
 		<div
 			class="flex-shrink-0 touch-none"
 			bind:this={handleElement}
-			on:pointerdown={handlePointerDown}
-			on:pointermove={handlePointerMove}
-			on:pointerup={handlePointerUp}
-			on:pointercancel={handlePointerCancel}
+			on:pointerdown={onPointerDown}
+			on:pointermove={drawerGesture.handlePointerMove}
+			on:pointerup={onPointerUp}
+			on:pointercancel={drawerGesture.handlePointerCancel}
 			tabindex="0"
 			role="button"
-			aria-label={expanded ? 'Collapse drawer' : 'Expand drawer'}
-			aria-expanded={expanded}
+			aria-label={$expanded ? 'Collapse drawer' : 'Expand drawer'}
+			aria-expanded={$expanded}
 			aria-controls="drawer-content"
 		>
 			<!-- Drag handle -->
@@ -474,12 +239,9 @@
 					>
 				{/if}
 
-				{#if expanded && drawerView === 'details'}
+				{#if $expanded && drawerView === 'details'}
 					<button
-						on:click={() => {
-							expanded = false;
-							drawerHeight.set(PEEK_HEIGHT);
-						}}
+						on:click={drawerGesture.collapse}
 						class="rounded-full p-2 text-primary transition-colors hover:bg-gray-100 dark:text-white dark:hover:bg-white/10"
 						aria-label="Collapse drawer"
 					>
@@ -496,11 +258,11 @@
 			id="drawer-content"
 			bind:this={contentScrollElement}
 			class="min-h-0 flex-1 overflow-y-auto"
-			style="overscroll-behavior-y: contain;"
-			on:touchstart={handleContentTouchStart}
-			on:touchmove={handleContentTouchMove}
-			on:touchend={handleContentTouchEnd}
-			on:touchcancel={handleContentTouchEnd}
+			style="overscroll-behavior-y: contain; touch-action: pan-y;"
+			on:touchstart={drawerGesture.handleContentTouchStart}
+			on:touchmove={onContentTouchMove}
+			on:touchend={drawerGesture.handleContentTouchEnd}
+			on:touchcancel={drawerGesture.handleContentTouchEnd}
 		>
 			{#if !merchant && fetchingMerchant}
 				<div class="space-y-4 px-4 pt-2 pb-4">
@@ -512,14 +274,14 @@
 					</div>
 				</div>
 			{:else if merchant}
-				{#if !expanded}
+				{#if !$expanded}
 					<!-- Peek content wrapper with swipe handlers - allows swiping from anywhere when collapsed -->
 					<div
 						class="touch-none px-4 pt-2 pb-4"
-						on:pointerdown={handlePointerDown}
-						on:pointermove={handlePointerMove}
-						on:pointerup={handlePointerUp}
-						on:pointercancel={handlePointerCancel}
+						on:pointerdown={onPointerDown}
+						on:pointermove={drawerGesture.handlePointerMove}
+						on:pointerup={onPointerUp}
+						on:pointercancel={drawerGesture.handlePointerCancel}
 					>
 						<MerchantPeekContentMobile
 							{merchant}


### PR DESCRIPTION
Fixes: #549

Allow users to swipe down from anywhere in the expanded merchant drawer (not just the handle) to collapse to peek view. Uses scroll-aware gesture detection: only initiates collapse when content is scrolled to top and user drags downward, preserving normal scroll behavior otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
