### PR TITLE
fix(home): add labels to buttons and links for better a11y

### DIFF
--- a/src/components/SocialLink.svelte
+++ b/src/components/SocialLink.svelte
@@ -18,7 +18,7 @@
 	href={url}
 	target="_blank"
 	rel="noreferrer"
-	aria-label={socialLabels[social] || social}
+	aria-label={`Visit us on ${socialLabels[social] || social}`}
 	class="inline-block rounded-full bg-link p-2 text-white transition-colors hover:bg-hover dark:bg-white/[0.15] dark:hover:bg-link"
 >
 	<!-- eslint-enable svelte/no-navigation-without-resolve -->

--- a/src/components/ThemeToggle.svelte
+++ b/src/components/ThemeToggle.svelte
@@ -28,8 +28,16 @@
 <button
 	on:click={toggleTheme}
 	disabled={!currentTheme}
-	aria-label={currentTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
-	title={currentTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+	aria-label={!currentTheme
+		? 'Theme toggle loading'
+		: currentTheme === 'dark'
+			? 'Switch to light mode'
+			: 'Switch to dark mode'}
+	title={!currentTheme
+		? 'Theme toggle loading'
+		: currentTheme === 'dark'
+			? 'Switch to light mode'
+			: 'Switch to dark mode'}
 	class="h-10 w-10 text-link transition-colors hover:text-hover dark:text-white dark:hover:text-link"
 >
 	{#if currentTheme === 'dark'}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -61,7 +61,7 @@
 								href={app.link}
 								target={app.type === 'Web' ? null : '_blank'}
 								rel={app.type === 'Web' ? null : 'noreferrer'}
-								aria-label={`Download for ${app.type}`}
+								aria-label={app.type === 'Web' ? 'Open web app' : `Download for ${app.type}`}
 								class="block rounded-full bg-link p-3 text-white transition-colors hover:bg-hover"
 							>
 								<!-- eslint-enable svelte/no-navigation-without-resolve -->


### PR DESCRIPTION
Add aria-label attributes to icon-only elements for screen reader support:
- Social links: Matrix, GitHub, Amboss, Nostr, X
- Theme toggle: dynamic label based on current mode, plus title tooltip
- App download links: Web, F-Droid, APK, iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
