### PR TITLE
fix(lint): rename style prop to class in Icon and Tip components #235

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,7 +43,6 @@ export default tseslint.config(
 			}
 		},
 		rules: {
-			'svelte/no-dupe-style-properties': 'warn', // mainly because of tailwind (v4 will fix this)
 			'svelte/no-unused-svelte-ignore': 'off', // These are used by vite-plugin-svelte/svelte-check, not ESLint
 			'@typescript-eslint/no-unused-expressions': 'warn',
 			'@typescript-eslint/no-unused-vars': [

--- a/src/components/BoostButton.svelte
+++ b/src/components/BoostButton.svelte
@@ -41,7 +41,7 @@
 			? 'hover:bg-bitcoinHover bg-bitcoin'
 			: 'bg-link hover:bg-hover'} mx-auto flex w-40 items-center justify-center rounded-xl p-3 text-center font-semibold text-white transition-colors"
 	>
-		<Icon w="20" h="20" style="text-white mr-1" icon="arrow_circle_up" type="material" />
+		<Icon w="20" h="20" class="mr-1 text-white" icon="arrow_circle_up" type="material" />
 		{boostLoading ? 'Boosting...' : boosted ? 'Extend Boost' : 'Boost'}
 	</button>
 {:else}
@@ -51,7 +51,7 @@
 		disabled={boostLoading || Boolean($boost)}
 		class="inline-flex items-center space-x-1 font-semibold text-link transition-colors hover:text-hover"
 	>
-		<Icon w="16" h="16" icon="arrow_circle_up" style="shrink-0" type="material" />
+		<Icon w="16" h="16" icon="arrow_circle_up" class="shrink-0" type="material" />
 		<p class="text-sm">{boostLoading ? 'Boosting...' : boosted ? 'Extend Boost' : 'Boost'}</p>
 	</button>
 {/if}

--- a/src/components/BoostContent.svelte
+++ b/src/components/BoostContent.svelte
@@ -144,7 +144,7 @@
 						<Icon
 							w="20"
 							h="20"
-							style="animate-wiggle absolute top-3.5 left-[15px] text-white"
+							class="absolute top-3.5 left-[15px] animate-wiggle text-white"
 							icon="currency_bitcoin"
 							type="material"
 						/>
@@ -239,7 +239,7 @@
 			target="_blank"
 			rel="noreferrer"
 			class="mx-auto flex w-[200px] items-center justify-center rounded-xl bg-twitter py-3 text-white"
-			>Share on Twitter <Icon w="24" h="24" style="ml-2" icon="twitter" type="socials" /></a
+			>Share on Twitter <Icon w="24" h="24" class="ml-2" icon="twitter" type="socials" /></a
 		>
 
 		<p class="text-sm text-body dark:text-white">

--- a/src/components/Breadcrumbs.svelte
+++ b/src/components/Breadcrumbs.svelte
@@ -17,7 +17,7 @@
 			{route.name}
 		</a>
 		{#if index !== routes.length - 1}
-			<Icon type="fa" icon="chevron-right" w="8" h="8" style="text-link" />
+			<Icon type="fa" icon="chevron-right" w="8" h="8" class="text-link" />
 		{/if}
 	{/each}
 </div>

--- a/src/components/CloseButton.svelte
+++ b/src/components/CloseButton.svelte
@@ -8,6 +8,6 @@
 
 <div class={position}>
 	<button on:click type="button" aria-label="Close">
-		<Icon w="25" h="25" style="{colors} transition-colors" icon="close_round" />
+		<Icon w="25" h="25" class="{colors} transition-colors" icon="close_round" />
 	</button>
 </div>

--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -6,15 +6,16 @@
 	import type { IconName as IconNameMobileNav } from '$lib/spritesheet-mobile-nav.ts';
 
 	type IconProps =
-		| { type: 'material'; icon: string; w: string; h: string; style?: string }
-		| { type: 'fa'; icon: string; w: string; h: string; style?: string }
-		| { type: 'socials'; icon: IconNameSocials; w: string; h: string; style?: string }
-		| { type: 'apps'; icon: IconNameApps; w: string; h: string; style?: string }
-		| { type: 'mobile-nav'; icon: IconNameMobileNav; w: string; h: string; style?: string };
+		| { type: 'material'; icon: string; w: string; h: string; class?: string }
+		| { type: 'fa'; icon: string; w: string; h: string; class?: string }
+		| { type: 'socials'; icon: IconNameSocials; w: string; h: string; class?: string }
+		| { type: 'apps'; icon: IconNameApps; w: string; h: string; class?: string }
+		| { type: 'mobile-nav'; icon: IconNameMobileNav; w: string; h: string; class?: string };
 
 	export let w: string;
 	export let h: string;
-	export let style: undefined | string = undefined;
+	let className: undefined | string = undefined;
+	export { className as class };
 	export let icon: string | IconNameApps | IconNameMobileNav | IconNameSocials;
 	export let type: 'apps' | 'fa' | 'material' | 'mobile-nav' | 'socials' = 'material';
 
@@ -22,7 +23,7 @@
 	// Type assertion to make TypeScript happy
 	// we want to make sure that if the type is 'material', the icon can be any string
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const props = { type, icon, w, h, style } as IconProps;
+	const props = { type, icon, w, h, class: className } as IconProps;
 
 	$: formattedIconifyIcon =
 		type === 'material'
@@ -71,9 +72,9 @@
 </script>
 
 {#if type === 'material' || type === 'fa'}
-	<IconIconify icon={formattedIconifyIcon} width={w} height={h} class={style} />
+	<IconIconify icon={formattedIconifyIcon} width={w} height={h} class={className} />
 {:else}
-	<svg width="{w}px" height="{h}px" class={style}>
+	<svg width="{w}px" height="{h}px" class={className}>
 		<use width="{w}px" height="{h}px" href={`${spriteHref}#${icon}`} />
 	</svg>
 {/if}

--- a/src/components/InfoTooltip.svelte
+++ b/src/components/InfoTooltip.svelte
@@ -17,6 +17,6 @@
 		icon="circle-info"
 		w="16"
 		h="16"
-		style="text-base text-primary inline align-middle dark:text-white"
+		class="inline align-middle text-base text-primary dark:text-white"
 	/>
 </button>

--- a/src/components/IssuesTable.svelte
+++ b/src/components/IssuesTable.svelte
@@ -217,7 +217,7 @@
 				<div
 					class="flex h-[572px] w-full animate-pulse items-center justify-center rounded-3xl border border-link/50"
 				>
-					<Icon type="fa" icon="table" w="96" h="96" style="animate-pulse text-link/50" />
+					<Icon type="fa" icon="table" w="96" h="96" class="animate-pulse text-link/50" />
 				</div>
 			</div>
 		{:else if !issues.length}

--- a/src/components/LatestTagger.svelte
+++ b/src/components/LatestTagger.svelte
@@ -105,7 +105,7 @@
 
 		<!-- lightning tip button -->
 		{#if lightning}
-			<Tip destination={lightning} style="block lg:inline mx-auto lg:mx-0" />
+			<Tip destination={lightning} class="mx-auto block lg:mx-0 lg:inline" />
 		{/if}
 	</div>
 </div>

--- a/src/components/MerchantDetailsContent.svelte
+++ b/src/components/MerchantDetailsContent.svelte
@@ -40,7 +40,7 @@
 			<Icon
 				w="16"
 				h="16"
-				style="mt-1 shrink-0 text-primary dark:text-white"
+				class="mt-1 shrink-0 text-primary dark:text-white"
 				icon="schedule"
 				type="material"
 			/>
@@ -134,7 +134,7 @@
 						<Icon
 							w="16"
 							h="16"
-							style="inline text-primary dark:text-white"
+							class="inline text-primary dark:text-white"
 							icon="verified"
 							type="material"
 						/>
@@ -142,7 +142,7 @@
 						<Icon
 							w="16"
 							h="16"
-							style="inline text-primary dark:text-white"
+							class="inline text-primary dark:text-white"
 							icon="error_outline"
 							type="material"
 						/>

--- a/src/components/OpenTicket.svelte
+++ b/src/components/OpenTicket.svelte
@@ -18,7 +18,7 @@
 	class="border-t-statBorder w-full items-center justify-between space-y-1 border-t p-5 text-center md:flex md:space-y-0 md:text-left"
 >
 	<div class="items-center space-y-1 md:flex md:space-y-0 md:space-x-2">
-		<Icon type="fa" icon="ticket" w="20" h="20" style="text-xl text-link" />
+		<Icon type="fa" icon="ticket" w="20" h="20" class="text-xl text-link" />
 
 		<div>
 			<p>
@@ -74,7 +74,7 @@
 		</div>
 
 		<div class="items-center md:flex">
-			<Icon type="fa" icon="comment" w="16" h="16" style="text-link md:mr-1" />
+			<Icon type="fa" icon="comment" w="16" h="16" class="text-link md:mr-1" />
 			<strong class="text-primary dark:text-white">{comments}</strong>
 		</div>
 	</div>

--- a/src/components/ProfileStat.svelte
+++ b/src/components/ProfileStat.svelte
@@ -22,7 +22,7 @@
 		{title}
 		{#if tooltip}
 			<button bind:this={tooltipElement}>
-				<Icon type="fa" icon="circle-info" w="16" h="16" style="text-base" />
+				<Icon type="fa" icon="circle-info" w="16" h="16" class="text-base" />
 			</button>
 		{/if}
 	</h3>

--- a/src/components/Socials.svelte
+++ b/src/components/Socials.svelte
@@ -28,28 +28,28 @@
 		<!-- eslint-disable svelte/no-navigation-without-resolve -->
 		<a href={website} target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-bitcoin">
-				<Icon type="fa" icon="globe" w="28" h="28" style="text-white" />
+				<Icon type="fa" icon="globe" w="28" h="28" class="text-white" />
 			</span>
 		</a>
 	{/if}
 	{#if email}
 		<a href="mailto:{email}" target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-[#53C5D5]">
-				<Icon type="fa" icon="envelope" w="28" h="28" style="text-white" />
+				<Icon type="fa" icon="envelope" w="28" h="28" class="text-white" />
 			</span>
 		</a>
 	{/if}
 	{#if nostr}
 		<a href="https://nostr.com/{nostr}" target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-nostr">
-				<Icon w="28" h="28" icon="nostr" type="socials" style="text-white" />
+				<Icon w="28" h="28" icon="nostr" type="socials" class="text-white" />
 			</span>
 		</a>
 	{/if}
 	{#if twitter}
 		<a href={twitter} target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-black">
-				<Icon w="25" h="25" icon="x" type="socials" style="text-white" />
+				<Icon w="25" h="25" icon="x" type="socials" class="text-white" />
 			</span>
 		</a>
 	{/if}
@@ -111,7 +111,7 @@
 	{#if rss}
 		<a href={rss} target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-orange-500">
-				<Icon type="fa" icon="rss" w="28" h="28" style="text-white" />
+				<Icon type="fa" icon="rss" w="28" h="28" class="text-white" />
 			</span>
 		</a>
 	{/if}

--- a/src/components/Tip.svelte
+++ b/src/components/Tip.svelte
@@ -3,7 +3,8 @@
 
 	export let user: undefined | string = undefined;
 	export let destination: string;
-	export let style: undefined | string = undefined;
+	let className: undefined | string = undefined;
+	export { className as class };
 	export let type: TipType = TipType.Address;
 </script>
 
@@ -43,7 +44,7 @@
 		href={type === 'url' ? destination : `lightning:${destination}`}
 		target={type === 'url' ? '_blank' : null}
 		rel={type === 'url' ? 'noreferrer' : null}
-		class="w-full rounded-lg border border-link py-2 text-center text-sm font-semibold text-link hover:border-white hover:bg-link hover:text-white md:w-20 md:py-1 {style} transition-colors"
+		class="w-full rounded-lg border border-link py-2 text-center text-sm font-semibold text-link hover:border-white hover:bg-link hover:text-white md:w-20 md:py-1 {className} transition-colors"
 	>
 		<!-- eslint-enable svelte/no-navigation-without-resolve -->
 		<!--  lightning icon -->

--- a/src/components/area/AreaActivity.svelte
+++ b/src/components/area/AreaActivity.svelte
@@ -163,7 +163,7 @@
 				>
 					New Places
 				</a>
-				<Icon type="fa" icon="location-pin" w="18" h="18" style="ml-1 inline align-middle" />
+				<Icon type="fa" icon="location-pin" w="18" h="18" class="ml-1 inline align-middle" />
 			</li>
 			<li>
 				<a
@@ -174,7 +174,7 @@
 				>
 					New Comments
 				</a>
-				<Icon type="fa" icon="comment" w="18" h="18" style="ml-1 inline align-middle" />
+				<Icon type="fa" icon="comment" w="18" h="18" class="ml-1 inline align-middle" />
 			</li>
 		</ul>
 	</div>

--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -221,19 +221,19 @@
 
 				<div class="flex items-center space-x-1">
 					{#each Array(5 - grade) as _, index (index)}
-						<Icon type="fa" icon="star" w="16" h="16" style="opacity-25" />
+						<Icon type="fa" icon="star" w="16" h="16" class="opacity-25" />
 					{/each}
 				</div>
 			{:else}
 				<div class="flex items-center space-x-1">
 					{#each Array(5) as _, index (index)}
-						<Icon type="fa" icon="star" w="16" h="16" style="animate-pulse text-link/50" />
+						<Icon type="fa" icon="star" w="16" h="16" class="animate-pulse text-link/50" />
 					{/each}
 				</div>
 			{/if}
 
 			<button bind:this={gradeTooltip}>
-				<Icon type="fa" icon="circle-info" w="14" h="14" style="text-sm" />
+				<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 			</button>
 		</div>
 	</h3>

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -469,7 +469,7 @@
 			<div
 				class="absolute top-0 right-0 flex h-8 w-8 items-center justify-center rounded-full bg-[#cce3e6] sm:hidden"
 			>
-				<Icon type="fa" icon="chevron-right" w="16" h="16" style="text-link" />
+				<Icon type="fa" icon="chevron-right" w="16" h="16" class="text-link" />
 			</div>
 		{/if}
 	</div>

--- a/src/components/area/AreaStats.svelte
+++ b/src/components/area/AreaStats.svelte
@@ -373,7 +373,7 @@
 					icon="chart-pie"
 					w="208"
 					h="208"
-					style="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 animate-pulse text-link/50"
+					class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 animate-pulse text-link/50"
 				/>
 			</div>
 		{/if}
@@ -396,7 +396,7 @@
 					<div
 						class="absolute top-0 left-0 flex h-[400px] w-full animate-pulse items-center justify-center rounded-3xl border border-link/50"
 					>
-						<Icon type="fa" icon="chart-area" w="96" h="96" style="animate-pulse text-link/50" />
+						<Icon type="fa" icon="chart-area" w="96" h="96" class="animate-pulse text-link/50" />
 					</div>
 				{/if}
 				<canvas bind:this={totalChartCanvas} width="100%" height="400" />
@@ -412,7 +412,7 @@
 					<div
 						class="absolute top-0 left-0 flex h-[400px] w-full animate-pulse items-center justify-center rounded-3xl border border-link/50"
 					>
-						<Icon type="fa" icon="chart-area" w="96" h="96" style="animate-pulse text-link/50" />
+						<Icon type="fa" icon="chart-area" w="96" h="96" class="animate-pulse text-link/50" />
 					</div>
 				{/if}
 				<canvas bind:this={upToDateChartCanvas} width="100%" height="400" />

--- a/src/components/area/MerchantCard.svelte
+++ b/src/components/area/MerchantCard.svelte
@@ -90,7 +90,7 @@
 					h="24"
 					icon={icon !== 'question_mark' ? icon : 'currency_bitcoin'}
 					type="material"
-					style="shrink-0"
+					class="shrink-0"
 				/>
 				<p class="text-lg break-all">{displayMerchant.name || 'BTC Map Merchant'}</p>
 			</a>
@@ -99,7 +99,7 @@
 		<div class="mb-3 w-full space-y-2 break-all text-primary dark:text-white">
 			{#if address}
 				<div class="flex items-center space-x-2 font-medium">
-					<Icon w="16" h="16" icon="location_on" type="material" style="shrink-0" />
+					<Icon w="16" h="16" icon="location_on" type="material" class="shrink-0" />
 					<a
 						href="geo:{merchant.lat},{merchant.lon}"
 						class="text-sm underline decoration-primary decoration-1 underline-offset-4 dark:decoration-white"
@@ -111,7 +111,7 @@
 
 			{#if website}
 				<div class="flex items-center space-x-2">
-					<Icon w="16" h="16" icon="language" type="material" style="shrink-0" />
+					<Icon w="16" h="16" icon="language" type="material" class="shrink-0" />
 					<!-- eslint-disable svelte/no-navigation-without-resolve -->
 					<a
 						href={website.startsWith('http') ? website : `https://${website}`}
@@ -127,7 +127,7 @@
 
 			{#if openingHours}
 				<div class="flex items-center space-x-2">
-					<Icon w="16" h="16" icon="schedule" type="material" style="shrink-0" />
+					<Icon w="16" h="16" icon="schedule" type="material" class="shrink-0" />
 					<div class="text-sm">
 						<time class="flex flex-col items-start">
 							<!-- eslint-disable-next-line svelte/no-at-html-tags - we sanitize the content in formatOpeningHours -->
@@ -139,7 +139,7 @@
 
 			{#if phone}
 				<div class="flex items-center space-x-2">
-					<Icon w="16" h="16" icon="phone" type="material" style="shrink-0" />
+					<Icon w="16" h="16" icon="phone" type="material" class="shrink-0" />
 					<a
 						href="tel:{phone}"
 						class="text-sm underline decoration-primary decoration-1 underline-offset-4 dark:decoration-white"
@@ -151,7 +151,7 @@
 
 			{#if email}
 				<div class="flex items-center space-x-2">
-					<Icon w="16" h="16" icon="email" type="material" style="shrink-0" />
+					<Icon w="16" h="16" icon="email" type="material" class="shrink-0" />
 					<a
 						href="mailto:{email}"
 						class="text-sm underline decoration-primary decoration-1 underline-offset-4 dark:decoration-white"
@@ -213,13 +213,13 @@
 
 				{#if !(Date.parse(verified[0]) > verifiedDate)}
 					<div bind:this={outdatedTooltip} class="text-primary dark:text-white">
-						<Icon w="16" h="16" icon="error_outline" type="material" style="shrink-0" />
+						<Icon w="16" h="16" icon="error_outline" type="material" class="shrink-0" />
 					</div>
 				{/if}
 			</div>
 		{:else}
 			<div class="flex items-center space-x-1 text-gray-500 dark:text-gray-400">
-				<Icon w="16" h="16" icon="sentiment_dissatisfied" type="material" style="shrink-0" />
+				<Icon w="16" h="16" icon="sentiment_dissatisfied" type="material" class="shrink-0" />
 				<p class="text-sm font-semibold">Not Verified</p>
 			</div>
 		{/if}
@@ -240,7 +240,7 @@
 				class="inline-flex items-center space-x-1 font-semibold text-link transition-colors hover:text-hover"
 				title="Help improve the data for everyone"
 			>
-				<Icon w="16" h="16" icon="verified" type="material" style="shrink-0" />
+				<Icon w="16" h="16" icon="verified" type="material" class="shrink-0" />
 				<p class="text-sm">Verify</p>
 			</a>
 

--- a/src/components/layout/Header.svelte
+++ b/src/components/layout/Header.svelte
@@ -124,7 +124,7 @@
 			<Icon
 				w={showMobileMenu ? '28' : '34'}
 				h={showMobileMenu ? '27' : '12'}
-				style="mx-auto mb-3 text-mobileMenu dark:text-white"
+				class="text-mobileMenu mx-auto mb-3 dark:text-white"
 				icon={showMobileMenu ? 'close' : 'bars'}
 				type="mobile-nav"
 			/>

--- a/src/components/layout/NavDropdownDesktop.svelte
+++ b/src/components/layout/NavDropdownDesktop.svelte
@@ -21,7 +21,7 @@
 			: ''} mt-4 mr-4 flex items-center text-xl font-semibold text-link transition-colors hover:text-hover md:mt-0 md:mr-0 dark:text-white dark:hover:text-link"
 	>
 		{title}
-		<Icon type="fa" icon="chevron-down" w="16" h="16" style="ml-1" />
+		<Icon type="fa" icon="chevron-down" w="16" h="16" class="ml-1" />
 	</button>
 
 	<!-- dropdown items -->
@@ -47,7 +47,7 @@
 						<!-- eslint-enable svelte/no-navigation-without-resolve -->
 						{link.title}
 						{#if link.external}
-							<Icon type="fa" icon="arrow-up-right-from-square" w="16" h="16" style="ml-1" />
+							<Icon type="fa" icon="arrow-up-right-from-square" w="16" h="16" class="ml-1" />
 						{/if}
 					</a>
 				{/each}

--- a/src/components/layout/NavDropdownMobile.svelte
+++ b/src/components/layout/NavDropdownMobile.svelte
@@ -47,7 +47,7 @@
 					</span>
 					<span>{link.title}</span>
 					{#if link.external}
-						<Icon type="fa" icon="arrow-up-right-from-square" w="16" h="16" style="ml-1" />
+						<Icon type="fa" icon="arrow-up-right-from-square" w="16" h="16" class="ml-1" />
 					{/if}
 				</a>
 			{/each}

--- a/src/components/leaderboard/AreaLeaderboard.svelte
+++ b/src/components/leaderboard/AreaLeaderboard.svelte
@@ -340,7 +340,7 @@
 					role="status"
 					aria-live="polite"
 				>
-					<Icon type="fa" icon="table" w="96" h="96" style="animate-pulse text-link/50" />
+					<Icon type="fa" icon="table" w="96" h="96" class="animate-pulse text-link/50" />
 				</div>
 			</div>
 		{:else if $leaderboardWithPositions.length === 0}

--- a/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
+++ b/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
@@ -68,7 +68,7 @@
 											class="ml-1 cursor-default"
 											aria-label="Information about total locations"
 										>
-											<Icon type="fa" icon="circle-info" w="14" h="14" style="text-sm" />
+											<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 										</button>
 									{:else if header.column.id === 'upToDateElements'}
 										<button
@@ -77,7 +77,7 @@
 											class="ml-1 cursor-default"
 											aria-label="Information about verified locations"
 										>
-											<Icon type="fa" icon="circle-info" w="14" h="14" style="text-sm" />
+											<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 										</button>
 									{:else if header.column.id === 'grade'}
 										<button
@@ -86,7 +86,7 @@
 											class="ml-1 cursor-default"
 											aria-label="Information about Grade metric"
 										>
-											<Icon type="fa" icon="circle-info" w="14" h="14" style="text-sm" />
+											<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 										</button>
 									{/if}
 									{#if header.column.getIsSorted().toString() === 'asc'}

--- a/src/lib/map/setup.ts
+++ b/src/lib/map/setup.ts
@@ -612,7 +612,7 @@ export const generateIcon = (L: Leaflet, icon: string, boosted: boolean, comment
 		props: {
 			w: '20',
 			h: '20',
-			style: `${className} mt-[5.75px] text-white`,
+			class: `${className} mt-[5.75px] text-white`,
 			icon: iconTmp,
 			type: 'material'
 		}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -32,7 +32,7 @@
 			<a
 				href={resolve('/')}
 				class="text-xl font-semibold text-link transition-colors hover:text-hover"
-				><Icon type="fa" icon="house" w="16" h="16" style="mr-2 inline" /> Home</a
+				><Icon type="fa" icon="house" w="16" h="16" class="mr-2 inline" /> Home</a
 			>
 			<h1 class="text-4xl md:text-5xl dark:text-white">{$page.status}: {$page.error?.message}</h1>
 			<h2 class="text-xl font-semibold text-primary dark:text-white">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -68,7 +68,7 @@
 								<Icon
 									w="32"
 									h="32"
-									style={app.icon === 'play' ? 'pl-0.5' : ''}
+									class={app.icon === 'play' ? 'pl-0.5' : ''}
 									icon={app.icon}
 									type="apps"
 								/>

--- a/src/routes/about-us/components/AboutMerchant.svelte
+++ b/src/routes/about-us/components/AboutMerchant.svelte
@@ -25,7 +25,7 @@
 	<Icon
 		w="40"
 		h="40"
-		style="text-white"
+		class="text-white"
 		icon={icon !== 'question_mark' ? icon : 'currency_bitcoin'}
 		type="material"
 	/>

--- a/src/routes/about-us/components/AboutPlus.svelte
+++ b/src/routes/about-us/components/AboutPlus.svelte
@@ -4,7 +4,7 @@
 
 <div class="space-y-2">
 	<div class="mx-auto flex h-24 w-24 items-center justify-center rounded-full bg-link">
-		<Icon type="fa" icon="circle-plus" w="40" h="40" style="text-white" />
+		<Icon type="fa" icon="circle-plus" w="40" h="40" class="text-white" />
 	</div>
 
 	<p class="text-center font-semibold">More!</p>

--- a/src/routes/communities/[section]/components/CommunityCard.svelte
+++ b/src/routes/communities/[section]/components/CommunityCard.svelte
@@ -66,7 +66,7 @@
 			<SponsorBadge />
 		{/if}
 		{#if tip}
-			<Tip destination={tip.destination} type={tip.type} style="mx-auto block" />
+			<Tip destination={tip.destination} type={tip.type} class="mx-auto block" />
 		{/if}
 	</div>
 

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -99,7 +99,7 @@
 									href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Lightning-Tips"
 									target="_blank"
 									rel="noreferrer"
-									><Icon type="fa" icon="circle-info" w="14" h="14" style="text-sm inline" /></a
+									><Icon type="fa" icon="circle-info" w="14" h="14" class="inline text-sm" /></a
 								>
 							{/if}
 						</h3>

--- a/src/routes/leaderboard/components/LeaderboardItem.svelte
+++ b/src/routes/leaderboard/components/LeaderboardItem.svelte
@@ -71,6 +71,6 @@
 	{/each}
 
 	{#if lightning}
-		<Tip destination={lightning} style="mx-auto lg:!my-auto lg:h-[30px] block lg:inline" />
+		<Tip destination={lightning} class="mx-auto block lg:!my-auto lg:inline lg:h-[30px]" />
 	{/if}
 </div>

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1170,7 +1170,7 @@
 				aria-label="Open merchant list"
 				aria-expanded={$merchantList.isOpen}
 			>
-				<Icon w="18" h="18" icon="menu" type="material" style="text-primary dark:text-white" />
+				<Icon w="18" h="18" icon="menu" type="material" class="text-primary dark:text-white" />
 				{#if currentZoom >= MERCHANT_LIST_LOW_ZOOM && $merchantList.isLoadingList}
 					<LoadingSpinner size="h-4 w-4" color="text-primary dark:text-white" />
 					<span class="text-primary dark:text-white">Nearby</span>

--- a/src/routes/map/components/MerchantListItem.svelte
+++ b/src/routes/map/components/MerchantListItem.svelte
@@ -62,7 +62,7 @@
 							{enrichedData.name}
 						</span>
 						{#if isVerified}
-							<Icon w="12" h="12" icon="verified" type="material" style="shrink-0 text-link" />
+							<Icon w="12" h="12" icon="verified" type="material" class="shrink-0 text-link" />
 						{/if}
 						{#if isBoosted}
 							<Icon
@@ -70,7 +70,7 @@
 								h="12"
 								icon="arrow_circle_up"
 								type="material"
-								style="shrink-0 text-bitcoin"
+								class="shrink-0 text-bitcoin"
 							/>
 						{/if}
 					{:else if showSkeleton}
@@ -150,7 +150,7 @@
 				h="16"
 				icon="chevron_right"
 				type="material"
-				style="mt-0.5 shrink-0 text-gray-400 dark:text-white/40"
+				class="mt-0.5 shrink-0 text-gray-400 dark:text-white/40"
 			/>
 		</div>
 	</button>

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -200,7 +200,7 @@
 							h="16"
 							icon="search"
 							type="material"
-							style="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-white/50 pointer-events-none"
+							class="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-gray-400 dark:text-white/50"
 						/>
 						<input
 							bind:this={searchInput}
@@ -314,7 +314,7 @@
 							h="48"
 							icon="search"
 							type="material"
-							style="text-gray-300 dark:text-white/30"
+							class="text-gray-300 dark:text-white/30"
 						/>
 						<p class="text-sm text-body dark:text-white/70">Search for merchants by name</p>
 					</div>
@@ -341,7 +341,7 @@
 						h="48"
 						icon="zoom_in"
 						type="material"
-						style="text-gray-300 dark:text-white/30"
+						class="text-gray-300 dark:text-white/30"
 					/>
 					<div>
 						<p class="text-sm font-medium text-primary dark:text-white">

--- a/src/routes/map/components/MerchantPeekContentMobile.svelte
+++ b/src/routes/map/components/MerchantPeekContentMobile.svelte
@@ -36,7 +36,7 @@
 				class="flex-shrink-0 rounded-full bg-link px-2.5 py-1 text-xs font-semibold text-white"
 				title="Boosted merchant"
 			>
-				<Icon w="14" h="14" icon="bolt" type="material" style="inline mr-1" />
+				<Icon w="14" h="14" icon="bolt" type="material" class="mr-1 inline" />
 				Boosted
 			</div>
 		{/if}

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -393,7 +393,7 @@
 	{#if data.placeData.deleted_at}
 		<div class="bg-red-600 py-4 text-center text-white">
 			<p class="text-lg font-semibold">
-				<Icon w="20" h="20" style="inline-block text-white mr-2" icon="skull" type="material" />
+				<Icon w="20" h="20" class="mr-2 inline-block text-white" icon="skull" type="material" />
 				This merchant has been removed from BTC Map and may no longer accept Bitcoin.
 			</p>
 			<p class="mt-1 text-sm">The data shown below is outdated and for reference only.</p>
@@ -415,7 +415,7 @@
 							<Icon
 								w="60"
 								h="60"
-								style="text-white"
+								class="text-white"
 								icon={data.placeData.deleted_at
 									? 'skull'
 									: icon !== 'question_mark'
@@ -478,7 +478,7 @@
 								<Icon
 									w="16"
 									h="16"
-									style="text-primary dark:text-white inline-block"
+									class="inline-block text-primary dark:text-white"
 									icon="phone"
 									type="material"
 								/>
@@ -512,7 +512,7 @@
 											icon="mobile-screen-button"
 											w="32"
 											h="32"
-											style="text-primary transition-colors hover:text-link dark:text-white dark:hover:text-link"
+											class="text-primary transition-colors hover:text-link dark:text-white dark:hover:text-link"
 										/>
 									</a>
 								{:else if typeof window !== 'undefined'}
@@ -553,7 +553,7 @@
 								<Icon
 									w="16"
 									h="16"
-									style="text-primary dark:text-white inline"
+									class="inline text-primary dark:text-white"
 									icon="schedule"
 									type="material"
 								/>
@@ -692,7 +692,7 @@
 											<Icon
 												w="30"
 												h="30"
-												style="text-primary dark:text-white mr-2"
+												class="mr-2 text-primary dark:text-white"
 												icon="verified"
 												type="material"
 											/>
@@ -702,7 +702,7 @@
 											<Icon
 												w="30"
 												h="30"
-												style="text-primary dark:text-white mr-2"
+												class="mr-2 text-primary dark:text-white"
 												icon="error_outline"
 												type="material"
 											/>

--- a/src/routes/merchant/[id]/components/CommentAdd.svelte
+++ b/src/routes/merchant/[id]/components/CommentAdd.svelte
@@ -131,7 +131,7 @@
 					onStatusCheckError={handleStatusCheckError}
 				>
 					<p class="rounded-md border p-1 text-sm text-body dark:text-white">
-						<Icon w="16" h="16" icon="info" style="inline-block" />
+						<Icon w="16" h="16" icon="info" class="inline-block" />
 						Your comment will be published when our bots have confirmed the payment.
 					</p>
 

--- a/src/routes/merchant/[id]/components/MerchantButton.svelte
+++ b/src/routes/merchant/[id]/components/MerchantButton.svelte
@@ -19,7 +19,7 @@
 	class="flex h-20 min-w-24 items-center justify-center rounded-lg border border-primary py-1 !text-primary transition-colors hover:border-link hover:!text-link dark:border-white/95 dark:!text-white dark:hover:border-link dark:hover:!text-link"
 >
 	<div>
-		<Icon w="30" h="30" icon={materialIcon} type="material" style="mx-auto" />
+		<Icon w="30" h="30" icon={materialIcon} type="material" class="mx-auto" />
 		<span class="mt-1 block text-center text-xs font-semibold">{text}</span>
 	</div>
 </button>

--- a/src/routes/merchant/[id]/components/MerchantEvent.svelte
+++ b/src/routes/merchant/[id]/components/MerchantEvent.svelte
@@ -68,7 +68,7 @@
 
 		<!-- lightning tip button -->
 		{#if lightning}
-			<Tip destination={lightning} style="block lg:inline mx-auto lg:mx-0" />
+			<Tip destination={lightning} class="mx-auto block lg:mx-0 lg:inline" />
 		{/if}
 	</div>
 </div>

--- a/src/routes/merchant/[id]/components/MerchantLink.svelte
+++ b/src/routes/merchant/[id]/components/MerchantLink.svelte
@@ -39,7 +39,7 @@
 >
 	<!-- eslint-enable svelte/no-navigation-without-resolve -->
 	<div>
-		<Icon w="30" h="30" icon={resolvedIcon} type={isFaIcon ? 'fa' : 'material'} style="mx-auto" />
+		<Icon w="30" h="30" icon={resolvedIcon} type={isFaIcon ? 'fa' : 'material'} class="mx-auto" />
 		<span class="mt-1 block text-center text-xs font-semibold">{text}</span>
 	</div>
 </a>

--- a/src/routes/tagger/[id]/+page.svelte
+++ b/src/routes/tagger/[id]/+page.svelte
@@ -538,7 +538,7 @@
 								icon="chart-pie"
 								w="208"
 								h="208"
-								style="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 animate-pulse text-link/50"
+								class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 animate-pulse text-link/50"
 							/>
 						</div>
 					{/if}

--- a/src/routes/tickets/components/OpenTicketSkeleton.svelte
+++ b/src/routes/tickets/components/OpenTicketSkeleton.svelte
@@ -6,7 +6,7 @@
 	class="border-t-statBorder w-full items-center justify-between space-y-1 border-t p-5 text-center md:flex md:space-y-0 md:text-left"
 >
 	<div class="items-center space-y-1 md:flex md:space-y-0 md:space-x-2">
-		<Icon type="fa" icon="ticket" w="20" h="20" style="animate-pulse text-xl text-link/50" />
+		<Icon type="fa" icon="ticket" w="20" h="20" class="animate-pulse text-xl text-link/50" />
 
 		<div>
 			<span class="mr-1 inline-block h-6 w-32 animate-pulse rounded bg-link/50" />
@@ -22,6 +22,6 @@
 	</div>
 
 	<div>
-		<Icon type="fa" icon="comment" w="16" h="16" style="animate-pulse text-link/50" />
+		<Icon type="fa" icon="comment" w="16" h="16" class="animate-pulse text-link/50" />
 	</div>
 </div>


### PR DESCRIPTION
Renamed the `style` prop to `class` in Icon and Tip components to fix false positives from svelte/no-dupe-style-properties lint rule. The rule was incorrectly flagging Tailwind prefixes (lg:, dark:) as duplicate CSS properties when used in the style prop.

- Renamed style prop to class in Icon.svelte and Tip.svelte
- Updated all 53 component usages across the codebase
- Removed warn override in eslint.config.js (default is error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
