### PR TITLE
fix(map): close drawer on map click regardless of marker selection #235

### DIFF
--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -908,20 +908,12 @@
 
 			// Close drawer when clicking on map (not on markers)
 			map.on('click', () => {
-				if (selectedMarkerId) {
-					clearMarkerSelection(selectedMarkerId);
-					selectedMarkerId = null;
-
-					const hash = window.location.hash.substring(1);
-					const ampIndex = hash.indexOf('&');
-					const mapPart = ampIndex !== -1 ? hash.substring(0, ampIndex) : hash;
-
-					// Remove merchant parameter and reset hash to just map location
-					if (mapPart) {
-						window.location.hash = mapPart;
-					} else {
-						window.location.hash = '';
+				if ($merchantDrawer.isOpen) {
+					if (selectedMarkerId) {
+						clearMarkerSelection(selectedMarkerId);
+						selectedMarkerId = null;
 					}
+					merchantDrawer.close();
 				}
 			});
 


### PR DESCRIPTION
Previously the drawer only closed when clicking the map if selectedMarkerId was set. This failed when the drawer was opened via search panel or URL hash. Now checks $merchantDrawer.isOpen instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
