### PR TITLE
feat(map): add more map styles and switch dark-mode default

### DIFF
--- a/src/lib/map/setup.ts
+++ b/src/lib/map/setup.ts
@@ -119,10 +119,18 @@ export const layers = (leaflet: Leaflet, map: Map) => {
 		style: 'https://static.btcmap.org/map-styles/dark.json'
 	});
 
+	const cartoPositron = window.L.maplibreGL({
+		style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json'
+	});
+
+	const cartoDarkMatter = window.L.maplibreGL({
+		style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json'
+	});
+
 	let activeLayer;
 	if (theme === 'dark') {
-		openFreeMapDark.addTo(map);
-		activeLayer = openFreeMapDark;
+		cartoDarkMatter.addTo(map);
+		activeLayer = cartoDarkMatter;
 	} else {
 		openFreeMapLiberty.addTo(map);
 		activeLayer = openFreeMapLiberty;
@@ -131,6 +139,8 @@ export const layers = (leaflet: Leaflet, map: Map) => {
 	const baseMaps = {
 		'OpenFreeMap Liberty': openFreeMapLiberty,
 		'OpenFreeMap Dark': openFreeMapDark,
+		'Carto Positron': cartoPositron,
+		'Carto Dark Matter': cartoDarkMatter,
 		OpenStreetMap: osm
 	};
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -247,6 +247,8 @@ export type MapGroups = { [key: string]: LayerGroup | FeatureGroup.SubGroup };
 export type BaseMaps = {
 	'OpenFreeMap Liberty': MaplibreGL;
 	'OpenFreeMap Dark': MaplibreGL;
+	'Carto Positron': MaplibreGL;
+	'Carto Dark Matter': MaplibreGL;
 	OpenStreetMap: TileLayer;
 };
 


### PR DESCRIPTION
- Carto Positron light style
- Carto Dark Matter (new dark-mode default)
- ~https://openmaptiles.org/styles/#fiord-color (seems broken?)~


### PROD
<img width="185" height="108" alt="image" src="https://github.com/user-attachments/assets/649ca307-bb29-4650-8f89-67541be9334c" />

### PR

<img width="190" height="169" alt="image" src="https://github.com/user-attachments/assets/995b48c4-1b68-41c2-927c-d26e4d1b1400" />



### Further context

> 
>   License Summary
> 
>   | Component    | License              | FOSS?                     |
>   |--------------|----------------------|---------------------------|
>   | Style code   | BSD 3-Clause         | ✅ Yes                    |
>   | Design       | CC-BY 4.0            | ✅ Yes (with attribution) |
>   | Hosted tiles | Enterprise agreement | ❌ Unclear                |
> 
>   The Catch
> 
>   The LICENSE.md says the hosted tiles at basemaps.cartocdn.com technically require an "enterprise agreement" for access. However, in practice:
> 
>   - The tiles have been freely accessible without API keys for years
>   - Many open-source projects use them (including MapLibre docs)
>   - No enforcement has been observed for typical usage
> 
>   Attribution Required
> 
>   Must credit both:
>   - CARTO (link to carto.com)
>   - OpenMapTiles.org (link to openmaptiles.org)
> 
>   Safer Alternative?
> 
>   If you want fully FOSS with no ambiguity, the OpenMapTiles versions of https://github.com/openmaptiles/positron-gl-style and https://github.com/openmaptiles/dark-matter-gl-style are BSD-3-Clause - but they require hosting modified versions.
> 
>   Sources:
>   - https://github.com/CartoDB/basemap-styles