### PR TITLE
fix(map): use fixed positioning for Leaflet controls on mobile

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -157,4 +157,11 @@
 			filter: drop-shadow(0 0 6px #f7931a) drop-shadow(0 0 12px #f7931a);
 		}
 	}
+
+	/* Fix for Leaflet controls not visible on mobile Firefox/Brave */
+	/* Only apply to fullscreen map to avoid breaking embedded maps */
+	.map-fullscreen .leaflet-bottom {
+		position: fixed !important;
+		bottom: 0 !important;
+	}
 }

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1439,7 +1439,7 @@
 			</button>
 		{/if}
 
-		<div bind:this={mapElement} class="absolute inset-0 !bg-teal dark:!bg-dark" />
+		<div bind:this={mapElement} class="map-fullscreen absolute inset-0 !bg-teal dark:!bg-dark" />
 	</div>
 
 	<MerchantDrawerHash />


### PR DESCRIPTION
Change from absolute to fixed positioning so the scale and attribution controls stay visible above mobile browser UI (URL bar, navigation) on Firefox and Brave browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
