### PR TITLE
fix(ui): prevent comment modal closure on backdrop click #439

### DIFF
--- a/src/routes/merchant/[id]/components/CommentAdd.svelte
+++ b/src/routes/merchant/[id]/components/CommentAdd.svelte
@@ -36,6 +36,9 @@
 		$lastUpdatedPlaceId = undefined;
 	};
 
+	const handleOutClick = () => {
+		// Never close the modal on outside clicks to prevent accidental loss of progress
+	};
 	const generateInvoice = (event: SubmitEvent) => {
 		event.preventDefault();
 		if (!elementId || !commentValue.trim()) {
@@ -85,7 +88,7 @@
 </script>
 
 {#if open}
-	<OutClick excludeQuerySelectorAll="#boost-button" on:outclick={closeModal}>
+	<OutClick excludeQuerySelectorAll="#boost-button" on:outclick={handleOutClick}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
 			class="center-fixed z-[2000] max-h-[90vh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:w-[430px] dark:border-white/95 dark:bg-dark"


### PR DESCRIPTION
### **User description**
**Does this PR address a related issue?**
Fixes #439

**A description of the changes proposed in the pull request**
Prevents the "Add Comment" modal from closing when clicking the background overlay. This ensures users don't accidentally lose their typed comment.

I implemented this by applying the same pattern used in the `Boost` modal (using an empty `handleOutClick` handler), as suggested in the issue.

**Screenshots**
N/A


___

### **PR Type**
Bug fix


___

### **Description**
- Prevents comment modal from closing on backdrop click

- Adds empty `handleOutClick` handler to block unintended dismissals

- Protects user progress by preventing accidental modal closure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OutClick event"] -- "previously triggered" --> B["closeModal handler"]
  A -- "now triggers" --> C["handleOutClick handler"]
  C -- "does nothing" --> D["Modal stays open"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CommentAdd.svelte</strong><dd><code>Block backdrop clicks from closing comment modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/routes/merchant/[id]/components/CommentAdd.svelte

<ul><li>Added <code>handleOutClick</code> function that prevents modal closure on backdrop <br>clicks<br> <li> Changed <code>OutClick</code> component event binding from <code>closeModal</code> to <br><code>handleOutClick</code><br> <li> Preserves user input by blocking accidental modal dismissals</ul>


</details>


  </td>
  <td><a href="https://github.com/teambtcmap/btcmap.org/pull/620/files#diff-38c7f9b400dea7cf0325ea2d4ced17c1d267005e240ec89b8d9d72e26b411fd6">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

