### PR TITLE
feat(merchant): remove 'note' field from merchant view #264

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -118,7 +118,6 @@ export interface MerchantPageData {
 	icon?: string;
 	address?: string;
 	description?: string;
-	note?: string;
 	hours?: string;
 	payment?: PayMerchant;
 	boosted?: string;

--- a/src/routes/merchant/[id]/+page.server.ts
+++ b/src/routes/merchant/[id]/+page.server.ts
@@ -160,7 +160,6 @@ export const load: PageServerLoad<MerchantPageData> = async ({ params }) => {
 			icon,
 			address,
 			description: placeData.description,
-			note: placeData['osm:note'],
 			hours,
 			payment,
 			boosted,

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -101,7 +101,7 @@
 		icon = data.icon;
 		address = data.address;
 		description = data.description;
-		note = data.note;
+
 		hours = data.hours;
 		payment = data.payment;
 		phone = data.phone;
@@ -206,7 +206,7 @@
 	let icon: string | undefined;
 	let address: string | undefined;
 	let description: string | undefined;
-	let note: string | undefined;
+
 	let hours: string | undefined;
 	let payment: PayMerchant;
 	let boosted: string | undefined;
@@ -668,10 +668,6 @@
 
 		{#if description}
 			<p class="mx-auto max-w-[600px] text-primary dark:text-white">{description}</p>
-		{/if}
-
-		{#if note}
-			<p class="mx-auto max-w-[600px] text-primary dark:text-white">{note}</p>
 		{/if}
 
 		<!-- Three cards: Last Surveyed, Boost, Comments (use server data, don't wait for store sync) -->


### PR DESCRIPTION
Fixes #264 

Removes the note field from merchant pages. Notes are internal info for mappers, not end users.

<img width="1678" height="821" alt="Screenshot 2026-02-06 at 5 00 46 PM" src="https://github.com/user-attachments/assets/530ef0ac-16f2-4f96-b87c-f37fc63c92ca" />

