### PR TITLE
fix(area-page): properly handle reports loading state in stats section

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -349,7 +349,7 @@
 	// Calculate areaReports reactively based on data initialization and reports store
 	// Returns undefined while loading, empty array if no reports for this area, or filtered reports
 	$: areaReports =
-		dataInitialized && data?.id
+		dataInitialized && data?.id && $reports.length > 0
 			? $reports
 					.filter((report) => report.area_id === data.id)
 					.sort((a, b) => Date.parse(b['created_at']) - Date.parse(a['created_at']))


### PR DESCRIPTION
### **User description**
Fix the stats section showing 'Data will appear within 24 hours' incorrectly:
- Check $reports?.length instead of truthy check (empty array is truthy)
- Add reactive statement to update areaReports when store loads after init
- Keep 'Loading data...' until areaReports is actually populated

This fixes the issue where empty reports store was treated as loaded data.

🤖 Generated with [opencode](https://opencode.ai)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix stats section incorrectly showing "Data will appear within 24 hours" when reports store is empty

- Check `$reports?.length` instead of truthy check to distinguish between loading and empty states

- Add reactive statement to update `areaReports` when reports store loads after component initialization

- Keep `areaReports` undefined during loading to display proper "Loading data..." message


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Reports Store Loading"] -->|Empty Array| B["areaReports stays undefined"]
  A -->|Has Data| C["areaReports populated with filtered reports"]
  B -->|Show| D["Loading data... message"]
  C -->|Show| E["AreaStats component"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AreaPage.svelte</strong><dd><code>Properly handle reports loading state in stats section</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/area/AreaPage.svelte

<ul><li>Changed initial <code>areaReports</code> assignment to only set when <br><code>$reports?.length</code> is truthy, keeping it undefined during loading<br> <li> Added reactive statement to update <code>areaReports</code> after <code>dataInitialized</code> <br>when reports store loads with data<br> <li> Simplified conditional checks in stats section template by removing <br>redundant <code>!dataInitialized</code> check and unnecessary truthiness check on <br><code>areaReports</code></ul>


</details>


  </td>
  <td><a href="https://github.com/teambtcmap/btcmap.org/pull/679/files#diff-53634de5c7dd09f3830c96e2662f49aeb86268dcef9d27d3f29e183b01b3e913">+16/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved area page data handling so loading detection and report display timing are more consistent, reducing flicker and race conditions during load.
  * Loading indicator now appears only when data is truly unavailable; reports render reliably as soon as they are ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->