### PR TITLE
feat(i18n): translate add location view and FormSuccess

### DIFF
--- a/src/components/FormSuccess.svelte
+++ b/src/components/FormSuccess.svelte
@@ -8,6 +8,7 @@ export let showIssueLink = true;
 
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
+import { _ } from "$lib/i18n";
 import { theme } from "$lib/theme";
 </script>
 
@@ -15,7 +16,7 @@ import { theme } from "$lib/theme";
 	<div>
 		{#if typeof window !== 'undefined'}
 			<h2 class="{$theme === 'dark' ? 'text-white' : 'gradient'} mb-5 text-4xl font-semibold">
-				{type} Submitted!
+				{$_("formSuccess.submittedTitle", { values: { type } })}
 			</h2>
 		{:else}
 			<HeaderPlaceholder />
@@ -23,18 +24,18 @@ import { theme } from "$lib/theme";
 		<p class="mb-5 w-full text-primary md:w-[500px] dark:text-white">
 			{text}
 			{#if showIssueLink && issue}
-				You may also monitor the progress of your submission here:
+				{$_("formSuccess.monitorProgress")}
 				<a
 					href="https://gitea.btcmap.org/teambtcmap/{repo}/issues/{issue}"
 					target="_blank"
 					rel="noreferrer"
-					class="text-link transition-colors hover:text-hover">Issue #{issue}</a
+					class="text-link transition-colors hover:text-hover">{$_("formSuccess.issueLink", { values: { issue } })}</a
 				>.
 			{/if}
 		</p>
 
 		<PrimaryButton on:click style="{buttonWidth} py-3 mx-auto mt-10 rounded-xl">
-			Submit another {type.toLowerCase()}
+			{$_("formSuccess.submitAnother", { values: { type } })}
 		</PrimaryButton>
 	</div>
 </div>

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -37,7 +37,15 @@
 		"supertaggerImageAlt": "тъмен супертагър",
 		"supertaggerWikiButton": "Вижте Уики за инструкции",
 		"tooltip": "Всички добавяния се правят от доброволци и не можем да гарантираме кога мястото ви ще бъде добавено.",
-		"websitePlaceholder": "https://bitcoin.org"
+		"websitePlaceholder": "https://bitcoin.org",
+		"formSuccessType": "Място",
+		"formSuccessText": "Ще прегледаме информацията и ще я добавим възможно най-скоро."
+	},
+	"formSuccess": {
+		"submittedTitle": "{type} изпратено!",
+		"monitorProgress": "Можете също да следите напредъка на вашето подаване тук:",
+		"issueLink": "Заявка #{issue}",
+		"submitAnother": "Изпрати друго {type}"
 	},
 	"mapControls": {
 		"fullScreen": "Цял екран",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -296,7 +296,15 @@
 		"supertaggerHeading": "Shadowy Supertagger?",
 		"supertaggerDescription": "Contribute changes directly to OSM - like a 😎 boss. Who needs forms anyway.",
 		"supertaggerImageAlt": "shadowy supertagger",
-		"supertaggerWikiButton": "See Wiki for instructions"
+		"supertaggerWikiButton": "See Wiki for instructions",
+		"formSuccessType": "Location",
+		"formSuccessText": "We'll review your information and add it ASAP."
+	},
+	"formSuccess": {
+		"submittedTitle": "{type} Submitted!",
+		"monitorProgress": "You may also monitor the progress of your submission here:",
+		"issueLink": "Issue #{issue}",
+		"submitAnother": "Submit another {type}"
 	},
 	"verifyLocation": {
 		"hero": "Help improve the data for everyone.",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -278,7 +278,15 @@
 		"supertaggerHeading": "Supertagger Misterioso?",
 		"supertaggerDescription": "Contribua com alterações diretamente no OSM - como um chefão. Quem precisa de formulários mesmo.",
 		"supertaggerImageAlt": "supertagger misterioso",
-		"supertaggerWikiButton": "Veja a Wiki para instruções"
+		"supertaggerWikiButton": "Veja a Wiki para instruções",
+		"formSuccessType": "Local",
+		"formSuccessText": "Analisaremos suas informações e adicionaremos o mais rápido possível."
+	},
+	"formSuccess": {
+		"submittedTitle": "{type} enviado!",
+		"monitorProgress": "Você também pode acompanhar o progresso do seu envio aqui:",
+		"issueLink": "Issue #{issue}",
+		"submitAnother": "Enviar outro {type}"
 	},
 	"tip": {
 		"label": "Doar",

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -678,8 +678,8 @@ $: $theme !== undefined && mapLoaded === true && toggleTheme();
 	</div>
 {:else}
 	<FormSuccess
-		type="Location"
-		text="We'll review your information and add it ASAP."
+		type={$_("addLocation.formSuccessType")}
+		text={$_("addLocation.formSuccessText")}
 		issue={submissionIssueNumber}
 		on:click={resetForm}
 	/>


### PR DESCRIPTION
- add-location/+page.svelte (FormSuccess props)
- FormSuccess.svelte (layout strings)

Adds formSuccess and addLocation.formSuccess* to en, pt-BR, bg. FormSuccess is shared across add-location, verify-location, communities/add, tagger-onboarding.