### PR TITLE
feat(i18n): translate tagger-onboarding page title

### DIFF
--- a/src/routes/tagger-onboarding/+page.svelte
+++ b/src/routes/tagger-onboarding/+page.svelte
@@ -94,6 +94,7 @@ onMount(async () => {
 <svelte:head>
 	<title>BTC Map - {$_('nav.becomeTagger')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
+	<meta property="og:title" content="BTC Map - {$_('nav.becomeTagger')}" />
 	<meta property="twitter:title" content="BTC Map - {$_('nav.becomeTagger')}" />
 	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tagger onboarding page now uses dynamic translations for the page title.
  * Social media metadata (Open Graph and Twitter titles) are localized so shared links show translated titles.
  * No user-facing behavior changes beyond localized metadata; content and navigation remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->