### PR TITLE
fix: use name instead of property for Twitter Card meta tags

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -40,11 +40,11 @@
 		<meta property="og:type" content="website" />
 		<meta name="description" content="Easily find places to spend sats anywhere on the planet." />
 		<meta
-			property="twitter:description"
+			name="twitter:description"
 			content="Easily find places to spend sats anywhere on the planet."
 		/>
-		<meta property="twitter:site" content="@btcmap" />
-		<meta property="twitter:card" content="summary_large_image" />
+		<meta name="twitter:site" content="@btcmap" />
+		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="msapplication-TileColor" content="#0B9072" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="manifest" href="/btcmap.webmanifest" />

--- a/src/error.html
+++ b/src/error.html
@@ -17,11 +17,11 @@
 		<meta property="og:type" content="website" />
 		<meta name="description" content="Easily find places to spend sats anywhere on the planet." />
 		<meta
-			property="twitter:description"
+			name="twitter:description"
 			content="Easily find places to spend sats anywhere on the planet."
 		/>
-		<meta property="twitter:site" content="@btcmap" />
-		<meta property="twitter:card" content="summary_large_image" />
+		<meta name="twitter:site" content="@btcmap" />
+		<meta name="twitter:card" content="summary_large_image" />
 		<meta charset="utf-8" />
 		<meta name="msapplication-TileColor" content="#0B9072" />
 		<meta name="viewport" content="width=device-width" />
@@ -3770,8 +3770,8 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
 		<!-- HEAD_svelte-12p4y40_END -->
 		<!-- HEAD_svelte-1gr44ch_START -->
 		<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-		<meta property="twitter:title" content="BTC Map" />
-		<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+		<meta name="twitter:title" content="BTC Map" />
+		<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 		<!-- HEAD_svelte-1gr44ch_END -->
 	</head>
 	<body class="bg-teal dark:bg-dark">

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -16,8 +16,8 @@ onMount(() => {
 <svelte:head>
 	<title>BTC Map - Error</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-	<meta property="twitter:title" content="BTC Map" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="bg-teal dark:bg-dark">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,8 +14,8 @@ import { resolve } from "$app/paths";
 <svelte:head>
 	<title>BTC Map</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-	<meta property="twitter:title" content="BTC Map" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="street-map bg-teal dark:bg-dark">

--- a/src/routes/about-us/+page.svelte
+++ b/src/routes/about-us/+page.svelte
@@ -299,8 +299,8 @@ const coreTeam: {
 <svelte:head>
 	<title>BTC Map - {$_( "aboutUs.title" )}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-	<meta property="twitter:title" content="BTC Map - {$_( "aboutUs.title" )}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map - {$_( "aboutUs.title" )}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-20 text-primary md:space-y-40 dark:text-white">

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -107,8 +107,8 @@ $: latestTaggers = !!(supertaggers?.length && !elementsLoading);
 <svelte:head>
 	<title>BTC Map - Activity</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/activity.png" />
-	<meta property="twitter:title" content="BTC Map - Activity" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/activity.png" />
+	<meta name="twitter:title" content="BTC Map - Activity" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/activity.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-10">

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -285,8 +285,8 @@ $: $theme !== undefined && mapLoaded === true && toggleTheme();
 <svelte:head>
 	<title>BTC Map - Add Location</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/add.png" />
-	<meta property="twitter:title" content="BTC Map - Add Location" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/add.png" />
+	<meta name="twitter:title" content="BTC Map - Add Location" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/add.png" />
 </svelte:head>
 
 {#if !submitted}

--- a/src/routes/apps/+page.svelte
+++ b/src/routes/apps/+page.svelte
@@ -26,8 +26,8 @@ const communityApps: {
 	<title>BTC Map - {$_('nav.apps')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/apps.png" />
 	<meta property="og:title" content="BTC Map - {$_('nav.apps')}" />
-	<meta property="twitter:title" content="BTC Map - {$_('nav.apps')}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/apps.png" />
+	<meta name="twitter:title" content="BTC Map - {$_('nav.apps')}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/apps.png" />
 </svelte:head>
 
 <div class="my-10 space-y-10 text-center md:my-20">

--- a/src/routes/badges/+page.svelte
+++ b/src/routes/badges/+page.svelte
@@ -46,8 +46,8 @@ const contributions = [
 <svelte:head>
 	<title>BTC Map - {$_("badges.title")}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/badges.png" />
-	<meta property="twitter:title" content="BTC Map - {$_("badges.title")}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/badges.png" />
+	<meta name="twitter:title" content="BTC Map - {$_("badges.title")}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/badges.png" />
 </svelte:head>
 
 <div class="my-10 text-center md:my-20">

--- a/src/routes/communities/[section]/+page.svelte
+++ b/src/routes/communities/[section]/+page.svelte
@@ -294,8 +294,8 @@ onDestroy(() => {
 <svelte:head>
 	<title>BTC Map - Communities</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
-	<meta property="twitter:title" content="BTC Map - Communities" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/communities.png" />
+	<meta name="twitter:title" content="BTC Map - Communities" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
 </svelte:head>
 
 <div class="my-10 space-y-10 text-center md:my-20">

--- a/src/routes/communities/add/+page.svelte
+++ b/src/routes/communities/add/+page.svelte
@@ -173,8 +173,8 @@ onMount(async () => {
 <svelte:head>
 	<title>BTC Map - Add Community</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/add-community.png" />
-	<meta property="twitter:title" content="BTC Map - Add Community" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/add-community.png" />
+	<meta name="twitter:title" content="BTC Map - Add Community" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/add-community.png" />
 </svelte:head>
 
 <Breadcrumbs {routes} />

--- a/src/routes/communities/leaderboard/+page.svelte
+++ b/src/routes/communities/leaderboard/+page.svelte
@@ -23,8 +23,8 @@ onMount(() => {
 <svelte:head>
 	<title>BTC Map - Communities Leaderboard</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/top-communities.png" />
-	<meta property="twitter:title" content="BTC Map - Communities Leaderboard" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/top-communities.png" />
+	<meta name="twitter:title" content="BTC Map - Communities Leaderboard" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/top-communities.png" />
 </svelte:head>
 
 <Breadcrumbs {routes} />

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -290,8 +290,8 @@ onDestroy(async () => {
 <svelte:head>
 	<title>BTC Map - Community Map</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
-	<meta property="twitter:title" content="BTC Map - Community Map" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/communities.png" />
+	<meta name="twitter:title" content="BTC Map - Community Map" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
 </svelte:head>
 
 <div>

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -18,8 +18,8 @@ const routes = [
 <svelte:head>
 	<title>{name ? name + ' - ' : ''}BTC Map Community</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
-	<meta property="twitter:title" content="{name ? name + ' - ' : ''}BTC Map Community" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/communities.png" />
+	<meta name="twitter:title" content="{name ? name + ' - ' : ''}BTC Map Community" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
 </svelte:head>
 
 <Breadcrumbs {routes} />

--- a/src/routes/countries/[section]/+page.svelte
+++ b/src/routes/countries/[section]/+page.svelte
@@ -121,8 +121,8 @@ function handleSectionChange(event: Event) {
 <svelte:head>
 	<title>BTC Map - Countries</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/countries.png" />
-	<meta property="twitter:title" content="BTC Map - Countries" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/countries.png" />
+	<meta name="twitter:title" content="BTC Map - Countries" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/countries.png" />
 </svelte:head>
 
 <div class="my-10 space-y-10 text-center md:my-20">

--- a/src/routes/countries/leaderboard/+page.svelte
+++ b/src/routes/countries/leaderboard/+page.svelte
@@ -24,8 +24,8 @@ onMount(() => {
 <svelte:head>
 	<title>BTC Map - Countries Leaderboard</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/top-countries.png" />
-	<meta property="twitter:title" content="BTC Map - Countries Leaderboard" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/top-countries.png" />
+	<meta name="twitter:title" content="BTC Map - Countries Leaderboard" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/top-countries.png" />
 </svelte:head>
 
 <Breadcrumbs {routes} />

--- a/src/routes/country/[area]/[section]/+page.svelte
+++ b/src/routes/country/[area]/[section]/+page.svelte
@@ -37,8 +37,8 @@ $: routes = [
 <svelte:head>
 	<title>{data.name ? data.name + ' - ' : ''}BTC Map Country</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/countries.png" />
-	<meta property="twitter:title" content="{data.name ? data.name + ' - ' : ''}BTC Map Country" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/countries.png" />
+	<meta name="twitter:title" content="{data.name ? data.name + ' - ' : ''}BTC Map Country" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/countries.png" />
 </svelte:head>
 
 <Breadcrumbs {routes} />

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -284,8 +284,8 @@ $: {
 <svelte:head>
 	<title>BTC Map - {$_('dashboard.hero')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/dash.png" />
-	<meta property="twitter:title" content="BTC Map - {$_('dashboard.hero')}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/dash.png" />
+	<meta name="twitter:title" content="BTC Map - {$_('dashboard.hero')}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/dash.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-10">

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -304,8 +304,8 @@ const handlePeriodChange = async (event: Event) => {
 <svelte:head>
 	<title>BTC Map - {$_(`leaderboard.taggerHero`)}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/leader.png" />
-	<meta property="twitter:title" content="BTC Map - {$_(`leaderboard.taggerHero`)}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/leader.png" />
+	<meta name="twitter:title" content="BTC Map - {$_(`leaderboard.taggerHero`)}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/leader.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20">

--- a/src/routes/license/+page.svelte
+++ b/src/routes/license/+page.svelte
@@ -6,8 +6,8 @@ import { _ } from "$lib/i18n";
 	<title>BTC Map - {$_('footer.license')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
 	<meta property="og:title" content="BTC Map - {$_('footer.license')}" />
-	<meta property="twitter:title" content="BTC Map - {$_('footer.license')}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map - {$_('footer.license')}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-5 text-body dark:text-white">

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1408,8 +1408,8 @@ onDestroy(async () => {
 <svelte:head>
 	<title>BTC Map</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/map.png" />
-	<meta property="twitter:title" content="BTC Map" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/map.png" />
+	<meta name="twitter:title" content="BTC Map" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/map.png" />
 </svelte:head>
 
 <div class="relative h-screen w-full">

--- a/src/routes/media/+page.svelte
+++ b/src/routes/media/+page.svelte
@@ -88,8 +88,8 @@ const assetSections = [
 <svelte:head>
 	<title>BTC Map - {$_("media.title")}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-	<meta property="twitter:title" content="BTC Map - {$_("media.title")}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map - {$_("media.title")}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-10 text-center text-primary dark:text-white">

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -364,8 +364,8 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 <svelte:head>
 	<title>{name ? name + ' - ' : ''}BTC Map Merchant</title>
 	<meta property="og:image" content={ogImage} />
-	<meta property="twitter:title" content="{name ? name + ' - ' : ''}BTC Map Merchant" />
-	<meta property="twitter:image" content={ogImage} />
+	<meta name="twitter:title" content="{name ? name + ' - ' : ''}BTC Map Merchant" />
+	<meta name="twitter:image" content={ogImage} />
 </svelte:head>
 
 {#if data.placeData.deleted_at}

--- a/src/routes/privacy-policy/+page.svelte
+++ b/src/routes/privacy-policy/+page.svelte
@@ -8,8 +8,8 @@ const linkClass = "text-link transition-colors hover:text-hover";
 <svelte:head>
 	<title>BTC Map - {$_("privacyPolicy.title")}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-	<meta property="twitter:title" content="BTC Map - {$_("privacyPolicy.title")}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map - {$_("privacyPolicy.title")}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-10">

--- a/src/routes/support-us/+page.svelte
+++ b/src/routes/support-us/+page.svelte
@@ -79,8 +79,8 @@ const supporters = [
 <svelte:head>
 	<title>BTC Map - {t("supportUs.title")}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/support.png" />
-	<meta property="twitter:title" content="BTC Map - {t("supportUs.title")}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/support.png" />
+	<meta name="twitter:title" content="BTC Map - {t("supportUs.title")}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/support.png" />
 </svelte:head>
 
 <div class="my-10 space-y-10 text-center md:my-20">

--- a/src/routes/tagger-onboarding/+page.svelte
+++ b/src/routes/tagger-onboarding/+page.svelte
@@ -95,8 +95,8 @@ onMount(async () => {
 	<title>BTC Map - {$_('nav.becomeTagger')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
 	<meta property="og:title" content="BTC Map - {$_('nav.becomeTagger')}" />
-	<meta property="twitter:title" content="BTC Map - {$_('nav.becomeTagger')}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map - {$_('nav.becomeTagger')}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 {#if !submitted}

--- a/src/routes/tagger/[id]/+page.svelte
+++ b/src/routes/tagger/[id]/+page.svelte
@@ -492,8 +492,8 @@ onDestroy(() => {
 <svelte:head>
 	<title>{username ? username + ' - ' : ''}BTC Map Supertagger</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/supertagger.png" />
-	<meta property="twitter:title" content="{username ? username + ' - ' : ''}BTC Map Supertagger" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/supertagger.png" />
+	<meta name="twitter:title" content="{username ? username + ' - ' : ''}BTC Map Supertagger" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/supertagger.png" />
 </svelte:head>
 
 <div class="my-10 text-center md:my-20">

--- a/src/routes/tagging-issues/+page.svelte
+++ b/src/routes/tagging-issues/+page.svelte
@@ -12,8 +12,8 @@ let issues: RpcIssue[] = data.rpcResult.requested_issues;
 <svelte:head>
 	<title>BTC Map - {$_("taggingIssues.heading")}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-	<meta property="twitter:title" content="BTC Map - {$_("taggingIssues.heading")}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map - {$_("taggingIssues.heading")}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-10">

--- a/src/routes/tickets/+page.svelte
+++ b/src/routes/tickets/+page.svelte
@@ -53,8 +53,8 @@ const isMaintenance = data.maintenance ?? false;
 <svelte:head>
 	<title>BTC Map - {$_('nav.openTickets')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-	<meta property="twitter:title" content="BTC Map - {$_('nav.openTickets')}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+	<meta name="twitter:title" content="BTC Map - {$_('nav.openTickets')}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
 <div class="mt-10 mb-20 space-y-10">

--- a/src/routes/verify-location/+page.svelte
+++ b/src/routes/verify-location/+page.svelte
@@ -121,8 +121,8 @@ onMount(async () => {
 <svelte:head>
 	<title>BTC Map - {$_('verifyLocation.heading')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/verify.png" />
-	<meta property="twitter:title" content="BTC Map - {$_('verifyLocation.heading')}" />
-	<meta property="twitter:image" content="https://btcmap.org/images/og/verify.png" />
+	<meta name="twitter:title" content="BTC Map - {$_('verifyLocation.heading')}" />
+	<meta name="twitter:image" content="https://btcmap.org/images/og/verify.png" />
 </svelte:head>
 
 {#if !submitted}


### PR DESCRIPTION
Twitter Cards spec requires name attribute for twitter:* tags, not property (which is Open Graph convention). Fixes twitter:title, twitter:image, twitter:description, twitter:site, and twitter:card across all pages.