### PR TITLE
feat(i18n): translate dashboard, tickets, and apps pages

### DIFF
--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -682,6 +682,10 @@
 			"wholeTagger": { "title": "Whole Tagger", "desc": "1" }
 		}
 	},
+	"apps": {
+		"official": "Official",
+		"community": "Community"
+	},
 	"media": {
 		"title": "Media",
 		"intro": "Media assets are available for free to use for promotional purposes.",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -568,6 +568,10 @@
 			"wholeTagger": { "title": "Whole Tagger", "desc": "1" }
 		}
 	},
+	"apps": {
+		"official": "Oficial",
+		"community": "Comunidade"
+	},
 	"media": {
 		"title": "Mídia",
 		"intro": "Recursos de mídia estão disponíveis gratuitamente para uso promocional.",

--- a/src/routes/apps/+page.svelte
+++ b/src/routes/apps/+page.svelte
@@ -47,7 +47,7 @@ const communityApps: {
 		We have you covered on whatever device and OS you choose.
 	</h2>
 
-	<h3 class="text-2xl font-semibold text-primary md:text-left dark:text-white">Official</h3>
+	<h3 class="text-2xl font-semibold text-primary md:text-left dark:text-white">{$_('apps.official')}</h3>
 	<section id="official-apps" class="grid gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 		{#each $apps as app (app.link)}
 			<AppCard image={app.icon} text={app.type} desc={app.desc} link={app.link} />
@@ -57,7 +57,7 @@ const communityApps: {
 		Note: There is no Google Play option due to their excessive KYC requirements for developers.
 	</p>
 
-	<h3 class="text-2xl font-semibold text-primary md:text-left dark:text-white">Community</h3>
+	<h3 class="text-2xl font-semibold text-primary md:text-left dark:text-white">{$_('apps.community')}</h3>
 	<section id="community-apps" class="grid gap-10 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
 		{#each communityApps as app (app.link)}
 			<AppCard image={app.icon} text={app.type} desc={app.desc} link={app.link} />

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -306,13 +306,13 @@ $: {
 			class="grid rounded-3xl border border-gray-300 md:grid-cols-2 xl:grid-cols-2 dark:border-white/95 dark:bg-white/10"
 		>
 			<DashboardStat
-				title="Total Merchants"
+				title={$_('dashboard.totalMerchants')}
 				stat={areaDashboard?.total_merchants}
 				border="border-b md:border-b-0 border-gray-300"
 				loading={false}
 			/>
 			<DashboardStat
-				title="Recently Verified"
+				title={$_('dashboard.recentlyVerified')}
 				stat={areaDashboard?.verified_merchants_1y}
 				loading={false}
 			/>
@@ -330,7 +330,7 @@ $: {
 				loading={false}
 			/>
 			<DashboardStat
-				title="Recently Verified"
+				title={$_('dashboard.recentlyVerified')}
 				stat={areaDashboard?.verified_exchanges_1y}
 				loading={false}
 			/>

--- a/src/routes/tickets/+page.svelte
+++ b/src/routes/tickets/+page.svelte
@@ -131,7 +131,7 @@ const isMaintenance = data.maintenance ?? false;
 							<p
 								class="border-t border-gray-300 p-5 text-center text-body dark:border-white/95 dark:text-white"
 							>
-								No open <strong>add</strong> tickets.
+								{$_('maintain.noAddTickets')}
 							</p>
 						{/if}
 					{:else if showType === 'Verify'}
@@ -173,7 +173,7 @@ const isMaintenance = data.maintenance ?? false;
 							<p
 								class="border-t border-gray-300 p-5 text-center text-body dark:border-white/95 dark:text-white"
 							>
-								No open <strong>community</strong> tickets.
+								{$_('maintain.noCommunityTickets')}
 							</p>
 						{/if}
 					{/if}


### PR DESCRIPTION
- Dashboard: use dashboard.* for stat titles (Total Merchants, etc.)
- Tickets: use maintain.noAddTickets, noVerifyTickets, noCommunityTickets
- Apps: add apps.official and apps.community for section headings