### PR TITLE
fix(ci): remove literal ${{ }} from JS comment that broke YAML parser

### DIFF
--- a/.github/workflows/health-report-commands.yml
+++ b/.github/workflows/health-report-commands.yml
@@ -109,7 +109,7 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            // Extract title from the comment body directly to avoid injection via ${{ }}
+            // Extract title from the comment body directly to avoid injection
             const body = context.payload.comment.body.trim();
             const title = body.split('\n')[0].replace('/create-issue', '').trim();
 


### PR DESCRIPTION
GitHub Actions evaluates ${{ }} expressions even inside scalar blocks, causing 'An expression was expected' parse error on workflow load.

🤖 Generated with [opencode](https://opencode.ai)
