### PR TITLE
feat(i18n): tagger profile stats, chart labels, and other UI strings

### DIFF
--- a/src/components/OrgBadge.svelte
+++ b/src/components/OrgBadge.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+import { _ } from "$lib/i18n";
+
 export let org: string;
 
 $: organizations = org
@@ -14,7 +16,7 @@ $: organizations = org
 		{#each organizations as organization (organization)}
 			<p
 				class="w-fit rounded-full bg-[#10B981] px-3.5 py-1 text-xs font-semibold whitespace-nowrap text-white uppercase"
-				title="Organization"
+				title={$_('communityMap.organization')}
 			>
 				{organization}
 			</p>

--- a/src/components/layout/Footer.svelte
+++ b/src/components/layout/Footer.svelte
@@ -68,7 +68,7 @@ const links = [
 				type="button"
 				on:click={() => switchLanguage('en')}
 				disabled={$locale === 'en'}
-				aria-label="Switch to English"
+				aria-label={$_('footer.switchToEnglish')}
 				class="
 					{$locale === 'en'
 					? 'cursor-default font-bold text-body underline dark:text-white/50'
@@ -96,7 +96,7 @@ const links = [
 				type="button"
 				on:click={() => switchLanguage('bg')}
 				disabled={$locale === 'bg'}
-				aria-label="Преминаване към български"
+				aria-label={$_('footer.switchToBulgarian')}
 				class="
 					{$locale === 'bg'
 					? 'cursor-default font-bold text-body underline dark:text-white/50'

--- a/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
+++ b/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
@@ -5,6 +5,7 @@ import { flexRender } from "@tanstack/svelte-table";
 import Icon from "$components/Icon.svelte";
 import AreaLeaderboardItemName from "$components/leaderboard/AreaLeaderboardItemName.svelte";
 import GradeDisplay from "$components/leaderboard/GradeDisplay.svelte";
+import { _ } from "$lib/i18n";
 import type { AreaType } from "$lib/types";
 import { isEven } from "$lib/utils";
 
@@ -16,7 +17,7 @@ export let upToDateTooltip: HTMLButtonElement;
 export let gradeTooltip: HTMLButtonElement;
 </script>
 
-<div class="hidden lg:block" role="region" aria-label="Leaderboard table">
+<div class="hidden lg:block" role="region" aria-label={$_('areaLeaderboard.tableAria')}>
 	<table class="w-full text-left text-xs text-primary lg:text-sm xl:text-lg dark:text-white">
 		<thead>
 			{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
@@ -67,7 +68,7 @@ export let gradeTooltip: HTMLButtonElement;
 											bind:this={totalTooltip}
 											type="button"
 											class="ml-1 cursor-default"
-											aria-label="Information about total locations"
+											aria-label={$_('areaLeaderboard.totalTooltipInfo')}
 										>
 											<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 										</button>
@@ -76,7 +77,7 @@ export let gradeTooltip: HTMLButtonElement;
 											bind:this={upToDateTooltip}
 											type="button"
 											class="ml-1 cursor-default"
-											aria-label="Information about verified locations"
+											aria-label={$_('areaLeaderboard.verifiedTooltipInfo')}
 										>
 											<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 										</button>
@@ -85,7 +86,7 @@ export let gradeTooltip: HTMLButtonElement;
 											bind:this={gradeTooltip}
 											type="button"
 											class="ml-1 cursor-default"
-											aria-label="Information about Grade metric"
+											aria-label={$_('areaLeaderboard.gradeTooltipInfo')}
 										>
 											<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 										</button>

--- a/src/components/leaderboard/AreaLeaderboardItemName.svelte
+++ b/src/components/leaderboard/AreaLeaderboardItemName.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import LeaderboardCountryName from "$components/leaderboard/LeaderboardCountryName.svelte";
+import { _ } from "$lib/i18n";
 import type { AreaType } from "$lib/types";
 
 export let type: AreaType;
@@ -41,7 +42,7 @@ function handleImageError(event: Event) {
 					)
 						? 'break-all'
 						: ''}"
-					aria-label="View {localizedName} details"
+					aria-label={$_('areaLeaderboard.viewDetails', { values: { name: localizedName } })}
 				>
 					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 					{localizedName}
@@ -61,7 +62,7 @@ function handleImageError(event: Event) {
 			<a
 				href={`/${type}/${id}`}
 				class="font-medium text-link transition-colors hover:text-hover {hasLongName ? 'break-all' : ''}"
-				aria-label="View {displayName} details"
+				aria-label={$_('areaLeaderboard.viewDetails', { values: { name: displayName } })}
 			>
 				<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				{displayName}
@@ -70,7 +71,7 @@ function handleImageError(event: Event) {
 	{/if}
 {:else}
 	<!-- Skeleton loading state -->
-	<div class="flex items-center gap-3" role="status" aria-label="Loading area information">
+	<div class="flex items-center gap-3" role="status" aria-label={$_('areaLeaderboard.loadingAreaInfo')}>
 		<div class="h-10 w-10 shrink-0 animate-pulse rounded-full bg-link/50" aria-hidden="true"></div>
 		<div class="h-5 w-24 animate-pulse rounded bg-link/50" aria-hidden="true"></div>
 		<span class="sr-only">Loading...</span>

--- a/src/components/leaderboard/AreaLeaderboardMobileCard.svelte
+++ b/src/components/leaderboard/AreaLeaderboardMobileCard.svelte
@@ -3,6 +3,7 @@ import type { Table } from "@tanstack/svelte-table";
 
 import GradeDisplay from "$components/leaderboard/GradeDisplay.svelte";
 import LeaderboardCountryName from "$components/leaderboard/LeaderboardCountryName.svelte";
+import { _ } from "$lib/i18n";
 import type { AreaType } from "$lib/types";
 import { isEven } from "$lib/utils";
 
@@ -61,7 +62,7 @@ export let type: AreaType;
 							)
 								? 'break-all'
 								: ''}"
-							aria-label="View {localizedName} details"
+							aria-label={$_('areaLeaderboard.viewDetails', { values: { name: localizedName } })}
 						>
 							{localizedName}
 						</a>
@@ -95,7 +96,7 @@ export let type: AreaType;
 						)
 							? 'break-all'
 							: ''}"
-						aria-label="View {area.tags?.name || 'Unknown'} details"
+						aria-label={$_('areaLeaderboard.viewDetails', { values: { name: area.tags?.name || 'Unknown' } })}
 					>
 						{area.tags?.name || 'Unknown'}
 					</a>

--- a/src/components/leaderboard/GradeDisplay.svelte
+++ b/src/components/leaderboard/GradeDisplay.svelte
@@ -1,4 +1,8 @@
 <script lang="ts">
+import { get } from "svelte/store";
+
+import { _ } from "$lib/i18n";
+
 export let grade: number = 0;
 export let percentage: number | undefined = undefined;
 export let avgDate: string | undefined = undefined;
@@ -69,7 +73,9 @@ function gradeTooltipAction(
 		class:flex={size === 'large'}
 		class:justify-center={size === 'large'}
 		role="img"
-		aria-label="{grade} out of 5 stars{percentage ? `, ${percentage.toFixed(1)}% up-to-date` : ''}"
+		aria-label={percentage !== undefined
+			? get(_)("gradeDisplay.ariaLabelWithPercentage", { values: { grade, percentage: percentage.toFixed(1) } })
+			: get(_)("gradeDisplay.ariaLabel", { values: { grade } })}
 		use:gradeTooltipAction={{ percentage, avgDate }}
 	>
 		{'★'.repeat(grade)}{'☆'.repeat(5 - grade)}

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -277,6 +277,9 @@
 		"updateError": "Не може да се актуализират местата, използват се кеширани данни."
 	},
 	"footer": {
+		"switchToEnglish": "Преминаване към английски",
+		"switchToPortuguese": "Преминаване към португалски",
+		"switchToBulgarian": "Преминаване към български",
 		"aboutUs": "За нас",
 		"analytics": "Анализи",
 		"bitcoinForBusiness": "₿ за бизнеса",
@@ -481,7 +484,13 @@
 		"secondaryCalc": "Вторично: Общ брой места.",
 		"locationsNote": "Местата включват банкомати.",
 		"totalTooltip": "Всички места включ. банкомати",
-		"verifiedTooltip": "Места, проверени през последната година"
+		"verifiedTooltip": "Места, проверени през последната година",
+		"tableAria": "Таблица с класация",
+		"totalTooltipInfo": "Информация за общо места",
+		"verifiedTooltipInfo": "Информация за проверени места",
+		"gradeTooltipInfo": "Информация за метриката Оценка",
+		"viewDetails": "Преглед на детайли за {name}",
+		"loadingAreaInfo": "Зареждане на информация за областта"
 	},
 	"verifyCommunityForm": {
 		"heading": "Провери информацията за общността",
@@ -693,6 +702,10 @@
 		"official": "Официални",
 		"community": "Общност",
 		"googlePlayNote": "Забележка: Няма опция за Google Play поради прекомерните изисквания за KYC за разработчици."
+	},
+	"gradeDisplay": {
+		"ariaLabel": "{grade} от 5 звезди",
+		"ariaLabelWithPercentage": "{grade} от 5 звезди, {percentage}% актуално"
 	},
 	"badges": {
 		"title": "Значки",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -151,6 +151,7 @@
 		"description": "Make this merchant stand out in bitcoin orange on the map, shine in the search results, and be discovered in the exclusive boosted locations map!",
 		"seeHowItLooks": "See how it looks",
 		"boostedPinAlt": "Boosted pin",
+		"boostedMerchant": "Boosted merchant",
 		"feeNote": "The fee is used to support the BTC Map open-source project and continue its development.",
 		"boostFor1Month": "Boost for 1 month",
 		"boostForNMonths": "Boost for {time} months",
@@ -274,6 +275,9 @@
 		"searchInput": "Search for Bitcoin merchants"
 	},
 	"footer": {
+		"switchToEnglish": "Switch to English",
+		"switchToPortuguese": "Switch to Portuguese",
+		"switchToBulgarian": "Switch to Bulgarian",
 		"aboutUs": "About Us",
 		"media": "Media",
 		"license": "License",
@@ -299,7 +303,8 @@
 	},
 	"communityMap": {
 		"viewCommunity": "View Community",
-		"pageTitle": "Community Map"
+		"pageTitle": "Community Map",
+		"organization": "Organization"
 	},
 	"taggerOnboarding": {
 		"nameLabel": "Name",
@@ -316,7 +321,16 @@
 		"successMessage": "Thanks for your interest in becoming a tagger! We'll review your application and one of the team will be in contact via the email you provided. Contact hello@btcmap.org if you need to follow up."
 	},
 	"taggerProfile": {
-		"osmProfile": "OSM Profile"
+		"osmProfile": "OSM Profile",
+		"totalTags": "Total Tags",
+		"created": "Created",
+		"updated": "Updated",
+		"deleted": "Deleted",
+		"chartCreated": "Created",
+		"chartUpdated": "Updated",
+		"chartDeleted": "Deleted",
+		"chartLabel": "Tag Types",
+		"mappingSince": "Mapping Since"
 	},
 	"forms": {
 		"optional": "(optional)",
@@ -667,7 +681,13 @@
 		"secondaryCalc": "Secondary: Total number of locations.",
 		"locationsNote": "Locations include ATMs.",
 		"totalTooltip": "All locations inc. ATMs",
-		"verifiedTooltip": "Locations verified within the past year"
+		"verifiedTooltip": "Locations verified within the past year",
+		"tableAria": "Leaderboard table",
+		"totalTooltipInfo": "Information about total locations",
+		"verifiedTooltipInfo": "Information about verified locations",
+		"gradeTooltipInfo": "Information about Grade metric",
+		"viewDetails": "View {name} details",
+		"loadingAreaInfo": "Loading area information"
 	},
 	"issuesTable": {
 		"searchPlaceholder": "Search...",
@@ -710,6 +730,10 @@
 		"northAmerica": "North America",
 		"oceania": "Oceania",
 		"southAmerica": "South America"
+	},
+	"gradeDisplay": {
+		"ariaLabel": "{grade} out of 5 stars",
+		"ariaLabelWithPercentage": "{grade} out of 5 stars, {percentage}% up-to-date"
 	},
 	"badges": {
 		"title": "Badges",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -151,6 +151,7 @@
 		"description": "Destaque este comerciante em laranja bitcoin no mapa, brilhe nos resultados de pesquisa e seja descoberto no mapa exclusivo de locais impulsionados!",
 		"seeHowItLooks": "Veja como fica",
 		"boostedPinAlt": "Pin impulsionado",
+		"boostedMerchant": "Comerciante impulsionado",
 		"feeNote": "A taxa é usada para apoiar o projeto open source BTC Map e continuar seu desenvolvimento.",
 		"boostFor1Month": "Impulsionar por 1 mês",
 		"boostForNMonths": "Impulsionar por {time} meses",
@@ -257,6 +258,9 @@
 		"searchInput": "Pesquisar comerciantes Bitcoin"
 	},
 	"footer": {
+		"switchToEnglish": "Mudar para inglês",
+		"switchToPortuguese": "Mudar para português",
+		"switchToBulgarian": "Mudar para búlgaro",
 		"aboutUs": "Sobre Nós",
 		"media": "Mídia",
 		"license": "Licença",
@@ -282,7 +286,8 @@
 	},
 	"communityMap": {
 		"viewCommunity": "Ver Comunidade",
-		"pageTitle": "Mapa da Comunidade"
+		"pageTitle": "Mapa da Comunidade",
+		"organization": "Organização"
 	},
 	"taggerOnboarding": {
 		"nameLabel": "Nome",
@@ -299,7 +304,16 @@
 		"successMessage": "Obrigado pelo seu interesse em se tornar um etiquetador! Revisaremos sua candidatura e alguém da equipe entrará em contato pelo e-mail fornecido. Entre em contato em hello@btcmap.org se precisar de acompanhamento."
 	},
 	"taggerProfile": {
-		"osmProfile": "Perfil OSM"
+		"osmProfile": "Perfil OSM",
+		"totalTags": "Total de Tags",
+		"created": "Criados",
+		"updated": "Atualizados",
+		"deleted": "Excluídos",
+		"chartCreated": "Criados",
+		"chartUpdated": "Atualizados",
+		"chartDeleted": "Excluídos",
+		"chartLabel": "Tipos de Tags",
+		"mappingSince": "Mapeando desde"
 	},
 	"forms": {
 		"optional": "(opcional)",
@@ -598,7 +612,17 @@
 		"secondaryCalc": "Secundário: Número total de locais.",
 		"locationsNote": "Locais incluem caixas eletrônicos.",
 		"totalTooltip": "Todos os locais incl. caixas eletrônicos",
-		"verifiedTooltip": "Locais verificados no último ano"
+		"verifiedTooltip": "Locais verificados no último ano",
+		"tableAria": "Tabela do ranking",
+		"totalTooltipInfo": "Informações sobre total de locais",
+		"verifiedTooltipInfo": "Informações sobre locais verificados",
+		"gradeTooltipInfo": "Informações sobre métrica de nota",
+		"viewDetails": "Ver detalhes de {name}",
+		"loadingAreaInfo": "Carregando informações da área"
+	},
+	"gradeDisplay": {
+		"ariaLabel": "{grade} de 5 estrelas",
+		"ariaLabelWithPercentage": "{grade} de 5 estrelas, {percentage}% atualizado"
 	},
 	"badges": {
 		"title": "Emblemas",

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -324,7 +324,7 @@ $: {
 			class="grid rounded-3xl border border-gray-300 md:grid-cols-2 xl:grid-cols-2 dark:border-white/95 dark:bg-white/10"
 		>
 			<DashboardStat
-				title="Total Exchanges"
+				title={$_('dashboard.totalExchanges')}
 				stat={areaDashboard?.total_exchanges}
 				border="border-b md:border-b-0 border-gray-300"
 				loading={false}

--- a/src/routes/map/components/MerchantDrawerMobile.svelte
+++ b/src/routes/map/components/MerchantDrawerMobile.svelte
@@ -221,7 +221,7 @@ export function openDrawer(id: number) {
 		on:focusout={handleFocusOut}
 		role="dialog"
 		aria-modal="true"
-		aria-label="Merchant details"
+		aria-label={$_("mapDrawer.merchantDetails")}
 	>
 		<!-- Drag handle and header area -->
 		<div

--- a/src/routes/map/components/MerchantPeekContentMobile.svelte
+++ b/src/routes/map/components/MerchantPeekContentMobile.svelte
@@ -35,7 +35,7 @@ $: hasVerification = merchant.verified_at !== undefined;
 		{#if isBoosted}
 			<div
 				class="flex-shrink-0 rounded-full bg-link px-2.5 py-1 text-xs font-semibold text-white"
-				title="Boosted merchant"
+				title={$_('boost.boostedMerchant')}
 			>
 				<Icon w="14" h="14" icon="bolt" type="material" class="mr-1 inline" />
 				Boosted

--- a/src/routes/tagger/[id]/+page.svelte
+++ b/src/routes/tagger/[id]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { _ } from "svelte-i18n";
+import { get } from "svelte/store";
+
+import { _ } from "$lib/i18n";
 
 import type { PageData } from "./$types";
 export let data: PageData;
@@ -356,10 +358,15 @@ const initializeData = async () => {
 			existingChart.destroy();
 		}
 
+		const t = get(_);
 		tagTypeChart = new Chart(tagTypeChartCanvas, {
 			type: "pie",
 			data: {
-				labels: ["Created", "Updated", "Deleted"],
+				labels: [
+					t("taggerProfile.chartCreated"),
+					t("taggerProfile.chartUpdated"),
+					t("taggerProfile.chartDeleted"),
+				],
 				datasets: [
 					{
 						label: "Tag Types",
@@ -521,7 +528,7 @@ onDestroy(() => {
 			<p class="flex items-center justify-center space-x-1 text-sm text-primary dark:text-white">
 				<Icon type="fa" icon="map-pin" w="16" h="16" />
 				<span class="block">
-					Mapping Since: {mappingSince ? format(new Date(mappingSince), 'yyyy-MM-dd') : '-'}
+					{$_('taggerProfile.mappingSince')}: {mappingSince ? format(new Date(mappingSince), 'yyyy-MM-dd') : '-'}
 				</span>
 			</p>
 			{#if username}
@@ -592,23 +599,23 @@ onDestroy(() => {
 			class="grid rounded-t-3xl border border-gray-300 md:grid-cols-2 xl:grid-cols-4 dark:border-white/95 dark:bg-white/10"
 		>
 			<ProfileStat
-				title="Total Tags"
+				title={$_('taggerProfile.totalTags')}
 				stat={total}
 				border="border-b xl:border-b-0 md:border-r border-gray-300 dark:border-white/95"
 			/>
 			<ProfileStat
-				title="Created"
+				title={$_('taggerProfile.created')}
 				stat={created}
 				percent={createdPercent}
 				border="border-b xl:border-b-0 xl:border-r border-gray-300 dark:border-white/95"
 			/>
 			<ProfileStat
-				title="Updated"
+				title={$_('taggerProfile.updated')}
 				stat={updated}
 				percent={updatedPercent}
 				border="border-b md:border-b-0 md:border-r border-gray-300 dark:border-white/95"
 			/>
-			<ProfileStat title="Deleted" stat={deleted} percent={deletedPercent} />
+			<ProfileStat title={$_('taggerProfile.deleted')} stat={deleted} percent={deletedPercent} />
 		</div>
 
 		<div


### PR DESCRIPTION
- Tagger profile: totalTags, created, updated, deleted, mappingSince, chart labels
- MerchantPeekContentMobile: boost.boostedMerchant title
- Dashboard: totalExchanges
- OrgBadge: communityMap.organization
- AreaLeaderboard: tableAria, tooltip info, viewDetails, loadingAreaInfo
- GradeDisplay: aria-label with grade/percentage
- MerchantDrawerMobile: mapDrawer.merchantDetails
- Footer: language switcher aria-labels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text and accessibility labels across the app for English, Portuguese, and Bulgarian languages, including dashboard titles, leaderboard tooltips, merchant details, and user profile information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->