### PR TITLE
chore(git): ignore opencode local config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ package-lock.json
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# OpenCode local config
+opencode.json


### PR DESCRIPTION
## Summary
- add `opencode.json` to the repository `.gitignore`
- keep local OpenCode configuration out of git status and commits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration to exclude local configuration files from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->