### PR TITLE
feat(drawer): replace View Details button with subtle text link

### DIFF
--- a/src/components/MerchantDetailsContent.svelte
+++ b/src/components/MerchantDetailsContent.svelte
@@ -340,13 +340,6 @@ async function fetchComments(placeId: number) {
 		</div>
 	</div>
 
-	<a
-		href={resolve(`/merchant/${merchant.id}`)}
-		class="block rounded-lg bg-link py-3 text-center text-white transition-colors hover:bg-hover"
-	>
-		{$_('merchant.viewDetails')}
-	</a>
-
 	<!-- Comments Section -->
 	{#if commentsLoading}
 		<div class="space-y-2">
@@ -370,4 +363,14 @@ async function fetchComments(placeId: number) {
 			</div>
 		</div>
 	{/if}
+
+	<div class="pt-2 text-center">
+		<a
+			href={resolve(`/merchant/${merchant.id}`)}
+			class="inline-flex items-center gap-1 text-sm text-link transition-colors hover:text-hover"
+		>
+			{$_('merchant.seeFullProfile')}
+			<Icon w="14" h="14" icon="arrow_forward" type="material" />
+		</a>
+	</div>
 </div>

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -584,6 +584,7 @@
 		"tagIssues": "Проблеми с етикетите",
 		"unknown": "Неизвестно",
 		"viewDetails": "Пълен преглед",
+		"seeFullProfile": "Вижте пълния профил",
 		"viewOSM": "Преглед в OSM",
 		"socialX": "X",
 		"socialInstagram": "Instagram",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -110,6 +110,7 @@
 		"socialInstagram": "Instagram",
 		"socialFacebook": "Facebook",
 		"viewDetails": "Vollständige Details anzeigen",
+		"seeFullProfile": "Vollständiges Profil ansehen",
 		"comments": "Kommentare",
 		"commentsCount": "Kommentare ({count})",
 		"unknown": "Unbekannt",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -110,6 +110,7 @@
 		"socialInstagram": "Instagram",
 		"socialFacebook": "Facebook",
 		"viewDetails": "View Full Details",
+		"seeFullProfile": "See full profile",
 		"comments": "Comments",
 		"commentsCount": "Comments ({count})",
 		"unknown": "Unknown",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -110,6 +110,7 @@
 		"socialInstagram": "Instagram",
 		"socialFacebook": "Facebook",
 		"viewDetails": "Bekijk volledige details",
+		"seeFullProfile": "Bekijk volledig profiel",
 		"comments": "Opmerkingen",
 		"commentsCount": "Opmerkingen ({count})",
 		"unknown": "Onbekend",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -110,6 +110,7 @@
 		"socialInstagram": "Instagram",
 		"socialFacebook": "Facebook",
 		"viewDetails": "Ver Detalhes Completos",
+		"seeFullProfile": "Ver perfil completo",
 		"comments": "Comentários",
 		"commentsCount": "Comentários ({count})",
 		"unknown": "Desconhecido",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -110,6 +110,7 @@
 		"socialInstagram": "Instagram",
 		"socialFacebook": "Facebook",
 		"viewDetails": "Посмотреть полностью",
+		"seeFullProfile": "Полный профиль",
 		"comments": "Комментарии",
 		"commentsCount": "Комментарии ({count})",
 		"unknown": "Неизвестно",

--- a/tests/map-drawer.spec.ts
+++ b/tests/map-drawer.spec.ts
@@ -139,8 +139,8 @@ test.describe('Map Drawer', () => {
 		const drawer = page.locator('[role="dialog"]');
 		await expect(drawer).toBeVisible({ timeout: 15000 });
 
-		// Look for "View Full Details" button in drawer
-		const viewDetailsButton = page.locator('a:has-text("View Full Details")');
+		// Look for "See full profile" button in drawer
+		const viewDetailsButton = page.locator('a:has-text("See full profile")');
 		await expect(viewDetailsButton).toBeVisible({ timeout: 10000 });
 
 		const merchantHref = await viewDetailsButton.getAttribute('href');
@@ -254,8 +254,8 @@ test.describe('Map Drawer', () => {
 			console.error('API response wait failed:', error);
 		}
 
-		// Verify "View Full Details" button appears (confirms drawer has content)
-		const viewDetailsButton = page.locator('a:has-text("View Full Details")');
+		// Verify "See full profile" button appears (confirms drawer has content)
+		const viewDetailsButton = page.locator('a:has-text("See full profile")');
 		await expect(viewDetailsButton).toBeVisible({ timeout: 10000 });
 
 		// Verify the correct merchant is displayed

--- a/tests/merchant-list-panel.spec.ts
+++ b/tests/merchant-list-panel.spec.ts
@@ -116,11 +116,11 @@ test.describe('Merchant List Panel', () => {
 		}
 
 		// Drawer should open (use specific selector to exclude mobile list dialog)
-		const drawer = page.locator('[role="dialog"]:has(a:has-text("View Full Details"))');
+		const drawer = page.locator('[role="dialog"]:has(a:has-text("See full profile"))');
 		await expect(drawer).toBeVisible({ timeout: 10000 });
 
-		// Drawer should have View Full Details button
-		const viewDetailsButton = drawer.locator('a:has-text("View Full Details")');
+		// Drawer should have See full profile button
+		const viewDetailsButton = drawer.locator('a:has-text("See full profile")');
 		await expect(viewDetailsButton).toBeVisible({ timeout: 10000 });
 	});
 


### PR DESCRIPTION
Replace the large teal "View Full Details" button with a subtle "See full profile →" text link at the bottom of the drawer, after comments. Reduces visual competition with action buttons.

Translations added to all 6 locales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<img width="419" height="921" alt="image" src="https://github.com/user-attachments/assets/f1a1c69e-3a78-46c2-ab00-52afdde2fc79" />
<img width="442" height="932" alt="image" src="https://github.com/user-attachments/assets/770958bb-401b-4e70-bfcf-8f5f681b8626" />
<img width="402" height="701" alt="image" src="https://github.com/user-attachments/assets/76544ea8-82c2-4433-a6ce-7691246a8bb9" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated merchant profile links with improved styling, icon design, and clearer call-to-action text for better user visibility and engagement.

* **Localization**
  * Added multi-language support for merchant profile links across Bulgarian, German, Dutch, Portuguese, and Russian.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->