### PR TITLE
Improve mobile modal UX with bottom sheet style

### DIFF
--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -47,7 +47,7 @@ export function setTrigger(el: HTMLElement) {
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby={titleId}
-			class="z-[2000] flex flex-col overflow-auto border border-gray-300 bg-white p-6 shadow-2xl fixed inset-0 w-full h-full dark:border-white/95 dark:bg-dark md:inset-auto md:top-1/2 md:left-1/2 md:w-80 md:max-h-[90vh] md:h-auto md:rounded-xl md:translate-x-[-50%] md:translate-y-[-50%]"
+			class="z-[2000] flex flex-col overflow-hidden border border-gray-300 bg-white shadow-2xl fixed inset-x-4 bottom-4 max-h-[85dvh] rounded-2xl dark:border-white/95 dark:bg-dark sm:inset-auto sm:top-1/2 sm:left-1/2 sm:w-80 sm:max-h-[90vh] sm:h-auto sm:rounded-xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:px-6 sm:py-6 px-5 py-5"
 		>
 			<div class="mb-4 flex items-center justify-between">
 				<h2 id={titleId} class="text-lg font-semibold text-primary dark:text-white">
@@ -56,7 +56,9 @@ export function setTrigger(el: HTMLElement) {
 				<CloseButton on:click={() => (open = false)} />
 			</div>
 
-			<slot />
+			<div class="flex-1 overflow-y-auto -mx-5 px-5">
+				<slot />
+			</div>
 		</div>
 	</OutClick>
 {/if}


### PR DESCRIPTION
Makes language and apps modals more mobile-friendly with:\n- Bottom sheet style on mobile (slides up from bottom with rounded corners)\n- Better spacing with  padding on mobile\n- Scrollable content area with proper overflow handling\n- Desktop modal remains centered with standard styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined modal dialog appearance with improved spacing, visual hierarchy, and overall design and presentation quality.
  * Enhanced responsive design with improved layout behavior optimized for both mobile devices and larger desktop screens.
  * Optimized content area sizing, overflow handling, and floating panel positioning to deliver an improved and more polished user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->