### PR TITLE
Reorder app stores so android always comes first

### DIFF
--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -104,14 +104,14 @@ export const appConfigs: AppConfig[] = [
 		sponsor: true,
 		stores: [
 			{
-				store: "app-store",
-				platform: "ios",
-				url: "https://apps.apple.com/us/app/wallet-of-satoshi/id1438599608",
-			},
-			{
 				store: "google-play",
 				platform: "android",
 				url: "https://play.google.com/store/apps/details?id=com.livingroomofsatoshi.wallet",
+			},
+			{
+				store: "app-store",
+				platform: "ios",
+				url: "https://apps.apple.com/us/app/wallet-of-satoshi/id1438599608",
 			},
 		],
 	},
@@ -122,6 +122,11 @@ export const appConfigs: AppConfig[] = [
 		tag: "powered-by-btcmap",
 		sponsor: false,
 		stores: [
+			{
+				store: "google-play",
+				platform: "android",
+				url: "https://play.google.com/store/apps/details?id=com.getalby.mobile",
+			},
 			{
 				store: "zapstore",
 				platform: "android",
@@ -137,11 +142,6 @@ export const appConfigs: AppConfig[] = [
 				platform: "ios",
 				url: "https://apps.apple.com/us/app/alby-go/id6471335774",
 			},
-			{
-				store: "google-play",
-				platform: "android",
-				url: "https://play.google.com/store/apps/details?id=com.getalby.mobile",
-			},
 		],
 	},
 	{
@@ -152,6 +152,11 @@ export const appConfigs: AppConfig[] = [
 		sponsor: false,
 		stores: [
 			{
+				store: "google-play",
+				platform: "android",
+				url: "https://play.google.com/store/apps/details?id=io.aquawallet.android",
+			},
+			{
 				store: "zapstore",
 				platform: "android",
 				url: "https://zapstore.dev/apps/io.aquawallet.android",
@@ -160,11 +165,6 @@ export const appConfigs: AppConfig[] = [
 				store: "app-store",
 				platform: "ios",
 				url: "https://apps.apple.com/us/app/aqua-wallet/id6468594241",
-			},
-			{
-				store: "google-play",
-				platform: "android",
-				url: "https://play.google.com/store/apps/details?id=io.aquawallet.android",
 			},
 		],
 	},
@@ -176,14 +176,14 @@ export const appConfigs: AppConfig[] = [
 		sponsor: true,
 		stores: [
 			{
-				store: "app-store",
-				platform: "ios",
-				url: "https://apps.apple.com/us/app/cash-app/id711923939",
-			},
-			{
 				store: "google-play",
 				platform: "android",
 				url: "https://play.google.com/store/apps/details?id=com.squareup.cash",
+			},
+			{
+				store: "app-store",
+				platform: "ios",
+				url: "https://apps.apple.com/us/app/cash-app/id711923939",
 			},
 		],
 	},
@@ -224,14 +224,14 @@ export const appConfigs: AppConfig[] = [
 				url: "https://play.google.com/store/apps/details?id=com.fedi",
 			},
 			{
-				store: "app-store",
-				platform: "ios",
-				url: "https://apps.apple.com/us/app/fedi-alpha/id6448916281",
-			},
-			{
 				store: "apk",
 				platform: "android",
 				url: "https://apk.fedi.xyz",
+			},
+			{
+				store: "app-store",
+				platform: "ios",
+				url: "https://apps.apple.com/us/app/fedi-alpha/id6448916281",
 			},
 		],
 	},
@@ -276,6 +276,11 @@ export const appConfigs: AppConfig[] = [
 		sponsor: false,
 		stores: [
 			{
+				store: "google-play",
+				platform: "android",
+				url: "https://play.google.com/store/apps/details?id=io.blink.wallet",
+			},
+			{
 				store: "zapstore",
 				platform: "android",
 				url: "https://zapstore.dev/apps/io.blink.wallet",
@@ -284,11 +289,6 @@ export const appConfigs: AppConfig[] = [
 				store: "apk",
 				platform: "android",
 				url: "https://github.com/blinkbitcoin/blink-mobile/releases/latest",
-			},
-			{
-				store: "google-play",
-				platform: "android",
-				url: "https://play.google.com/store/apps/details?id=io.blink.wallet",
 			},
 			{
 				store: "app-store",


### PR DESCRIPTION
Reorders store entries in apps.ts so android sources always appear before iOS:\n\n- Wallet of Satoshi: android first\n- Alby: google-play, zapstore, apk, then iOS\n- Aqua: google-play, zapstore, then iOS\n- Cash App: android first\n- Fedi: android sources (google-play, apk) before iOS\n- Blink: android sources before iOS\n\nApps already correct: Manna, Stacked, Bull Bitcoin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reordered app store availability and prominence for several applications to optimize platform prioritization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->