### PR TITLE
perf(area): scope per-place enrichment to /activity tab only

### DIFF
--- a/src/components/area/AreaMerchantHighlights.svelte
+++ b/src/components/area/AreaMerchantHighlights.svelte
@@ -16,11 +16,10 @@ $: boosts = filteredPlaces
 			Date.parse(b.boosted_until || "") - Date.parse(a.boosted_until || ""),
 	);
 
-$: latest = filteredPlaces
-	?.toSorted(
-		(a, b) => Date.parse(b.created_at || "") - Date.parse(a.created_at || ""),
-	)
-	.slice(0, 6);
+// element.id is a SQLite rowid auto-assigned on insert, so sorting by id desc is
+// a close approximation of "latest added" and works without per-place enrichment
+// (created_at isn't in the static places.json the global $places store is seeded from).
+$: latest = filteredPlaces?.toSorted((a, b) => b.id - a.id).slice(0, 6);
 </script>
 
 <section id="boosted">

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -128,80 +128,79 @@ const handleSectionChange = (section: Sections) => {
 
 let dataInitialized = false;
 let elementsLoading = false;
+let activityEnriched = false;
 
-// Fetch places for area using geographic filtering + enrichment with verification data
-const fetchPlacesForArea = async (areaId: string): Promise<Place[]> => {
+// Fetch minimal per-place data (id + osm_id + deleted_at) for the area so the /activity
+// tab's Supertaggers list can match $events.element_id to place.osm_id. osm_id isn't in
+// the static places.json the global $places store is seeded from, so it has to come from
+// the API. This is an interim shim: once the area-scoped top-editors REST endpoint ships,
+// the whole function + its call site go away.
+const fetchActivityPlaceIds = async (placeIds: number[]): Promise<Place[]> => {
 	try {
 		elementsLoading = true;
-
-		// Step 1: Geographic filtering (fast, uses existing store)
-		const area = $areas.find((a) => a.id === areaId);
-		if (!area || !area.tags.geo_json) {
-			console.error("Area not found or missing geo_json:", areaId);
-			return [];
-		}
-
-		const allPlaces = $places;
-		const rewoundPoly = rewind(area.tags.geo_json, true);
-		const areaPlaces = allPlaces.filter((place: Place) => {
-			return (
-				place.lat &&
-				place.lon &&
-				geoContains(rewoundPoly, [place.lon, place.lat])
-			);
-		});
-
-		console.info(
-			`Geographic filtering found ${areaPlaces.length} places for ${areaId}`,
-		);
-
-		// Step 2: Enrich with verification data from API (batched requests)
-		const placeIds = areaPlaces.map((p) => p.id);
 		const batchSize = 20;
-		const enrichedPlaces: Place[] = [];
-
-		console.info(
-			`Enriching ${placeIds.length} places with verification data in ${Math.ceil(placeIds.length / batchSize)} batches`,
-		);
+		const enriched: Place[] = [];
+		const fieldsParam = buildFieldsParam(PLACE_FIELD_SETS.ACTIVITY_AGGREGATE);
 
 		for (let i = 0; i < placeIds.length; i += batchSize) {
 			const batch = placeIds.slice(i, i + batchSize);
-			const batchPromises = batch.map((id) =>
-				axios
-					.get<Place>(
-						`https://api.btcmap.org/v4/places/${id}?fields=${buildFieldsParam(PLACE_FIELD_SETS.COMPLETE_PLACE)}`,
-					)
-					.then((response) => response.data)
-					.catch((error) => {
-						console.warn(
-							`Failed to fetch place ${id}:`,
-							error.response?.status,
-						);
-						return null;
-					}),
+			const batchResults = await Promise.all(
+				batch.map((id) =>
+					axios
+						.get<Place>(
+							`https://api.btcmap.org/v4/places/${id}?fields=${fieldsParam}`,
+						)
+						.then((response) => response.data)
+						.catch((error) => {
+							console.warn(
+								`Failed to fetch place ${id}:`,
+								error.response?.status,
+							);
+							return null;
+						}),
+				),
 			);
-
-			const batchResults = await Promise.all(batchPromises);
-			const validPlaces = batchResults
-				.filter((place): place is Place => place !== null)
-				.filter((place) => !place.deleted_at);
-			enrichedPlaces.push(...validPlaces);
-
-			console.info(
-				`Batch ${Math.floor(i / batchSize) + 1} completed: ${validPlaces.length}/${batch.length} successful`,
-			);
+			for (const place of batchResults) {
+				if (place && !place.deleted_at) enriched.push(place);
+			}
 		}
-
-		console.info(
-			`Successfully enriched ${enrichedPlaces.length} places for ${areaId}`,
-		);
-		return enrichedPlaces;
+		return enriched;
 	} catch (error) {
-		console.error("Failed to fetch places for area:", areaId, error);
+		console.error("Failed to fetch activity place ids:", error);
 		return [];
 	} finally {
 		elementsLoading = false;
 	}
+};
+
+const populateTaggersFromEvents = (placesForTaggers: Place[]) => {
+	if (!$events.length || !$users.length) return;
+
+	const areaEvents = $events.filter((event) =>
+		placesForTaggers.find((place) => place.osm_id === event.element_id),
+	);
+	areaEvents.sort(
+		(a, b) => Date.parse(b.created_at) - Date.parse(a.created_at),
+	);
+
+	const newTaggers: User[] = [];
+	areaEvents.forEach((event) => {
+		const foundUser = $users.find((user) => user.id === event.user_id);
+		if (foundUser && !newTaggers.find((t) => t.id === foundUser.id)) {
+			newTaggers.push(foundUser);
+		}
+	});
+	taggers = newTaggers;
+};
+
+const enrichForActivity = async () => {
+	if (activityEnriched || !filteredPlaces.length) return;
+	activityEnriched = true;
+
+	const placesForTaggers = await fetchActivityPlaceIds(
+		filteredPlaces.map((p) => p.id),
+	);
+	populateTaggersFromEvents(placesForTaggers);
 };
 
 const initializeData = async () => {
@@ -322,35 +321,21 @@ const initializeData = async () => {
 	issues = data.issues;
 
 	dataInitialized = true;
-
-	// Fetch places in the background for rich components
-	if (browser) {
-		const places = await fetchPlacesForArea(areaFound.id);
-		filteredPlaces = places;
-
-		// Process events after places are loaded, only if events and users stores are populated
-		if ($events.length && $users.length) {
-			const areaEvents = $events.filter((event) =>
-				filteredPlaces.find((place) => place.osm_id === event.element_id),
-			);
-
-			areaEvents.sort(
-				(a, b) => Date.parse(b.created_at) - Date.parse(a.created_at),
-			);
-
-			areaEvents.forEach((event) => {
-				let foundUser = $users.find((user) => user.id === event.user_id);
-				if (foundUser && !taggers.find((t) => t.id === foundUser?.id)) {
-					taggers.push(foundUser);
-				}
-			});
-
-			taggers = taggers;
-		}
-	}
 };
 
 $: $areas?.length && $places?.length && !dataInitialized && initializeData();
+
+// Activity tab is the only section that needs per-place data beyond the static
+// places.json (it needs osm_id to match events to places). Fire enrichment only
+// when the user actually lands on /activity — merchants/stats/maintain don't need it.
+$: if (
+	browser &&
+	dataInitialized &&
+	activeSection === Sections.activity &&
+	!activityEnriched
+) {
+	enrichForActivity();
+}
 
 // Calculate areaReports reactively based on data initialization and reports store
 // Returns undefined while loading, empty array if no reports for this area, or filtered reports
@@ -591,7 +576,7 @@ let issues: RpcIssue[] = [];
 				<p>{$_('area.loadingData')}</p>
 			</div>
 		{:else if areaReports.length > 0}
-			<AreaStats {name} {filteredPlaces} {areaReports} areaTags={area} />
+			<AreaStats {name} {areaReports} areaTags={area} />
 		{:else}
 			<div class="text-center text-primary dark:text-white">
 				<p class="text-xl">{$_('area.dataWithin24Hours')}</p>

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -127,8 +127,11 @@ const handleSectionChange = (section: Sections) => {
 // No need for hash handling anymore - sections are handled by route parameters
 
 let dataInitialized = false;
-let elementsLoading = false;
-let activityEnriched = false;
+// Two flags because the UI needs to know "has the enrichment actually finished",
+// while the reactive trigger needs to know "is it already running" — using a single
+// flag causes a flash of the empty-state message for the duration of fetch.
+let activityEnrichmentInFlight = false;
+let activityEnrichmentDone = false;
 
 // Fetch minimal per-place data (id + osm_id + deleted_at) for the area so the /activity
 // tab's Supertaggers list can match $events.element_id to place.osm_id. osm_id isn't in
@@ -137,7 +140,6 @@ let activityEnriched = false;
 // the whole function + its call site go away.
 const fetchActivityPlaceIds = async (placeIds: number[]): Promise<Place[]> => {
 	try {
-		elementsLoading = true;
 		const batchSize = 20;
 		const enriched: Place[] = [];
 		const fieldsParam = buildFieldsParam(PLACE_FIELD_SETS.ACTIVITY_AGGREGATE);
@@ -168,8 +170,6 @@ const fetchActivityPlaceIds = async (placeIds: number[]): Promise<Place[]> => {
 	} catch (error) {
 		console.error("Failed to fetch activity place ids:", error);
 		return [];
-	} finally {
-		elementsLoading = false;
 	}
 };
 
@@ -194,13 +194,22 @@ const populateTaggersFromEvents = (placesForTaggers: Place[]) => {
 };
 
 const enrichForActivity = async () => {
-	if (activityEnriched || !filteredPlaces.length) return;
-	activityEnriched = true;
-
-	const placesForTaggers = await fetchActivityPlaceIds(
-		filteredPlaces.map((p) => p.id),
-	);
-	populateTaggersFromEvents(placesForTaggers);
+	if (
+		activityEnrichmentInFlight ||
+		activityEnrichmentDone ||
+		!filteredPlaces.length
+	)
+		return;
+	activityEnrichmentInFlight = true;
+	try {
+		const placesForTaggers = await fetchActivityPlaceIds(
+			filteredPlaces.map((p) => p.id),
+		);
+		populateTaggersFromEvents(placesForTaggers);
+		activityEnrichmentDone = true;
+	} finally {
+		activityEnrichmentInFlight = false;
+	}
 };
 
 const initializeData = async () => {
@@ -328,11 +337,17 @@ $: $areas?.length && $places?.length && !dataInitialized && initializeData();
 // Activity tab is the only section that needs per-place data beyond the static
 // places.json (it needs osm_id to match events to places). Fire enrichment only
 // when the user actually lands on /activity — merchants/stats/maintain don't need it.
+// Also wait for $events/$users to populate: batchSync runs them independently of
+// $areas/$places, so dataInitialized can flip true before events/users are ready,
+// and populateTaggersFromEvents would silently produce an empty list in that window.
 $: if (
 	browser &&
 	dataInitialized &&
 	activeSection === Sections.activity &&
-	!activityEnriched
+	$events.length &&
+	$users.length &&
+	!activityEnrichmentInFlight &&
+	!activityEnrichmentDone
 ) {
 	enrichForActivity();
 }
@@ -559,10 +574,7 @@ let issues: RpcIssue[] = [];
 
 	{#if activeSection === Sections.merchants}
 		<AreaMap {name} geoJSON={area?.geo_json} {filteredPlaces} />
-		<AreaMerchantHighlights
-			dataInitialized={dataInitialized && !elementsLoading}
-			{filteredPlaces}
-		/>
+		<AreaMerchantHighlights {dataInitialized} {filteredPlaces} />
 		{#if browser}
 			<Boost />
 		{/if}
@@ -586,14 +598,14 @@ let issues: RpcIssue[] = [];
 		<AreaActivity
 			{alias}
 			{name}
-			dataInitialized={dataInitialized && !elementsLoading}
+			dataInitialized={dataInitialized && activityEnrichmentDone}
 			{taggers}
 		/>
 	{:else if activeSection === Sections.maintain}
 		<IssuesTable
 			title={$_('area.taggingIssues', { values: { name: name || $_('area.defaultName') } })}
 			{issues}
-			loading={!(dataInitialized && !elementsLoading)}
+			loading={!dataInitialized}
 		/>
 		<AreaTickets tickets={data.tickets} title={$_('area.openTickets', { values: { name: name || $_('area.defaultName') } })} />
 		{#if type === 'community'}

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -132,16 +132,28 @@ let dataInitialized = false;
 // flag causes a flash of the empty-state message for the duration of fetch.
 let activityEnrichmentInFlight = false;
 let activityEnrichmentDone = false;
+// Bounded retry: fetchActivityPlaceIds swallows per-request errors and returns []
+// on a full network outage. Without a counter, the reactive trigger would retry in
+// a tight loop. Reset on area change.
+let activityEnrichmentAttempts = 0;
+const MAX_ACTIVITY_ATTEMPTS = 3;
 
-// Fetch minimal per-place data (id + osm_id + deleted_at) for the area so the /activity
-// tab's Supertaggers list can match $events.element_id to place.osm_id. osm_id isn't in
-// the static places.json the global $places store is seeded from, so it has to come from
-// the API. This is an interim shim: once the area-scoped top-editors REST endpoint ships,
-// the whole function + its call site go away.
-const fetchActivityPlaceIds = async (placeIds: number[]): Promise<Place[]> => {
+// The activity shim requests only id/osm_id/deleted_at; the returned objects don't
+// satisfy Place's required lat/lon/icon contract. Use a narrower type so the axios
+// generic and downstream signatures are honest.
+type ActivityPlace = Pick<Place, "id" | "osm_id" | "deleted_at">;
+
+// Fetch minimal per-place data for the area so the /activity tab's Supertaggers list
+// can match $events.element_id to place.osm_id. osm_id isn't in the static places.json
+// the global $places store is seeded from, so it has to come from the API. Interim
+// shim: once the area-scoped top-editors REST endpoint ships, this function + its
+// call site go away.
+const fetchActivityPlaceIds = async (
+	placeIds: number[],
+): Promise<ActivityPlace[]> => {
 	try {
 		const batchSize = 20;
-		const enriched: Place[] = [];
+		const enriched: ActivityPlace[] = [];
 		const fieldsParam = buildFieldsParam(PLACE_FIELD_SETS.ACTIVITY_AGGREGATE);
 
 		for (let i = 0; i < placeIds.length; i += batchSize) {
@@ -149,7 +161,7 @@ const fetchActivityPlaceIds = async (placeIds: number[]): Promise<Place[]> => {
 			const batchResults = await Promise.all(
 				batch.map((id) =>
 					axios
-						.get<Place>(
+						.get<ActivityPlace>(
 							`https://api.btcmap.org/v4/places/${id}?fields=${fieldsParam}`,
 						)
 						.then((response) => response.data)
@@ -173,23 +185,31 @@ const fetchActivityPlaceIds = async (placeIds: number[]): Promise<Place[]> => {
 	}
 };
 
-const populateTaggersFromEvents = (placesForTaggers: Place[]) => {
+const populateTaggersFromEvents = (placesForTaggers: ActivityPlace[]) => {
 	if (!$events.length || !$users.length) return;
 
-	const areaEvents = $events.filter((event) =>
-		placesForTaggers.find((place) => place.osm_id === event.element_id),
-	);
-	areaEvents.sort(
-		(a, b) => Date.parse(b.created_at) - Date.parse(a.created_at),
-	);
+	const placeOsmIds = new Set<string>();
+	for (const place of placesForTaggers) {
+		if (place.osm_id) placeOsmIds.add(place.osm_id);
+	}
+	const usersById = new Map<number, User>();
+	for (const user of $users) {
+		usersById.set(user.id, user);
+	}
 
+	const areaEvents = $events
+		.filter((event) => placeOsmIds.has(event.element_id))
+		.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
+
+	const seenUserIds = new Set<number>();
 	const newTaggers: User[] = [];
-	areaEvents.forEach((event) => {
-		const foundUser = $users.find((user) => user.id === event.user_id);
-		if (foundUser && !newTaggers.find((t) => t.id === foundUser.id)) {
-			newTaggers.push(foundUser);
-		}
-	});
+	for (const event of areaEvents) {
+		if (seenUserIds.has(event.user_id)) continue;
+		const user = usersById.get(event.user_id);
+		if (!user) continue;
+		seenUserIds.add(event.user_id);
+		newTaggers.push(user);
+	}
 	taggers = newTaggers;
 };
 
@@ -197,16 +217,24 @@ const enrichForActivity = async () => {
 	if (
 		activityEnrichmentInFlight ||
 		activityEnrichmentDone ||
+		activityEnrichmentAttempts >= MAX_ACTIVITY_ATTEMPTS ||
 		!filteredPlaces.length
 	)
 		return;
 	activityEnrichmentInFlight = true;
+	activityEnrichmentAttempts++;
 	try {
 		const placesForTaggers = await fetchActivityPlaceIds(
 			filteredPlaces.map((p) => p.id),
 		);
 		populateTaggersFromEvents(placesForTaggers);
-		activityEnrichmentDone = true;
+		// Only lock as "done" when we actually got data. All-empty result with a
+		// non-empty filteredPlaces is the signature of a network failure (inner
+		// .catch swallows per-request errors and returns null); leave Done=false
+		// so the reactive trigger can retry up to MAX_ACTIVITY_ATTEMPTS times.
+		if (placesForTaggers.length > 0) {
+			activityEnrichmentDone = true;
+		}
 	} finally {
 		activityEnrichmentInFlight = false;
 	}
@@ -332,6 +360,23 @@ const initializeData = async () => {
 	dataInitialized = true;
 };
 
+// Reset area-scoped state when the user navigates client-side to a different area.
+// SvelteKit reuses the +page.svelte instance (and this AreaPage) across
+// /country/X/* → /country/Y/* transitions, and initializeData has an early
+// `if (dataInitialized) return` guard — so without this reset the previous area's
+// state would leak into the next one. Must run before the initializeData reactive
+// below so dataInitialized=false is observed on the same tick.
+let lastAreaId: string | undefined;
+$: if (data?.id !== lastAreaId) {
+	lastAreaId = data.id;
+	dataInitialized = false;
+	activityEnrichmentInFlight = false;
+	activityEnrichmentDone = false;
+	activityEnrichmentAttempts = 0;
+	taggers = [];
+	filteredPlaces = [];
+}
+
 $: $areas?.length && $places?.length && !dataInitialized && initializeData();
 
 // Activity tab is the only section that needs per-place data beyond the static
@@ -347,7 +392,8 @@ $: if (
 	$events.length &&
 	$users.length &&
 	!activityEnrichmentInFlight &&
-	!activityEnrichmentDone
+	!activityEnrichmentDone &&
+	activityEnrichmentAttempts < MAX_ACTIVITY_ATTEMPTS
 ) {
 	enrichForActivity();
 }

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -130,13 +130,10 @@ let dataInitialized = false;
 // Two flags because the UI needs to know "has the enrichment actually finished",
 // while the reactive trigger needs to know "is it already running" — using a single
 // flag causes a flash of the empty-state message for the duration of fetch.
+// Per-request transient failures are handled by axiosRetry (configured at module
+// scope above), so a single attempt is sufficient — no outer retry counter needed.
 let activityEnrichmentInFlight = false;
 let activityEnrichmentDone = false;
-// Bounded retry: fetchActivityPlaceIds swallows per-request errors and returns []
-// on a full network outage. Without a counter, the reactive trigger would retry in
-// a tight loop. Reset on area change.
-let activityEnrichmentAttempts = 0;
-const MAX_ACTIVITY_ATTEMPTS = 3;
 
 // The activity shim requests only id/osm_id/deleted_at; the returned objects don't
 // satisfy Place's required lat/lon/icon contract. Use a narrower type so the axios
@@ -214,28 +211,28 @@ const populateTaggersFromEvents = (placesForTaggers: ActivityPlace[]) => {
 };
 
 const enrichForActivity = async () => {
-	if (
-		activityEnrichmentInFlight ||
-		activityEnrichmentDone ||
-		activityEnrichmentAttempts >= MAX_ACTIVITY_ATTEMPTS ||
-		!filteredPlaces.length
-	)
+	if (activityEnrichmentInFlight || activityEnrichmentDone) return;
+
+	// Empty area: nothing to fetch; mark done so the UI falls through to
+	// the "No supertaggers" empty state instead of stalling on the skeleton.
+	if (!filteredPlaces.length) {
+		activityEnrichmentDone = true;
 		return;
+	}
+
 	activityEnrichmentInFlight = true;
-	activityEnrichmentAttempts++;
 	try {
 		const placesForTaggers = await fetchActivityPlaceIds(
 			filteredPlaces.map((p) => p.id),
 		);
 		populateTaggersFromEvents(placesForTaggers);
-		// Only lock as "done" when we actually got data. All-empty result with a
-		// non-empty filteredPlaces is the signature of a network failure (inner
-		// .catch swallows per-request errors and returns null); leave Done=false
-		// so the reactive trigger can retry up to MAX_ACTIVITY_ATTEMPTS times.
-		if (placesForTaggers.length > 0) {
-			activityEnrichmentDone = true;
-		}
 	} finally {
+		// Always mark done after a completed attempt. axiosRetry handles transient
+		// per-request failures internally; if everything still came back empty, that's
+		// a persistent failure and showing the empty state beats spinning forever.
+		// User can retry by navigating to a different area (the lastAreaId reactive
+		// resets activityEnrichmentDone).
+		activityEnrichmentDone = true;
 		activityEnrichmentInFlight = false;
 	}
 };
@@ -372,7 +369,6 @@ $: if (data?.id !== lastAreaId) {
 	dataInitialized = false;
 	activityEnrichmentInFlight = false;
 	activityEnrichmentDone = false;
-	activityEnrichmentAttempts = 0;
 	taggers = [];
 	filteredPlaces = [];
 }
@@ -392,8 +388,7 @@ $: if (
 	$events.length &&
 	$users.length &&
 	!activityEnrichmentInFlight &&
-	!activityEnrichmentDone &&
-	activityEnrichmentAttempts < MAX_ACTIVITY_ATTEMPTS
+	!activityEnrichmentDone
 ) {
 	enrichForActivity();
 }

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -220,20 +220,29 @@ const enrichForActivity = async () => {
 		return;
 	}
 
+	// Capture the area id at start. If the user navigates to a different area
+	// mid-fetch, the lastAreaId reactive resets our flags but cannot cancel an
+	// in-flight promise; without this guard the stale completion would overwrite
+	// the new area's taggers and stomp its inFlight flag.
+	const startAreaId = data.id;
 	activityEnrichmentInFlight = true;
 	try {
 		const placesForTaggers = await fetchActivityPlaceIds(
 			filteredPlaces.map((p) => p.id),
 		);
+		if (data.id !== startAreaId) return;
 		populateTaggersFromEvents(placesForTaggers);
 	} finally {
-		// Always mark done after a completed attempt. axiosRetry handles transient
-		// per-request failures internally; if everything still came back empty, that's
-		// a persistent failure and showing the empty state beats spinning forever.
-		// User can retry by navigating to a different area (the lastAreaId reactive
-		// resets activityEnrichmentDone).
-		activityEnrichmentDone = true;
-		activityEnrichmentInFlight = false;
+		// Only flip flags if we're still the current area. Stale completions return
+		// silently above; the new area's enrichForActivity owns its own inFlight.
+		// On the success path, marking Done lets the UI fall through to the empty
+		// state when the fetch produced nothing (axiosRetry already handles
+		// transient per-request failures). User can retry by navigating to a
+		// different area (the lastAreaId reactive resets activityEnrichmentDone).
+		if (data.id === startAreaId) {
+			activityEnrichmentDone = true;
+			activityEnrichmentInFlight = false;
+		}
 	}
 };
 

--- a/src/components/area/AreaStats.svelte
+++ b/src/components/area/AreaStats.svelte
@@ -5,15 +5,13 @@ import { _ } from "svelte-i18n";
 
 import Icon from "$components/Icon.svelte";
 import ProfileStat from "$components/ProfileStat.svelte";
-import { calcVerifiedDate, verifiedArr } from "$lib/map/setup";
 import { theme } from "$lib/theme";
-import type { AreaTags, Place, Report } from "$lib/types.js";
+import type { AreaTags, Report } from "$lib/types.js";
 import { updateChartThemes } from "$lib/utils";
 
 import { browser } from "$app/environment";
 
 export let name: string;
-export let filteredPlaces: Place[];
 export let areaReports: Report[];
 export let areaTags: AreaTags | undefined = undefined;
 
@@ -32,57 +30,17 @@ let dataInitialized = false;
 const initializeData = () => {
 	if (dataInitialized) return;
 
-	filteredPlaces.forEach((place) => {
-		// get date from 1 year ago to add verified check if survey is current
-		let verifiedDate = calcVerifiedDate();
-		let verified = verifiedArr(place);
-
-		if (verified.length && Date.parse(verified[0]) > verifiedDate) {
-			if (upToDate === undefined) {
-				upToDate = 1;
-			} else {
-				upToDate++;
-			}
-		} else {
-			if (outdated === undefined) {
-				outdated = 1;
-			} else {
-				outdated++;
-			}
-		}
-
-		if (place["osm:payment:bitcoin"]) {
-			if (legacy === undefined) {
-				legacy = 1;
-			} else {
-				legacy++;
-			}
-		}
-
-		if (total === undefined) {
-			total = 1;
-		} else {
-			total++;
-		}
-	});
-
-	if (!upToDate) {
-		upToDate = 0;
-	}
-
-	if (!outdated) {
-		outdated = 0;
-	}
-
-	if (!legacy) {
-		legacy = 0;
-	}
-
-	if (!total) {
-		total = 0;
-	}
-
-	upToDatePercent = upToDate ? (upToDate / (total / 100)).toFixed(0) : "0";
+	// Headline counts come straight from the latest report — the backend already
+	// aggregates total_elements / up_to_date_elements / legacy_elements /
+	// up_to_date_percent per area per day. No need to re-count client-side.
+	const latestReport = areaReports[0];
+	total = latestReport?.tags.total_elements ?? 0;
+	upToDate = latestReport?.tags.up_to_date_elements ?? 0;
+	legacy = latestReport?.tags.legacy_elements ?? 0;
+	outdated = Math.max(0, total - upToDate);
+	upToDatePercent = latestReport?.tags.up_to_date_percent
+		? latestReport.tags.up_to_date_percent.toFixed(0)
+		: "0";
 
 	const populateCharts = () => {
 		const chartsReports = [...areaReports].sort(
@@ -289,20 +247,8 @@ const initializeData = () => {
 	dataInitialized = true;
 };
 
-// Check if places have verification data (indicator that enrichment is complete)
-$: hasVerificationData =
-	filteredPlaces &&
-	filteredPlaces.length > 0 &&
-	filteredPlaces.some(
-		(p) =>
-			p["osm:survey:date"] ||
-			p["osm:check_date"] ||
-			p["osm:check_date:currency:XBT"],
-	);
-
-// Only initialize when we have verification data
-$: hasVerificationData &&
-	areaReports &&
+// Initialize once the report data is available and the canvases are mounted.
+$: areaReports?.length &&
 	initialRenderComplete &&
 	!dataInitialized &&
 	initializeData();

--- a/src/components/area/AreaStats.svelte
+++ b/src/components/area/AreaStats.svelte
@@ -37,7 +37,7 @@ const initializeData = () => {
 	total = latestReport?.tags.total_elements ?? 0;
 	upToDate = latestReport?.tags.up_to_date_elements ?? 0;
 	legacy = latestReport?.tags.legacy_elements ?? 0;
-	outdated = Math.max(0, total - upToDate);
+	outdated = latestReport?.tags.outdated_elements ?? 0;
 	upToDatePercent = latestReport?.tags.up_to_date_percent
 		? latestReport.tags.up_to_date_percent.toFixed(0)
 		: "0";

--- a/src/lib/api-fields.ts
+++ b/src/lib/api-fields.ts
@@ -68,6 +68,13 @@ export const PLACE_FIELD_SETS = {
 		"osm:payment:lightning",
 		"osm:payment:lightning_contactless",
 	] as const satisfies (keyof Place)[],
+	// Minimal fields for /activity tab's Supertaggers list — matches $events.element_id to
+	// place.osm_id. Interim shim: remove once the area-scoped top-editors REST endpoint ships.
+	ACTIVITY_AGGREGATE: [
+		"id",
+		"osm_id",
+		"deleted_at",
+	] as const satisfies (keyof Place)[],
 } as const;
 
 export const buildFieldsParam = (fields: readonly string[]) => fields.join(",");


### PR DESCRIPTION
## Testing: Compare the performance of i.e. these two
- https://deploy-preview-925--btcmap.netlify.app/country/de/merchants
- https://btcmap.org/country/de/merchants


## Further desc

The bulk fetchPlacesForArea() in AreaPage.svelte was firing ~7940 requests on every visit to /country/*/* (one /v4/places/{id} per place in the area, with the full COMPLETE_PLACE field set), even though only the /activity tab's Supertaggers list actually depends on a per-place field (osm_id) that isn't in the static places.json.

Changes:
- AreaStats reads total/up_to_date/legacy from the latest $reports entry instead of re-counting client-side over enriched places. Reports already carry these aggregates server-side.
- AreaMerchantHighlights "Latest Added" sorts by id DESC (SQLite rowid is monotonic with insert order) instead of created_at, removing the dependency on enriched data.
- AreaPage gates fetchPlacesForArea to activeSection === 'activity' with a per-section enriched flag and a reactive hook that fires on tab transitions. Field set trimmed to a new ACTIVITY_AGGREGATE (id, osm_id, deleted_at) — payload drops from ~40 fields to 3.

Net effect on cold cache:
- /merchants, /stats, /maintain: 0 per-place requests (was ~7940)
- /activity: same request count, ~95% smaller payload (interim shim until an area-scoped top-editors REST endpoint lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized activity view data loading to fetch only activity-relevant place data with a capped retry and run only on the activity tab.
  * Prevented cross-area state leakage by resetting area-scoped state on navigation.
  * Updated "latest" item ordering to use ID-based ranking.
  * Migrated area statistics to derive counts from server-provided reports instead of client-side place aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->