### PR TITLE
perf(area): replace per-place enrichment shim with API call

### DIFF
--- a/src/components/area/AreaActivity.svelte
+++ b/src/components/area/AreaActivity.svelte
@@ -11,6 +11,7 @@ export let alias: string;
 export let name: string;
 export let dataInitialized: boolean;
 export let taggers: Tagger[];
+export let taggersLoadError: boolean;
 
 let taggerCount = 25;
 $: taggersPaginated = taggers.slice(0, taggerCount);
@@ -64,6 +65,8 @@ let taggerDiv: HTMLDivElement;
 						</div>
 					{/each}
 				</div>
+			{:else if taggersLoadError}
+				<p class="p-5 text-center text-body dark:text-white">{$_(`areaActivity.supertaggersError`)}</p>
 			{:else}
 				<p class="p-5 text-center text-body dark:text-white">{$_(`areaActivity.noSupertaggers`)}</p>
 			{/if}

--- a/src/components/area/AreaActivity.svelte
+++ b/src/components/area/AreaActivity.svelte
@@ -3,14 +3,14 @@ import { _ } from "svelte-i18n";
 
 import AreaFeed from "$components/area/AreaFeed.svelte";
 import Icon from "$components/Icon.svelte";
-import type { User } from "$lib/types.js";
+import type { Tagger } from "$lib/types.js";
 
 import { resolve } from "$app/paths";
 
 export let alias: string;
 export let name: string;
 export let dataInitialized: boolean;
-export let taggers: User[];
+export let taggers: Tagger[];
 
 let taggerCount = 25;
 $: taggersPaginated = taggers.slice(0, taggerCount);
@@ -34,9 +34,7 @@ let taggerDiv: HTMLDivElement;
 						<div class="m-4 space-y-1 transition-transform hover:scale-110">
 							<a href={resolve(`/tagger/${tagger.id}`)}>
 								<img
-									src={tagger.osm_json.img
-										? tagger.osm_json.img.href
-										: '/images/satoshi-nakamoto.png'}
+									src={tagger.avatar_url ?? '/images/satoshi-nakamoto.png'}
 									alt={$_('aria.avatarAlt')}
 									class="mx-auto h-20 w-20 rounded-full object-cover"
 									on:error={function () {
@@ -44,9 +42,7 @@ let taggerDiv: HTMLDivElement;
 									}}
 								/>
 								<p class="text-center font-semibold text-body dark:text-white">
-									{tagger.osm_json.display_name.length > 21
-										? tagger.osm_json.display_name.slice(0, 18) + '...'
-										: tagger.osm_json.display_name}
+									{tagger.name.length > 21 ? tagger.name.slice(0, 18) + '...' : tagger.name}
 								</p>
 							</a>
 						</div>

--- a/src/components/area/AreaActivity.svelte
+++ b/src/components/area/AreaActivity.svelte
@@ -10,6 +10,7 @@ import { resolve } from "$app/paths";
 export let alias: string;
 export let name: string;
 export let dataInitialized: boolean;
+export let taggersLoaded: boolean;
 export let taggers: Tagger[];
 export let taggersLoadError: boolean;
 
@@ -56,7 +57,7 @@ let taggerDiv: HTMLDivElement;
 						on:click={() => (taggerCount = taggerCount + 25)}>{$_(`areaActivity.loadMore`)}</button
 					>
 				{/if}
-			{:else if !dataInitialized}
+			{:else if !taggersLoaded}
 				<div class="flex flex-wrap items-center justify-center">
 					{#each Array(5) as _, index (index)}
 						<div class="m-4 space-y-1 transition-transform hover:scale-110">

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -9,8 +9,6 @@ export let type: "country" | "community";
 export let data: AreaPageProps;
 
 import rewind from "@mapbox/geojson-rewind";
-import axios from "axios";
-import axiosRetry from "axios-retry";
 import { geoContains } from "d3-geo";
 import { differenceInMonths } from "date-fns/differenceInMonths";
 import { onMount } from "svelte";
@@ -30,18 +28,16 @@ import Socials from "$components/Socials.svelte";
 import SponsorBadge from "$components/SponsorBadge.svelte";
 import Tip from "$components/Tip.svelte";
 import { API_BASE } from "$lib/api-base";
-import { buildFieldsParam, PLACE_FIELD_SETS } from "$lib/api-fields";
+import api from "$lib/axios";
 import {
 	areaError,
 	areas,
 	eventError,
-	events,
 	places,
 	placesError,
 	reportError,
 	reports,
 	userError,
-	users,
 } from "$lib/store";
 import { areasSync } from "$lib/sync/areas";
 import { batchSync } from "$lib/sync/batchSync";
@@ -51,10 +47,9 @@ import { usersSync } from "$lib/sync/users";
 import type {
 	AreaPageProps,
 	AreaTags,
-	Event,
 	Place,
 	RpcIssue,
-	User,
+	Tagger,
 } from "$lib/types.js";
 import { TipType } from "$lib/types.js";
 import {
@@ -63,8 +58,6 @@ import {
 	parseDateSafely,
 	validateContinents,
 } from "$lib/utils";
-
-axiosRetry(axios, { retries: 3, retryDelay: axiosRetry.exponentialDelay });
 
 onMount(() => {
 	batchSync([areasSync, reportsSync, eventsSync, usersSync]);
@@ -128,121 +121,41 @@ const handleSectionChange = (section: Sections) => {
 // No need for hash handling anymore - sections are handled by route parameters
 
 let dataInitialized = false;
-// Two flags because the UI needs to know "has the enrichment actually finished",
-// while the reactive trigger needs to know "is it already running" — using a single
-// flag causes a flash of the empty-state message for the duration of fetch.
-// Per-request transient failures are handled by axiosRetry (configured at module
-// scope above), so a single attempt is sufficient — no outer retry counter needed.
-let activityEnrichmentInFlight = false;
-let activityEnrichmentDone = false;
+// Two flags: taggersInFlight prevents re-fire during the async fetch,
+// taggersLoaded gates the UI so the skeleton stays up until the fetch
+// completes. Per-request transient failures are handled by axiosRetry
+// on the shared $lib/axios instance, so a single attempt is sufficient.
+let taggersInFlight = false;
+let taggersLoaded = false;
 
-// The activity shim requests only id/osm_id/deleted_at; the returned objects don't
-// satisfy Place's required lat/lon/icon contract. Use a narrower type so the axios
-// generic and downstream signatures are honest.
-type ActivityPlace = Pick<Place, "id" | "osm_id" | "deleted_at">;
-
-// Fetch minimal per-place data for the area so the /activity tab's Supertaggers list
-// can match $events.element_id to place.osm_id. osm_id isn't in the static places.json
-// the global $places store is seeded from, so it has to come from the API. Interim
-// shim: once the area-scoped top-editors REST endpoint ships, this function + its
-// call site go away.
-const fetchActivityPlaceIds = async (
-	placeIds: number[],
-): Promise<ActivityPlace[]> => {
-	try {
-		const batchSize = 20;
-		const enriched: ActivityPlace[] = [];
-		const fieldsParam = buildFieldsParam(PLACE_FIELD_SETS.ACTIVITY_AGGREGATE);
-
-		for (let i = 0; i < placeIds.length; i += batchSize) {
-			const batch = placeIds.slice(i, i + batchSize);
-			const batchResults = await Promise.all(
-				batch.map((id) =>
-					axios
-						.get<ActivityPlace>(
-							`${API_BASE}/v4/places/${id}?fields=${fieldsParam}`,
-						)
-						.then((response) => response.data)
-						.catch((error) => {
-							console.warn(
-								`Failed to fetch place ${id}:`,
-								error.response?.status,
-							);
-							return null;
-						}),
-				),
-			);
-			for (const place of batchResults) {
-				if (place && !place.deleted_at) enriched.push(place);
-			}
-		}
-		return enriched;
-	} catch (error) {
-		console.error("Failed to fetch activity place ids:", error);
-		return [];
-	}
-};
-
-const populateTaggersFromEvents = (placesForTaggers: ActivityPlace[]) => {
-	if (!$events.length || !$users.length) return;
-
-	const placeOsmIds = new Set<string>();
-	for (const place of placesForTaggers) {
-		if (place.osm_id) placeOsmIds.add(place.osm_id);
-	}
-	const usersById = new Map<number, User>();
-	for (const user of $users) {
-		usersById.set(user.id, user);
-	}
-
-	const areaEvents = $events
-		.filter((event) => placeOsmIds.has(event.element_id))
-		.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at));
-
-	const seenUserIds = new Set<number>();
-	const newTaggers: User[] = [];
-	for (const event of areaEvents) {
-		if (seenUserIds.has(event.user_id)) continue;
-		const user = usersById.get(event.user_id);
-		if (!user) continue;
-		seenUserIds.add(event.user_id);
-		newTaggers.push(user);
-	}
-	taggers = newTaggers;
-};
-
-const enrichForActivity = async () => {
-	if (activityEnrichmentInFlight || activityEnrichmentDone) return;
-
-	// Empty area: nothing to fetch; mark done so the UI falls through to
-	// the "No supertaggers" empty state instead of stalling on the skeleton.
-	if (!filteredPlaces.length) {
-		activityEnrichmentDone = true;
-		return;
-	}
+const fetchAreaTopEditors = async () => {
+	if (taggersInFlight || taggersLoaded || !data?.id) return;
 
 	// Capture the area id at start. If the user navigates to a different area
 	// mid-fetch, the lastAreaId reactive resets our flags but cannot cancel an
-	// in-flight promise; without this guard the stale completion would overwrite
-	// the new area's taggers and stomp its inFlight flag.
+	// in-flight promise; without this guard the stale completion would
+	// overwrite the new area's taggers and stomp its loading state.
 	const startAreaId = data.id;
-	activityEnrichmentInFlight = true;
+	taggersInFlight = true;
 	try {
-		const placesForTaggers = await fetchActivityPlaceIds(
-			filteredPlaces.map((p) => p.id),
-		);
+		const url = `${API_BASE}/v4/areas/${encodeURIComponent(data.id)}/top-editors?limit=100`;
+		const response = await api.get<Tagger[]>(url);
 		if (data.id !== startAreaId) return;
-		populateTaggersFromEvents(placesForTaggers);
+		taggers = response.data;
+	} catch (error) {
+		if (data.id !== startAreaId) return;
+		console.warn("Failed to fetch area top editors:", error);
 	} finally {
-		// Only flip flags if we're still the current area. Stale completions return
-		// silently above; the new area's enrichForActivity owns its own inFlight.
-		// On the success path, marking Done lets the UI fall through to the empty
-		// state when the fetch produced nothing (axiosRetry already handles
-		// transient per-request failures). User can retry by navigating to a
-		// different area (the lastAreaId reactive resets activityEnrichmentDone).
+		// Only flip flags if we're still the current area. Stale completions
+		// return silently above; the new area's fetch owns its own state.
+		// Mark loaded after any completed attempt (success OR final failure
+		// after axiosRetry exhausts its retries) so the UI falls through to
+		// the empty state instead of hanging on the skeleton. User can retry
+		// by navigating to a different area (lastAreaId reactive resets
+		// taggersLoaded).
 		if (data.id === startAreaId) {
-			activityEnrichmentDone = true;
-			activityEnrichmentInFlight = false;
+			taggersLoaded = true;
+			taggersInFlight = false;
 		}
 	}
 };
@@ -377,30 +290,23 @@ let lastAreaId: string | undefined;
 $: if (data?.id !== lastAreaId) {
 	lastAreaId = data.id;
 	dataInitialized = false;
-	activityEnrichmentInFlight = false;
-	activityEnrichmentDone = false;
+	taggersInFlight = false;
+	taggersLoaded = false;
 	taggers = [];
 	filteredPlaces = [];
 }
 
 $: $areas?.length && $places?.length && !dataInitialized && initializeData();
 
-// Activity tab is the only section that needs per-place data beyond the static
-// places.json (it needs osm_id to match events to places). Fire enrichment only
-// when the user actually lands on /activity — merchants/stats/maintain don't need it.
-// Also wait for $events/$users to populate: batchSync runs them independently of
-// $areas/$places, so dataInitialized can flip true before events/users are ready,
-// and populateTaggersFromEvents would silently produce an empty list in that window.
+// Fire the area top-editors fetch only when the user actually lands on /activity.
+// One REST call replaces the previous per-place enrichment shim.
 $: if (
 	browser &&
-	dataInitialized &&
 	activeSection === Sections.activity &&
-	$events.length &&
-	$users.length &&
-	!activityEnrichmentInFlight &&
-	!activityEnrichmentDone
+	!taggersInFlight &&
+	!taggersLoaded
 ) {
-	enrichForActivity();
+	fetchAreaTopEditors();
 }
 
 // Calculate areaReports reactively based on data initialization and reports store
@@ -456,7 +362,7 @@ const calculateStaleness = (dateStr: string | undefined): boolean => {
 let isVerifiedDateStale: boolean = calculateStaleness(data.verifiedDate);
 let lightning: { destination: string; type: TipType } | undefined;
 
-let taggers: User[] = [];
+let taggers: Tagger[] = [];
 
 let issues: RpcIssue[] = [];
 </script>
@@ -649,7 +555,7 @@ let issues: RpcIssue[] = [];
 		<AreaActivity
 			{alias}
 			{name}
-			dataInitialized={dataInitialized && activityEnrichmentDone}
+			dataInitialized={dataInitialized && taggersLoaded}
 			{taggers}
 		/>
 	{:else if activeSection === Sections.maintain}

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -127,6 +127,7 @@ let dataInitialized = false;
 // on the shared $lib/axios instance, so a single attempt is sufficient.
 let taggersInFlight = false;
 let taggersLoaded = false;
+let taggersLoadError = false;
 
 const fetchAreaTopEditors = async () => {
 	if (taggersInFlight || taggersLoaded || !data?.id) return;
@@ -145,6 +146,7 @@ const fetchAreaTopEditors = async () => {
 	} catch (error) {
 		if (data.id !== startAreaId) return;
 		console.warn("Failed to fetch area top editors:", error);
+		taggersLoadError = true;
 	} finally {
 		// Only flip flags if we're still the current area. Stale completions
 		// return silently above; the new area's fetch owns its own state.
@@ -292,6 +294,7 @@ $: if (data?.id !== lastAreaId) {
 	dataInitialized = false;
 	taggersInFlight = false;
 	taggersLoaded = false;
+	taggersLoadError = false;
 	taggers = [];
 	filteredPlaces = [];
 }
@@ -557,6 +560,7 @@ let issues: RpcIssue[] = [];
 			{name}
 			dataInitialized={dataInitialized && taggersLoaded}
 			{taggers}
+			{taggersLoadError}
 		/>
 	{:else if activeSection === Sections.maintain}
 		<IssuesTable

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -121,41 +121,44 @@ const handleSectionChange = (section: Sections) => {
 // No need for hash handling anymore - sections are handled by route parameters
 
 let dataInitialized = false;
-// Two flags: taggersInFlight prevents re-fire during the async fetch,
-// taggersLoaded gates the UI so the skeleton stays up until the fetch
-// completes. Per-request transient failures are handled by axiosRetry
-// on the shared $lib/axios instance, so a single attempt is sufficient.
+// taggersInFlight prevents re-fire during the async fetch; taggersLoaded
+// gates the UI so the skeleton stays up until the fetch completes. Per-
+// request transient failures are handled by axiosRetry on the shared
+// $lib/axios instance, so a single attempt is sufficient.
+// taggersFetchGeneration is a monotonic request token: each fetch
+// captures the current value and later compares it to discard its result
+// if a newer fetch has since started (including same-area re-entry,
+// which an area-id guard cannot distinguish).
 let taggersInFlight = false;
 let taggersLoaded = false;
 let taggersLoadError = false;
+let taggersFetchGeneration = 0;
 
 const fetchAreaTopEditors = async () => {
 	if (taggersInFlight || taggersLoaded || !data?.id) return;
 
-	// Capture the area id at start. If the user navigates to a different area
-	// mid-fetch, the lastAreaId reactive resets our flags but cannot cancel an
-	// in-flight promise; without this guard the stale completion would
-	// overwrite the new area's taggers and stomp its loading state.
-	const startAreaId = data.id;
+	// Capture a monotonic token at start. The lastAreaId reactive cannot
+	// cancel an in-flight promise, and an area-id guard alone would miss
+	// same-area re-entry (A→B→A leaves two A fetches pending with matching
+	// ids). The token distinguishes them so stale completions return silently.
+	const gen = ++taggersFetchGeneration;
 	taggersInFlight = true;
 	try {
 		const url = `${API_BASE}/v4/areas/${encodeURIComponent(data.id)}/top-editors?limit=100`;
 		const response = await api.get<Tagger[]>(url);
-		if (data.id !== startAreaId) return;
+		if (gen !== taggersFetchGeneration) return;
 		taggers = response.data;
 	} catch (error) {
-		if (data.id !== startAreaId) return;
+		if (gen !== taggersFetchGeneration) return;
 		console.warn("Failed to fetch area top editors:", error);
 		taggersLoadError = true;
 	} finally {
-		// Only flip flags if we're still the current area. Stale completions
-		// return silently above; the new area's fetch owns its own state.
-		// Mark loaded after any completed attempt (success OR final failure
-		// after axiosRetry exhausts its retries) so the UI falls through to
-		// the empty state instead of hanging on the skeleton. User can retry
-		// by navigating to a different area (lastAreaId reactive resets
-		// taggersLoaded).
-		if (data.id === startAreaId) {
+		// Only flip flags if this is still the most recent fetch. Stale
+		// completions return silently above; the newer fetch owns its own
+		// state. Mark loaded after any completed attempt (success OR final
+		// failure after axiosRetry exhausts its retries) so the UI falls
+		// through to the empty state instead of hanging on the skeleton.
+		if (gen === taggersFetchGeneration) {
 			taggersLoaded = true;
 			taggersInFlight = false;
 		}
@@ -295,6 +298,10 @@ $: if (data?.id !== lastAreaId) {
 	taggersInFlight = false;
 	taggersLoaded = false;
 	taggersLoadError = false;
+	// Invalidate any in-flight fetch so its completion can't stomp the new
+	// area's state even if we cross sections and the fetch reactive doesn't
+	// re-fire to bump the token on its own.
+	taggersFetchGeneration++;
 	taggers = [];
 	filteredPlaces = [];
 }

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -558,7 +558,8 @@ let issues: RpcIssue[] = [];
 		<AreaActivity
 			{alias}
 			{name}
-			dataInitialized={dataInitialized && taggersLoaded}
+			{dataInitialized}
+			{taggersLoaded}
 			{taggers}
 			{taggersLoadError}
 		/>

--- a/src/lib/api-fields.ts
+++ b/src/lib/api-fields.ts
@@ -68,13 +68,6 @@ export const PLACE_FIELD_SETS = {
 		"osm:payment:lightning",
 		"osm:payment:lightning_contactless",
 	] as const satisfies (keyof Place)[],
-	// Minimal fields for /activity tab's Supertaggers list — matches $events.element_id to
-	// place.osm_id. Interim shim: remove once the area-scoped top-editors REST endpoint ships.
-	ACTIVITY_AGGREGATE: [
-		"id",
-		"osm_id",
-		"deleted_at",
-	] as const satisfies (keyof Place)[],
 } as const;
 
 export const buildFieldsParam = (fields: readonly string[]) => fields.join(",");

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -457,6 +457,7 @@
 		"supertaggersTitle": "Супертагъри на {name}",
 		"activityTitle": "Активност на {name}",
 		"noSupertaggers": "Няма супертагъри за показване.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"supertaggers": "Супертагъри",
 		"loadMore": "Зареди още",
 		"activity": "Активност",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -680,6 +680,7 @@
 		"supertaggers": "Supertagger",
 		"loadMore": "Mehr laden",
 		"noSupertaggers": "Keine Supertagger anzuzeigen.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"activity": "Aktivität",
 		"noActivity": "Keine Aktivität anzuzeigen.",
 		"atomFeeds": "Atom Feeds",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -740,6 +740,7 @@
 		"supertaggers": "Supertaggers",
 		"loadMore": "Load More",
 		"noSupertaggers": "No supertaggers to display.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"activity": "Activity",
 		"noActivity": "No activity to display.",
 		"loadError": "Failed to load activity.",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -680,6 +680,7 @@
 		"supertaggers": "Supertaggers",
 		"loadMore": "Cargar Más",
 		"noSupertaggers": "No hay supertaggers para mostrar.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"activity": "Actividad",
 		"noActivity": "No hay actividad para mostrar.",
 		"atomFeeds": "Feeds Atom",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -680,6 +680,7 @@
 		"supertaggers": "Supertaggers",
 		"loadMore": "Charger plus",
 		"noSupertaggers": "Aucun supertagger à afficher.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"activity": "Activité",
 		"noActivity": "Aucune activité à afficher.",
 		"atomFeeds": "Flux Atom",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -684,6 +684,7 @@
 		"supertaggers": "Supertaggers",
 		"loadMore": "Laad meer",
 		"noSupertaggers": "Er zijn geen supertaggers om weer te geven.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"activity": "Activiteit",
 		"noActivity": "Geen activiteit om weer te geven.",
 		"atomFeeds": "Atoomvoedingen",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -673,6 +673,7 @@
 		"supertaggers": "Supertaggers",
 		"loadMore": "Carregar Mais",
 		"noSupertaggers": "Nenhum supertagger para exibir.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"activity": "Atividade",
 		"noActivity": "Nenhuma atividade para exibir.",
 		"atomFeeds": "Feeds Atom",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -680,6 +680,7 @@
 		"supertaggers": "Редакторы",
 		"loadMore": "Загрузить ещё",
 		"noSupertaggers": "Нет редакторов для отображения.",
+		"supertaggersError": "Couldn't load top editors. Please try again later.",
 		"activity": "Активность",
 		"noActivity": "Нет активности для отображения.",
 		"atomFeeds": "Atom ленты",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -265,6 +265,19 @@ export type User = {
 	deleted_at: string;
 };
 
+// Response shape of GET /v4/areas/{id}/top-editors and /v4/top-editors.
+// Used by the Supertaggers list on /country|community/*/activity pages.
+export type Tagger = {
+	id: number;
+	name: string;
+	avatar_url: string | null;
+	total_edits: number;
+	places_created: number;
+	places_updated: number;
+	places_deleted: number;
+	tip_url: string | null;
+};
+
 // FRONTEND
 
 // leaflet


### PR DESCRIPTION
Blocked by: https://github.com/teambtcmap/btcmap-api/pull/86

  Full journey from where we started:

 | Metric | Before | After PR #925 (shim) | After this PR (REST) |
  | --- | --- | --- | --- |
  | `/merchants` per-place requests | ~7940 | 0 | 0 |
  | `/stats` per-place requests | ~7940 | 0 | 0 |
  | `/activity` per-place requests | ~7940 | ~600 (3-field) | **1** |
  | `/maintain` per-place requests | ~7940 | 0 | 0 |
## Desc

The /activity tab's Supertaggers list was built by fetching osm_id for every place in the area (~600 requests for Germany, ~7940 for the US) and matching against the events store client-side. This was an interim shim pending a server-side endpoint.

With GET /v4/areas/{id}/top-editors now available, replace the entire shim with a single REST call that returns pre-aggregated editor data.

Changes:
- AreaPage.svelte: delete fetchActivityPlaceIds, populateTaggersFromEvents, enrichForActivity, ActivityPlace type, and all activityEnrichment* flags. Add fetchAreaTopEditors that hits the new endpoint via $lib/axios (with axiosRetry for transients) and the same stale-area guard via captured startAreaId. Reactive trigger simplified (no longer needs $events/$users stores to be populated first).
- AreaActivity.svelte: accept Tagger[] instead of User[], render flat tagger.name and tagger.avatar_url instead of tagger.osm_json.*.
- types.ts: add Tagger type matching the /v4/areas/{id}/top-editors response shape.
- api-fields.ts: remove ACTIVITY_AGGREGATE field set (no longer used).

Net effect on /country/*/activity:
- Before: ~N per-place requests (one GET /v4/places/{id} per place, batched 20-at-a-time, with 3-field payload)
- After: 1 request (GET /v4/areas/{id}/top-editors?limit=100)

Verified against local btcmap-api via the Vite dev proxy on :5001.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows a localized error message when top editors fail to load.

* **Bug Fixes**
  * Improved avatar selection and editor name truncation in the activity list.
  * Better empty/error state handling for the top-editors section.

* **Chores**
  * Simplified and sped up activity tab data loading to reduce duplicate requests and improve responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->