### PR TITLE
feat(user-activity): add activity-type filter chips

### DIFF
--- a/src/components/activity/ActivityCard.svelte
+++ b/src/components/activity/ActivityCard.svelte
@@ -60,12 +60,14 @@ export let highlight = false;
 					>
 						{item.place_name || item.place_id}
 					</a>
-					{$_("areaActivity.commented")}
-					<span class="italic"
-						>"{item.comment && item.comment.length > 80
-							? item.comment.slice(0, 77) + "..."
-							: item.comment}"</span
-					>
+					{#if item.comment}
+						{$_("areaActivity.commented")}
+						<span class="italic"
+							>"{item.comment.length > 80
+								? item.comment.slice(0, 77) + "..."
+								: item.comment}"</span
+						>
+					{/if}
 				{:else if item.type === "place_boosted"}
 					<Icon
 						type="fa"

--- a/src/components/activity/ActivityCard.svelte
+++ b/src/components/activity/ActivityCard.svelte
@@ -2,6 +2,7 @@
 import Time from "svelte-time";
 
 import Icon from "$components/Icon.svelte";
+import SaveButton from "$components/SaveButton.svelte";
 import { type ActivityItem, dotColor } from "$lib/activity";
 import { _ } from "$lib/i18n";
 
@@ -11,6 +12,11 @@ export let item: ActivityItem;
 // When true, the outer ping-dot animates. Intended for the newest
 // (top-of-list) card so the feed has a single pulse of visual motion.
 export let highlight = false;
+
+// The feed is a discovery surface: most cards reference places the
+// viewer hasn't individually saved. Offer a save action on every
+// non-deleted event so users can capture places straight from the feed.
+$: showSaveButton = item.type !== "place_deleted";
 </script>
 
 <div
@@ -94,5 +100,17 @@ export let highlight = false;
 				<Time live={3000} relative timestamp={item.date} />
 			</span>
 		</div>
+
+		<!-- TODO(perf): SaveButton subscribes to $session and mounts a
+			SaveAuthPrompt per card, which is wasteful in long feeds
+			(especially AreaFeed after several load-more clicks). If a
+			real user reports lag at big sizes, switch to a lighter
+			list-context pattern: parent precomputes a
+			`Set<number>` of saved-place ids, passes `saved` + an
+			`onToggle(id)` handler to each card, and hoists a single
+			shared <SaveAuthPrompt> to the feed level. -->
+		{#if showSaveButton}
+			<SaveButton id={item.place_id} type="place" class="!mx-0 shrink-0" />
+		{/if}
 	</div>
 </div>

--- a/src/components/activity/ActivityCard.svelte
+++ b/src/components/activity/ActivityCard.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+import Time from "svelte-time";
+
+import Icon from "$components/Icon.svelte";
+import { type ActivityItem, dotColor } from "$lib/activity";
+import { _ } from "$lib/i18n";
+
+import { resolve } from "$app/paths";
+
+export let item: ActivityItem;
+// When true, the outer ping-dot animates. Intended for the newest
+// (top-of-list) card so the feed has a single pulse of visual motion.
+export let highlight = false;
+</script>
+
+<div
+	class="flex flex-col items-center gap-2 p-5 text-center text-xl lg:flex-row lg:gap-5 lg:text-left"
+>
+	<span class="relative mx-auto mb-2 flex h-3 w-3 lg:mx-0 lg:mb-0">
+		<span
+			class="{highlight
+				? 'animate-ping'
+				: ''} absolute inline-flex h-full w-full rounded-full {dotColor(item.type)} opacity-75"
+		/>
+		<span class="relative inline-flex h-3 w-3 rounded-full {dotColor(item.type)}" />
+	</span>
+
+	<div class="w-full flex-wrap items-center justify-between space-y-2 lg:flex lg:space-y-0">
+		<div class="space-y-2 lg:space-y-0">
+			<span class="text-primary lg:mr-5 dark:text-white">
+				{#if item.type === "place_added" || item.type === "place_updated" || item.type === "place_deleted"}
+					<a
+						href={resolve(`/merchant/${item.place_id}`)}
+						class="break-all text-link transition-colors hover:text-hover"
+					>
+						{item.place_name || item.place_id}
+					</a>
+					{$_("areaActivity.was")}
+					<strong
+						>{item.type === "place_added"
+							? $_("areaActivity.created")
+							: item.type === "place_deleted"
+								? $_("areaActivity.deleted")
+								: $_("areaActivity.updated")}</strong
+					>
+					{#if item.osm_user_id && item.osm_user_name}
+						{$_("areaActivity.by")}
+						<a
+							href={resolve(`/tagger/${item.osm_user_id}`)}
+							class="break-all text-link transition-colors hover:text-hover"
+						>
+							{item.osm_user_name}
+						</a>
+					{/if}
+				{:else if item.type === "place_commented"}
+					<Icon type="fa" icon="comment" w="16" h="16" class="mr-1 inline align-middle" />
+					<a
+						href={resolve(`/merchant/${item.place_id}`)}
+						class="break-all text-link transition-colors hover:text-hover"
+					>
+						{item.place_name || item.place_id}
+					</a>
+					{$_("areaActivity.commented")}
+					<span class="italic"
+						>"{item.comment && item.comment.length > 80
+							? item.comment.slice(0, 77) + "..."
+							: item.comment}"</span
+					>
+				{:else if item.type === "place_boosted"}
+					<Icon
+						type="fa"
+						icon="bolt"
+						w="16"
+						h="16"
+						class="mr-1 inline align-middle text-orange-500"
+					/>
+					<a
+						href={resolve(`/merchant/${item.place_id}`)}
+						class="break-all text-link transition-colors hover:text-hover"
+					>
+						{item.place_name || item.place_id}
+					</a>
+					{$_("areaActivity.was")}
+					<strong>{$_("areaActivity.boosted")}</strong>
+					{#if item.duration_days != null}
+						{$_("areaActivity.forDays", { values: { days: item.duration_days } })}
+					{/if}
+				{/if}
+			</span>
+
+			<span class="block text-center font-semibold text-taggerTime lg:inline dark:text-white/70">
+				<Time live={3000} relative timestamp={item.date} />
+			</span>
+		</div>
+	</div>
+</div>

--- a/src/components/activity/ActivityTypeFilter.svelte
+++ b/src/components/activity/ActivityTypeFilter.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+import { createEventDispatcher } from "svelte";
+
+import {
+	ACTIVITY_TYPES,
+	type ActivityType,
+	dotColor,
+	TYPE_LABEL_KEYS,
+} from "$lib/activity";
+import { _ } from "$lib/i18n";
+
+export let activeTypes: Set<ActivityType>;
+export let counts: Record<ActivityType, number>;
+// When false, the trailing "(N)" suffix on each chip is hidden. Used
+// during the first feed fetch where counts are uniformly zero and
+// would otherwise misleadingly imply "nothing to filter".
+export let showCounts = true;
+
+const dispatch = createEventDispatcher<{ change: undefined }>();
+
+function toggle(type: ActivityType) {
+	const next = new Set(activeTypes);
+	if (next.has(type)) next.delete(type);
+	else next.add(type);
+	activeTypes = next;
+	dispatch("change");
+}
+</script>
+
+<div class="flex flex-wrap items-center justify-center gap-2">
+	{#each ACTIVITY_TYPES as type (type)}
+		{@const active = activeTypes.has(type)}
+		<button
+			type="button"
+			aria-pressed={active}
+			on:click={() => toggle(type)}
+			class="flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors {active
+				? 'border-link bg-link/10 text-primary dark:border-link dark:text-white'
+				: 'border-gray-300 text-body/60 hover:border-link hover:text-body dark:border-white/20 dark:text-white/50 dark:hover:text-white'}"
+		>
+			<span class="h-2 w-2 rounded-full {dotColor(type)}" />
+			<span>{$_(TYPE_LABEL_KEYS[type])}</span>
+			{#if showCounts}
+				<span class="text-xs opacity-70">({counts[type]})</span>
+			{/if}
+		</button>
+	{/each}
+</div>

--- a/src/components/activity/ActivityTypeFilter.svelte
+++ b/src/components/activity/ActivityTypeFilter.svelte
@@ -34,7 +34,7 @@ function toggle(type: ActivityType) {
 			type="button"
 			aria-pressed={active}
 			on:click={() => toggle(type)}
-			class="flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors {active
+			class="flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-link focus-visible:ring-offset-1 dark:focus-visible:ring-offset-dark {active
 				? 'border-link bg-link/10 text-primary dark:border-link dark:text-white'
 				: 'border-gray-300 text-body/60 hover:border-link hover:text-body dark:border-white/20 dark:text-white/50 dark:hover:text-white'}"
 		>

--- a/src/components/activity/ActivityTypeFilter.svelte
+++ b/src/components/activity/ActivityTypeFilter.svelte
@@ -9,6 +9,16 @@ import {
 } from "$lib/activity";
 import { _ } from "$lib/i18n";
 
+// activeTypes is intended for two-way binding: `bind:activeTypes` in
+// the parent. The component reassigns the Set on each toggle, so the
+// parent's binding always sees the new value.
+//
+// A `change` event is dispatched on every toggle as a *separate*
+// channel — consumers that only care about "user changed the filter,
+// run a side effect" (e.g. resetting pagination) can `on:change`
+// without adding a reactive dependency on activeTypes. Svelte 4 has
+// no clean single-channel way to express "run a side effect when a
+// bound prop is written", hence the two-channel API.
 export let activeTypes: Set<ActivityType>;
 export let counts: Record<ActivityType, number>;
 // When false, the trailing "(N)" suffix on each chip is hidden. Used

--- a/src/components/area/AreaFeed.svelte
+++ b/src/components/area/AreaFeed.svelte
@@ -75,6 +75,10 @@ const loadMore = () => {
 	});
 };
 
+// Fresh-slate whenever the user navigates between areas: reset the
+// window size, drop buffered items, re-enable every activity type (so
+// a previous area's toggle state doesn't silently hide cards on the
+// new one), clear error/arrow indicators, and kick off the first fetch.
 $: if (dataInitialized && alias) {
 	days = DAYS_PER_PAGE;
 	feedItems = [];

--- a/src/components/area/AreaFeed.svelte
+++ b/src/components/area/AreaFeed.svelte
@@ -2,9 +2,15 @@
 import { _ } from "svelte-i18n";
 
 import ActivityCard from "$components/activity/ActivityCard.svelte";
+import ActivityTypeFilter from "$components/activity/ActivityTypeFilter.svelte";
 import Icon from "$components/Icon.svelte";
 import TaggerSkeleton from "$components/TaggerSkeleton.svelte";
-import type { ActivityItem } from "$lib/activity";
+import {
+	ACTIVITY_TYPES,
+	type ActivityItem,
+	type ActivityType,
+	countByType,
+} from "$lib/activity";
 import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
 
@@ -15,12 +21,20 @@ export let dataInitialized: boolean;
 const DAYS_PER_PAGE = 30;
 
 let feedItems: ActivityItem[] = [];
+let activeTypes: Set<ActivityType> = new Set(ACTIVITY_TYPES);
 let loading = false;
 let error = false;
 let feedDiv: HTMLDivElement;
 let hideArrow = false;
 let days = DAYS_PER_PAGE;
 let fetchGeneration = 0;
+
+$: typeCounts = countByType(feedItems);
+$: visibleItems = feedItems.filter((i) => activeTypes.has(i.type));
+// Hide the "(0)" chip suffix during the first fetch while typeCounts
+// is uniformly zero — otherwise every chip reads "(0)" as if there
+// were nothing to filter.
+$: showChipCounts = !(loading && !feedItems.length);
 
 const fetchFeed = async () => {
 	loading = true;
@@ -64,6 +78,7 @@ const loadMore = () => {
 $: if (dataInitialized && alias) {
 	days = DAYS_PER_PAGE;
 	feedItems = [];
+	activeTypes = new Set(ACTIVITY_TYPES);
 	error = false;
 	hideArrow = false;
 	fetchFeed();
@@ -78,6 +93,16 @@ $: if (dataInitialized && alias) {
 			{name || $_(`areaStats.defaultAreaName`)} {$_(`areaActivity.activity`)}
 		</h3>
 
+		{#if feedItems.length}
+			<div class="border-b border-gray-300 p-3 dark:border-white/95">
+				<ActivityTypeFilter
+					bind:activeTypes
+					counts={typeCounts}
+					showCounts={showChipCounts}
+				/>
+			</div>
+		{/if}
+
 		<div
 			bind:this={feedDiv}
 			class="hide-scroll relative max-h-[375px] space-y-2 overflow-y-scroll"
@@ -88,9 +113,19 @@ $: if (dataInitialized && alias) {
 			}}
 		>
 			{#if feedItems.length}
-				{#each feedItems as item, i (item.type + '-' + item.place_id + '-' + item.date + '-' + i)}
-					<ActivityCard {item} highlight={i === 0} />
-				{/each}
+				{#if !activeTypes.size}
+					<p class="p-5 text-center text-body dark:text-white">
+						{$_("userActivity.noTypesSelected")}
+					</p>
+				{:else if !visibleItems.length}
+					<p class="p-5 text-center text-body dark:text-white">
+						{$_("userActivity.noMatchingTypes")}
+					</p>
+				{:else}
+					{#each visibleItems as item, i (item.type + '-' + item.place_id + '-' + item.date + '-' + i)}
+						<ActivityCard {item} highlight={i === 0} />
+					{/each}
+				{/if}
 
 				{#if error}
 					<p class="mx-auto !mb-2 text-center text-body dark:text-white">
@@ -112,7 +147,7 @@ $: if (dataInitialized && alias) {
 					{loading ? $_(`areaActivity.loadMore`) + '...' : $_(`areaActivity.loadMore`)}
 				</button>
 
-				{#if !hideArrow && feedItems.length > 5}
+				{#if !hideArrow && visibleItems.length > 5}
 					<Icon
 						type="fa"
 						icon="chevron-down"

--- a/src/components/area/AreaFeed.svelte
+++ b/src/components/area/AreaFeed.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
 import { _ } from "svelte-i18n";
-import Time from "svelte-time";
 
+import ActivityCard from "$components/activity/ActivityCard.svelte";
 import Icon from "$components/Icon.svelte";
 import TaggerSkeleton from "$components/TaggerSkeleton.svelte";
-import { type ActivityItem, dotColor } from "$lib/activity";
+import type { ActivityItem } from "$lib/activity";
 import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
-
-import { resolve } from "$app/paths";
 
 export let alias: string;
 export let name: string;
@@ -91,89 +89,7 @@ $: if (dataInitialized && alias) {
 		>
 			{#if feedItems.length}
 				{#each feedItems as item, i (item.type + '-' + item.place_id + '-' + item.date + '-' + i)}
-					<div
-						class="flex flex-col items-center gap-2 p-5 text-center text-xl lg:flex-row lg:gap-5 lg:text-left"
-					>
-						<!-- dot -->
-						<span class="relative mx-auto mb-2 flex h-3 w-3 lg:mx-0 lg:mb-0">
-							<span
-								class="{i === 0 ? 'animate-ping' : ''} absolute inline-flex h-full w-full rounded-full {dotColor(item.type)} opacity-75"
-							/>
-							<span class="relative inline-flex h-3 w-3 rounded-full {dotColor(item.type)}" />
-						</span>
-
-						<div
-							class="w-full flex-wrap items-center justify-between space-y-2 lg:flex lg:space-y-0"
-						>
-							<div class="space-y-2 lg:space-y-0">
-								<span class="text-primary lg:mr-5 dark:text-white">
-									{#if item.type === 'place_added' || item.type === 'place_updated' || item.type === 'place_deleted'}
-										<a
-											href={resolve(`/merchant/${item.place_id}`)}
-											class="break-all text-link transition-colors hover:text-hover"
-										>
-											{item.place_name || item.place_id}
-										</a>
-										{$_('areaActivity.was')} <strong
-											>{item.type === 'place_added'
-												? $_('areaActivity.created')
-												: item.type === 'place_deleted'
-													? $_('areaActivity.deleted')
-													: $_('areaActivity.updated')}</strong
-										>
-										{#if item.osm_user_id && item.osm_user_name}
-											{$_('areaActivity.by')} <a
-												href={resolve(`/tagger/${item.osm_user_id}`)}
-												class="break-all text-link transition-colors hover:text-hover"
-											>
-												{item.osm_user_name}
-											</a>
-										{/if}
-									{:else if item.type === 'place_commented'}
-										<Icon
-											type="fa"
-											icon="comment"
-											w="16"
-											h="16"
-											class="mr-1 inline align-middle"
-										/>
-										<a
-											href={resolve(`/merchant/${item.place_id}`)}
-											class="break-all text-link transition-colors hover:text-hover"
-										>
-											{item.place_name || item.place_id}
-										</a>
-										{$_('areaActivity.commented')} <span class="italic"
-											>"{item.comment && item.comment.length > 80
-												? item.comment.slice(0, 77) + '...'
-												: item.comment}"</span
-										>
-									{:else if item.type === 'place_boosted'}
-										<Icon
-											type="fa"
-											icon="bolt"
-											w="16"
-											h="16"
-											class="mr-1 inline align-middle text-orange-500"
-										/>
-										<a
-											href={resolve(`/merchant/${item.place_id}`)}
-											class="break-all text-link transition-colors hover:text-hover"
-										>
-											{item.place_name || item.place_id}
-										</a>
-										{$_('areaActivity.was')} <strong>{$_('areaActivity.boosted')}</strong> {$_('areaActivity.forDays', { values: { days: item.duration_days } })}
-									{/if}
-								</span>
-
-								<span
-									class="block text-center font-semibold text-taggerTime lg:inline dark:text-white/70"
-								>
-									<Time live={3000} relative timestamp={item.date} />
-								</span>
-							</div>
-						</div>
-					</div>
+					<ActivityCard {item} highlight={i === 0} />
 				{/each}
 
 				{#if error}

--- a/src/components/area/AreaFeed.svelte
+++ b/src/components/area/AreaFeed.svelte
@@ -4,6 +4,7 @@ import Time from "svelte-time";
 
 import Icon from "$components/Icon.svelte";
 import TaggerSkeleton from "$components/TaggerSkeleton.svelte";
+import { type ActivityItem, dotColor } from "$lib/activity";
 import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
 
@@ -13,28 +14,7 @@ export let alias: string;
 export let name: string;
 export let dataInitialized: boolean;
 
-type ActivityItem = {
-	type: string;
-	place_id: number;
-	place_name?: string;
-	osm_user_id?: number;
-	osm_user_name?: string;
-	comment?: string;
-	duration_days?: number;
-	date: string;
-};
-
 const DAYS_PER_PAGE = 30;
-
-const DOT_COLORS: Record<string, string> = {
-	place_commented: "bg-amber-500",
-	place_boosted: "bg-orange-500",
-	place_added: "bg-created",
-	place_deleted: "bg-deleted",
-	place_updated: "bg-link",
-};
-
-const dotColor = (type: string) => DOT_COLORS[type] ?? "bg-link";
 
 let feedItems: ActivityItem[] = [];
 let loading = false;

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -47,8 +47,7 @@ export const TYPE_LABEL_KEYS: Record<ActivityType, string> = {
 	place_boosted: "userActivity.typeBoosted",
 };
 
-export const dotColor = (type: ActivityType): string =>
-	DOT_COLORS[type] ?? "bg-link";
+export const dotColor = (type: ActivityType): string => DOT_COLORS[type];
 
 export function emptyTypeCounts(): Record<ActivityType, number> {
 	return {

--- a/src/lib/activity.ts
+++ b/src/lib/activity.ts
@@ -1,0 +1,69 @@
+// Shared domain types, constants, and helpers for the place-activity
+// feed. Consumed by:
+// - src/routes/user/activity/+page.svelte (combined saved-items feed)
+// - src/components/area/AreaFeed.svelte (per-area feed)
+// - src/components/activity/ActivityCard.svelte (single-item renderer)
+// - src/components/activity/ActivityTypeFilter.svelte (chip row)
+
+export type ActivityType =
+	| "place_added"
+	| "place_updated"
+	| "place_deleted"
+	| "place_commented"
+	| "place_boosted";
+
+export type ActivityItem = {
+	type: ActivityType;
+	place_id: number;
+	place_name?: string;
+	osm_user_id?: number;
+	osm_user_name?: string;
+	comment?: string;
+	duration_days?: number;
+	date: string;
+};
+
+export const ACTIVITY_TYPES: ActivityType[] = [
+	"place_added",
+	"place_updated",
+	"place_deleted",
+	"place_commented",
+	"place_boosted",
+];
+
+export const DOT_COLORS: Record<ActivityType, string> = {
+	place_commented: "bg-amber-500",
+	place_boosted: "bg-orange-500",
+	place_added: "bg-created",
+	place_deleted: "bg-deleted",
+	place_updated: "bg-link",
+};
+
+export const TYPE_LABEL_KEYS: Record<ActivityType, string> = {
+	place_added: "userActivity.typeAdded",
+	place_updated: "userActivity.typeUpdated",
+	place_deleted: "userActivity.typeDeleted",
+	place_commented: "userActivity.typeCommented",
+	place_boosted: "userActivity.typeBoosted",
+};
+
+export const dotColor = (type: ActivityType): string =>
+	DOT_COLORS[type] ?? "bg-link";
+
+export function emptyTypeCounts(): Record<ActivityType, number> {
+	return {
+		place_added: 0,
+		place_updated: 0,
+		place_deleted: 0,
+		place_commented: 0,
+		place_boosted: 0,
+	};
+}
+
+export function countByType(
+	items: readonly ActivityItem[],
+): Record<ActivityType, number> {
+	const counts = emptyTypeCounts();
+	for (const item of items) counts[item.type]++;
+	return counts;
+}

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -69,7 +69,8 @@
 		"typeDeleted": "Deleted",
 		"typeCommented": "Commented",
 		"typeBoosted": "Boosted",
-		"noTypesSelected": "Select at least one activity type above"
+		"noTypesSelected": "Select at least one activity type above",
+		"noMatchingTypes": "No activity matches your selected types."
 	},
 	"login": {
 		"title": "Log in",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -63,7 +63,13 @@
 		"filterAreas": "Areas",
 		"placeFallback": "Place {id}",
 		"areaFallback": "Area {id}",
-		"timeWindow": "Showing activity from the last {days} days"
+		"timeWindow": "Showing activity from the last {days} days",
+		"typeAdded": "Added",
+		"typeUpdated": "Updated",
+		"typeDeleted": "Deleted",
+		"typeCommented": "Commented",
+		"typeBoosted": "Boosted",
+		"noTypesSelected": "Select at least one activity type above"
 	},
 	"login": {
 		"title": "Log in",

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -2,6 +2,7 @@
 import { onMount } from "svelte";
 
 import ActivityCard from "$components/activity/ActivityCard.svelte";
+import ActivityTypeFilter from "$components/activity/ActivityTypeFilter.svelte";
 import type { FormSelectOption } from "$components/form/FormSelect.svelte";
 import FormSelect from "$components/form/FormSelect.svelte";
 import Icon from "$components/Icon.svelte";
@@ -10,8 +11,6 @@ import {
 	type ActivityItem,
 	type ActivityType,
 	countByType,
-	dotColor,
-	TYPE_LABEL_KEYS,
 } from "$lib/activity";
 import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
@@ -65,14 +64,6 @@ $: totalPages = Math.max(1, Math.ceil(visibleItems.length / PAGE_SIZE));
 // "there's nothing to filter". After the initial fetch resolves we
 // always show counts, even if some are legitimately 0.
 $: showChipCounts = !(feedLoading && !feedItems.length);
-
-function toggleType(type: ActivityType) {
-	const next = new Set(activeTypes);
-	if (next.has(type)) next.delete(type);
-	else next.add(type);
-	activeTypes = next;
-	page = 0;
-}
 
 // Rebuild options when saved-id lists, hydrated names, or locale change.
 $: filterOptions = ((): FormSelectOption[] => {
@@ -225,24 +216,13 @@ onMount(async () => {
 			{$_("userActivity.timeWindow", { values: { days: DAYS } })}
 		</p>
 
-		<div class="mb-6 flex flex-wrap items-center justify-center gap-2">
-			{#each ACTIVITY_TYPES as type (type)}
-				{@const active = activeTypes.has(type)}
-				<button
-					type="button"
-					aria-pressed={active}
-					on:click={() => toggleType(type)}
-					class="flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors {active
-						? 'border-link bg-link/10 text-primary dark:border-link dark:text-white'
-						: 'border-gray-300 text-body/60 hover:border-link hover:text-body dark:border-white/20 dark:text-white/50 dark:hover:text-white'}"
-				>
-					<span class="h-2 w-2 rounded-full {dotColor(type)}" />
-					<span>{$_(TYPE_LABEL_KEYS[type])}</span>
-					{#if showChipCounts}
-						<span class="text-xs opacity-70">({typeCounts[type]})</span>
-					{/if}
-				</button>
-			{/each}
+		<div class="mb-6">
+			<ActivityTypeFilter
+				bind:activeTypes
+				counts={typeCounts}
+				showCounts={showChipCounts}
+				on:change={() => (page = 0)}
+			/>
 		</div>
 
 		{#if feedLoading && !feedItems.length}

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -315,7 +315,9 @@ onMount(async () => {
 				{$_("userActivity.noTypesSelected")}
 			</p>
 		{:else if !visibleItems.length}
-			<p class="text-center text-body dark:text-white/70">{$_("areaActivity.noActivity")}</p>
+			<p class="text-center text-body dark:text-white/70">
+				{$_("userActivity.noMatchingTypes")}
+			</p>
 		{:else}
 			{#if totalPages > 1}
 				<div class="mb-4 flex items-center justify-center gap-4">

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -45,12 +45,28 @@ const PAGE_SIZE = 20;
 // with 500+ saved places still gets a usable response instead of a 400.
 const MAX_PLACES = 500;
 
+const ACTIVITY_TYPES: ActivityType[] = [
+	"place_added",
+	"place_updated",
+	"place_deleted",
+	"place_commented",
+	"place_boosted",
+];
+
 const DOT_COLORS: Record<ActivityType, string> = {
 	place_commented: "bg-amber-500",
 	place_boosted: "bg-orange-500",
 	place_added: "bg-created",
 	place_deleted: "bg-deleted",
 	place_updated: "bg-link",
+};
+
+const TYPE_LABEL_KEYS: Record<ActivityType, string> = {
+	place_added: "userActivity.typeAdded",
+	place_updated: "userActivity.typeUpdated",
+	place_deleted: "userActivity.typeDeleted",
+	place_commented: "userActivity.typeCommented",
+	place_boosted: "userActivity.typeBoosted",
 };
 
 const dotColor = (type: ActivityType) => DOT_COLORS[type];
@@ -66,6 +82,7 @@ let hasSavedItems = false;
 // filterValue is the select's string value ("all" | "place:<id>" |
 // "area:<id>"); `filter` is the parsed typed view used by buildFeedUrl.
 let filterValue = "all";
+let activeTypes: Set<ActivityType> = new Set(ACTIVITY_TYPES);
 let feedItems: ActivityItem[] = [];
 let page = 0;
 let initialLoading = true;
@@ -74,8 +91,26 @@ let feedError = false;
 let fetchGeneration = 0;
 
 $: filter = parseFilterValue(filterValue);
-$: pagedItems = feedItems.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
-$: totalPages = Math.max(1, Math.ceil(feedItems.length / PAGE_SIZE));
+// Counts are over the unfiltered window so chip counts don't collapse
+// when the user toggles a type off.
+$: typeCounts = feedItems.reduce(
+	(acc, item) => {
+		acc[item.type] = (acc[item.type] ?? 0) + 1;
+		return acc;
+	},
+	{} as Record<ActivityType, number>,
+);
+$: visibleItems = feedItems.filter((i) => activeTypes.has(i.type));
+$: pagedItems = visibleItems.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
+$: totalPages = Math.max(1, Math.ceil(visibleItems.length / PAGE_SIZE));
+
+function toggleType(type: ActivityType) {
+	const next = new Set(activeTypes);
+	if (next.has(type)) next.delete(type);
+	else next.add(type);
+	activeTypes = next;
+	page = 0;
+}
 
 // Rebuild options when saved-id lists, hydrated names, or locale change.
 $: filterOptions = ((): FormSelectOption[] => {
@@ -224,9 +259,28 @@ onMount(async () => {
 			/>
 		</div>
 
-		<p class="mb-6 text-center text-sm text-body/70 dark:text-white/50">
+		<p class="mb-4 text-center text-sm text-body/70 dark:text-white/50">
 			{$_("userActivity.timeWindow", { values: { days: DAYS } })}
 		</p>
+
+		<div class="mb-6 flex flex-wrap items-center justify-center gap-2">
+			{#each ACTIVITY_TYPES as type (type)}
+				{@const active = activeTypes.has(type)}
+				{@const count = typeCounts[type] ?? 0}
+				<button
+					type="button"
+					aria-pressed={active}
+					on:click={() => toggleType(type)}
+					class="flex items-center gap-2 rounded-full border px-3 py-1 text-sm transition-colors {active
+						? 'border-link bg-link/10 text-primary dark:border-link dark:text-white'
+						: 'border-gray-300 text-body/60 hover:border-link hover:text-body dark:border-white/20 dark:text-white/50 dark:hover:text-white'}"
+				>
+					<span class="h-2 w-2 rounded-full {dotColor(type)}" />
+					<span>{$_(TYPE_LABEL_KEYS[type])}</span>
+					<span class="text-xs opacity-70">({count})</span>
+				</button>
+			{/each}
+		</div>
 
 		{#if feedLoading && !feedItems.length}
 			<div class="flex justify-center">
@@ -243,6 +297,12 @@ onMount(async () => {
 				</button>
 			</p>
 		{:else if !feedItems.length}
+			<p class="text-center text-body dark:text-white/70">{$_("areaActivity.noActivity")}</p>
+		{:else if !activeTypes.size}
+			<p class="text-center text-body dark:text-white/70">
+				{$_("userActivity.noTypesSelected")}
+			</p>
+		{:else if !visibleItems.length}
 			<p class="text-center text-body dark:text-white/70">{$_("areaActivity.noActivity")}</p>
 		{:else}
 			{#if totalPages > 1}

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -92,14 +92,20 @@ let fetchGeneration = 0;
 
 $: filter = parseFilterValue(filterValue);
 // Counts are over the unfiltered window so chip counts don't collapse
-// when the user toggles a type off.
-$: typeCounts = feedItems.reduce(
-	(acc, item) => {
-		acc[item.type] = (acc[item.type] ?? 0) + 1;
-		return acc;
-	},
-	{} as Record<ActivityType, number>,
-);
+// when the user toggles a type off. Prefill every key with 0 so the
+// record is fully populated and the chip template can read
+// `typeCounts[type]` without a fallback.
+$: typeCounts = ((): Record<ActivityType, number> => {
+	const counts: Record<ActivityType, number> = {
+		place_added: 0,
+		place_updated: 0,
+		place_deleted: 0,
+		place_commented: 0,
+		place_boosted: 0,
+	};
+	for (const item of feedItems) counts[item.type]++;
+	return counts;
+})();
 $: visibleItems = feedItems.filter((i) => activeTypes.has(i.type));
 $: pagedItems = visibleItems.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 $: totalPages = Math.max(1, Math.ceil(visibleItems.length / PAGE_SIZE));
@@ -266,7 +272,6 @@ onMount(async () => {
 		<div class="mb-6 flex flex-wrap items-center justify-center gap-2">
 			{#each ACTIVITY_TYPES as type (type)}
 				{@const active = activeTypes.has(type)}
-				{@const count = typeCounts[type] ?? 0}
 				<button
 					type="button"
 					aria-pressed={active}
@@ -277,7 +282,7 @@ onMount(async () => {
 				>
 					<span class="h-2 w-2 rounded-full {dotColor(type)}" />
 					<span>{$_(TYPE_LABEL_KEYS[type])}</span>
-					<span class="text-xs opacity-70">({count})</span>
+					<span class="text-xs opacity-70">({typeCounts[type]})</span>
 				</button>
 			{/each}
 		</div>

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { onMount } from "svelte";
-import Time from "svelte-time";
 
+import ActivityCard from "$components/activity/ActivityCard.svelte";
 import type { FormSelectOption } from "$components/form/FormSelect.svelte";
 import FormSelect from "$components/form/FormSelect.svelte";
 import Icon from "$components/Icon.svelte";
@@ -19,7 +19,6 @@ import { _ } from "$lib/i18n";
 import { session } from "$lib/session";
 
 import { goto } from "$app/navigation";
-import { resolve } from "$app/paths";
 
 type SavedPlace = { id: number; name: string };
 type SavedArea = { id: number; name: string };
@@ -300,101 +299,8 @@ onMount(async () => {
 			<div class="rounded-3xl border border-gray-300 dark:border-white/95 dark:bg-white/10">
 				<div class="space-y-2 p-2">
 					{#each pagedItems as item, i (item.type + "-" + item.place_id + "-" + item.date + "-" + i)}
-						<div
-							class="flex flex-col items-center gap-2 p-5 text-center text-xl lg:flex-row lg:gap-5 lg:text-left"
-						>
-							<span class="relative mx-auto mb-2 flex h-3 w-3 lg:mx-0 lg:mb-0">
-								<span
-									class="{i === 0 ? 'animate-ping' : ''} absolute inline-flex h-full w-full rounded-full {dotColor(
-										item.type,
-									)} opacity-75"
-								/>
-								<span
-									class="relative inline-flex h-3 w-3 rounded-full {dotColor(item.type)}"
-								/>
-							</span>
-
-							<div
-								class="w-full flex-wrap items-center justify-between space-y-2 lg:flex lg:space-y-0"
-							>
-								<div class="space-y-2 lg:space-y-0">
-									<span class="text-primary lg:mr-5 dark:text-white">
-										{#if item.type === "place_added" || item.type === "place_updated" || item.type === "place_deleted"}
-											<a
-												href={resolve(`/merchant/${item.place_id}`)}
-												class="break-all text-link transition-colors hover:text-hover"
-											>
-												{item.place_name || item.place_id}
-											</a>
-											{$_("areaActivity.was")}
-											<strong
-												>{item.type === "place_added"
-													? $_("areaActivity.created")
-													: item.type === "place_deleted"
-														? $_("areaActivity.deleted")
-														: $_("areaActivity.updated")}</strong
-											>
-											{#if item.osm_user_id && item.osm_user_name}
-												{$_("areaActivity.by")}
-												<a
-													href={resolve(`/tagger/${item.osm_user_id}`)}
-													class="break-all text-link transition-colors hover:text-hover"
-												>
-													{item.osm_user_name}
-												</a>
-											{/if}
-										{:else if item.type === "place_commented"}
-											<Icon
-												type="fa"
-												icon="comment"
-												w="16"
-												h="16"
-												class="mr-1 inline align-middle"
-											/>
-											<a
-												href={resolve(`/merchant/${item.place_id}`)}
-												class="break-all text-link transition-colors hover:text-hover"
-											>
-												{item.place_name || item.place_id}
-											</a>
-											{$_("areaActivity.commented")}
-											<span class="italic"
-												>"{item.comment && item.comment.length > 80
-													? item.comment.slice(0, 77) + "..."
-													: item.comment}"</span
-											>
-										{:else if item.type === "place_boosted"}
-											<Icon
-												type="fa"
-												icon="bolt"
-												w="16"
-												h="16"
-												class="mr-1 inline align-middle text-orange-500"
-											/>
-											<a
-												href={resolve(`/merchant/${item.place_id}`)}
-												class="break-all text-link transition-colors hover:text-hover"
-											>
-												{item.place_name || item.place_id}
-											</a>
-											{$_("areaActivity.was")}
-											<strong>{$_("areaActivity.boosted")}</strong>
-											{#if item.duration_days != null}
-												{$_("areaActivity.forDays", { values: { days: item.duration_days } })}
-											{/if}
-										{/if}
-									</span>
-
-									<span
-										class="block text-center font-semibold text-taggerTime lg:inline dark:text-white/70"
-									>
-										<Time live={3000} relative timestamp={item.date} />
-									</span>
-								</div>
-							</div>
-						</div>
+						<ActivityCard {item} highlight={i === 0} />
 					{/each}
-
 				</div>
 			</div>
 

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -188,7 +188,7 @@ onMount(async () => {
 	<title>{$_("userActivity.title")} | BTC Map</title>
 </svelte:head>
 
-<div class="mx-auto my-10 max-w-3xl px-4 md:my-20">
+<div class="my-10 md:my-20">
 	<h1 class="mb-8 text-center text-4xl font-semibold text-primary dark:text-white">
 		{$_("userActivity.title")}
 	</h1>

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -5,6 +5,14 @@ import Time from "svelte-time";
 import type { FormSelectOption } from "$components/form/FormSelect.svelte";
 import FormSelect from "$components/form/FormSelect.svelte";
 import Icon from "$components/Icon.svelte";
+import {
+	ACTIVITY_TYPES,
+	type ActivityItem,
+	type ActivityType,
+	countByType,
+	dotColor,
+	TYPE_LABEL_KEYS,
+} from "$lib/activity";
 import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
 import { _ } from "$lib/i18n";
@@ -12,24 +20,6 @@ import { session } from "$lib/session";
 
 import { goto } from "$app/navigation";
 import { resolve } from "$app/paths";
-
-type ActivityType =
-	| "place_added"
-	| "place_updated"
-	| "place_deleted"
-	| "place_commented"
-	| "place_boosted";
-
-type ActivityItem = {
-	type: ActivityType;
-	place_id: number;
-	place_name?: string;
-	osm_user_id?: number;
-	osm_user_name?: string;
-	comment?: string;
-	duration_days?: number;
-	date: string;
-};
 
 type SavedPlace = { id: number; name: string };
 type SavedArea = { id: number; name: string };
@@ -44,32 +34,6 @@ const PAGE_SIZE = 20;
 // Mirrors the server-side cap in /v4/activity — slice here so a user
 // with 500+ saved places still gets a usable response instead of a 400.
 const MAX_PLACES = 500;
-
-const ACTIVITY_TYPES: ActivityType[] = [
-	"place_added",
-	"place_updated",
-	"place_deleted",
-	"place_commented",
-	"place_boosted",
-];
-
-const DOT_COLORS: Record<ActivityType, string> = {
-	place_commented: "bg-amber-500",
-	place_boosted: "bg-orange-500",
-	place_added: "bg-created",
-	place_deleted: "bg-deleted",
-	place_updated: "bg-link",
-};
-
-const TYPE_LABEL_KEYS: Record<ActivityType, string> = {
-	place_added: "userActivity.typeAdded",
-	place_updated: "userActivity.typeUpdated",
-	place_deleted: "userActivity.typeDeleted",
-	place_commented: "userActivity.typeCommented",
-	place_boosted: "userActivity.typeBoosted",
-};
-
-const dotColor = (type: ActivityType) => DOT_COLORS[type];
 
 // IDs come from the session (always available once logged in).
 // Names are fetched from the API best-effort for the filter select —
@@ -92,20 +56,8 @@ let fetchGeneration = 0;
 
 $: filter = parseFilterValue(filterValue);
 // Counts are over the unfiltered window so chip counts don't collapse
-// when the user toggles a type off. Prefill every key with 0 so the
-// record is fully populated and the chip template can read
-// `typeCounts[type]` without a fallback.
-$: typeCounts = ((): Record<ActivityType, number> => {
-	const counts: Record<ActivityType, number> = {
-		place_added: 0,
-		place_updated: 0,
-		place_deleted: 0,
-		place_commented: 0,
-		place_boosted: 0,
-	};
-	for (const item of feedItems) counts[item.type]++;
-	return counts;
-})();
+// when the user toggles a type off.
+$: typeCounts = countByType(feedItems);
 $: visibleItems = feedItems.filter((i) => activeTypes.has(i.type));
 $: pagedItems = visibleItems.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 $: totalPages = Math.max(1, Math.ceil(visibleItems.length / PAGE_SIZE));

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -109,6 +109,11 @@ $: typeCounts = ((): Record<ActivityType, number> => {
 $: visibleItems = feedItems.filter((i) => activeTypes.has(i.type));
 $: pagedItems = visibleItems.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 $: totalPages = Math.max(1, Math.ceil(visibleItems.length / PAGE_SIZE));
+// Suppress the "(0)" suffix on every chip during the very first load,
+// where typeCounts is uniformly zero and a chipful of zeros looks like
+// "there's nothing to filter". After the initial fetch resolves we
+// always show counts, even if some are legitimately 0.
+$: showChipCounts = !(feedLoading && !feedItems.length);
 
 function toggleType(type: ActivityType) {
 	const next = new Set(activeTypes);
@@ -282,7 +287,9 @@ onMount(async () => {
 				>
 					<span class="h-2 w-2 rounded-full {dotColor(type)}" />
 					<span>{$_(TYPE_LABEL_KEYS[type])}</span>
-					<span class="text-xs opacity-70">({typeCounts[type]})</span>
+					{#if showChipCounts}
+						<span class="text-xs opacity-70">({typeCounts[type]})</span>
+					{/if}
 				</button>
 			{/each}
 		</div>


### PR DESCRIPTION
## My activity
<img width="1416" height="1114" alt="image" src="https://github.com/user-attachments/assets/35a8fa1a-2993-4d1f-9ca7-76870cc43b3e" />

<img width="1401" height="1250" alt="image" src="https://github.com/user-attachments/assets/42ecd36e-b992-43c6-a20c-377a595fd547" />

## Area activity

<img width="1378" height="1501" alt="image" src="https://github.com/user-attachments/assets/eebe8786-eb4a-4aec-8358-0230d12a5d04" />

## Desc

Users with many saved items can generate a noisy feed; add a chip row to toggle each of the five ActivityType kinds (added / updated / deleted / commented / boosted). Filtering happens entirely client-side on the already-fetched feedItems — no new API calls.

- Chips show the dot-color per type, the localized label, and a live count computed over the unfiltered window (so the count doesn't collapse as types are toggled off).
- Toggling resets paging to page 0.
- Composes cleanly with the existing place/area filter.
- Empty cases split: feedItems empty → "no activity", activeTypes empty → new "select at least one activity type above" hint.
- New userActivity.type{Added,Updated,Deleted,Commented,Boosted} + userActivity.noTypesSelected i18n keys.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activity feed supports filtering by type: Added, Updated, Deleted, Commented, Boosted.
  * New activity filter UI with per-type chips and optional counts; toggling resets pagination.
  * Feed items now render as unified activity cards with consistent icons, labels, truncated comments, and live relative timestamps.
  * Empty-state messages when no types are selected or when filters return no results.

* **Localization**
  * Added localized labels for activity types and related empty-state/help text; minor translation formatting fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->