### PR TITLE
feat(account): saved places map

### DIFF
--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -1,0 +1,165 @@
+<script lang="ts">
+import type { Map } from "leaflet";
+import { onDestroy, onMount } from "svelte";
+
+import AreaMerchantDrawer from "$components/area/AreaMerchantDrawer.svelte";
+import MapLoadingEmbed from "$components/MapLoadingEmbed.svelte";
+import { loadMapDependencies } from "$lib/map/imports";
+import {
+	attribution,
+	changeDefaultIcons,
+	generateIcon,
+	generateMarker,
+	geolocate,
+	layers,
+} from "$lib/map/setup";
+import { theme } from "$lib/theme";
+import type { BaseMaps, DomEventType, Leaflet } from "$lib/types";
+
+import { browser } from "$app/environment";
+
+type PlaceMarker = {
+	id: number;
+	name: string;
+	lat: number;
+	lon: number;
+};
+
+export let places: PlaceMarker[];
+
+let selectedMerchantId: number | null = null;
+
+const openDrawer = (id: number | string) => {
+	selectedMerchantId = Number(id);
+};
+
+const closeDrawer = () => {
+	selectedMerchantId = null;
+};
+
+let mapElement: HTMLDivElement;
+let map: Map;
+let mapLoaded = false;
+
+let baseMaps: BaseMaps;
+
+let leaflet: Leaflet;
+let DomEvent: DomEventType;
+let LocateControl: typeof import("leaflet.locatecontrol").LocateControl;
+
+const closePopup = () => {
+	map.closePopup();
+};
+
+$: $theme !== undefined && mapLoaded && closePopup();
+
+const toggleTheme = () => {
+	if ($theme === "dark") {
+		baseMaps["OpenFreeMap Liberty"].remove();
+		baseMaps["OpenFreeMap Dark"].addTo(map);
+	} else {
+		baseMaps["OpenFreeMap Dark"].remove();
+		baseMaps["OpenFreeMap Liberty"].addTo(map);
+	}
+};
+
+$: $theme !== undefined && mapLoaded && toggleTheme();
+
+onMount(async () => {
+	if (browser) {
+		const deps = await loadMapDependencies();
+		leaflet = deps.leaflet;
+		DomEvent = deps.leaflet.DomEvent;
+		LocateControl = deps.LocateControl;
+
+		initialRenderComplete = true;
+	}
+});
+
+onDestroy(() => {
+	if (map) {
+		console.info("Unloading Leaflet map.");
+		map.remove();
+	}
+});
+
+let initialRenderComplete = false;
+let dataInitialized = false;
+
+const initializeData = () => {
+	if (dataInitialized) return;
+
+	map = leaflet.map(mapElement, { attributionControl: false, maxZoom: 19 });
+
+	const layersResult = layers(leaflet, map);
+	baseMaps = layersResult.baseMaps;
+
+	leaflet.Icon.Default.prototype.options.imagePath = "/icons/";
+
+	attribution(leaflet, map);
+
+	// @ts-expect-error L is injected globally by leaflet.markercluster
+	const markers = L.markerClusterGroup();
+
+	geolocate(leaflet, map, LocateControl);
+
+	changeDefaultIcons(true, leaflet, mapElement, DomEvent);
+
+	places.forEach((place) => {
+		const divIcon = generateIcon(leaflet, "currency_bitcoin", false, 0);
+
+		const marker = generateMarker({
+			lat: place.lat,
+			long: place.lon,
+			icon: divIcon,
+			placeId: place.id,
+			leaflet,
+			verify: false,
+			onMarkerClick: (id) => openDrawer(id),
+		});
+
+		markers.addLayer(marker);
+	});
+
+	map.addLayer(markers);
+
+	if (places.length > 0) {
+		const coords = places.map((p) => [p.lat, p.lon] as [number, number]);
+		map.fitBounds(leaflet.latLngBounds(coords), {
+			maxZoom: 14,
+			padding: [20, 20],
+		});
+	} else {
+		map.setView([20, 0], 2);
+	}
+
+	map.on("click", () => {
+		if (selectedMerchantId) {
+			closeDrawer();
+		}
+	});
+
+	mapLoaded = true;
+	dataInitialized = true;
+};
+
+$: places && initialRenderComplete && !dataInitialized && initializeData();
+</script>
+
+<section>
+	<div class="relative">
+		<div class="overflow-hidden rounded-3xl">
+			<!-- prettier-ignore -->
+			<div
+				bind:this={mapElement}
+				class="z-10 h-[300px] rounded-3xl border border-gray-300 !bg-teal text-left md:h-[500px] dark:border-white/95 dark:!bg-[#202f33]"
+			/>
+			{#if !mapLoaded}
+				<MapLoadingEmbed
+					style="h-[300px] md:h-[500px] rounded-3xl border border-gray-300 dark:border-white/95"
+				/>
+			{/if}
+		</div>
+		<AreaMerchantDrawer merchantId={selectedMerchantId} onClose={closeDrawer} />
+	</div>
+</section>

--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -14,18 +14,11 @@ import {
 	layers,
 } from "$lib/map/setup";
 import { theme } from "$lib/theme";
-import type { BaseMaps, DomEventType, Leaflet } from "$lib/types";
+import type { BaseMaps, DomEventType, Leaflet, SavedPlace } from "$lib/types";
 
 import { browser } from "$app/environment";
 
-type PlaceMarker = {
-	id: number;
-	name: string;
-	lat: number;
-	lon: number;
-};
-
-export let places: PlaceMarker[];
+export let places: SavedPlace[];
 
 let selectedMerchantId: number | null = null;
 

--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -71,10 +71,16 @@ onDestroy(() => {
 
 let initialRenderComplete = false;
 let dataInitialized = false;
+let hasFitBoundsOnce = false;
 // markerClusterGroup extends FeatureGroup; its own type isn't bundled
 let markers: FeatureGroup;
 
-const renderPlaces = () => {
+// Re-render markers for the current places. Only fit bounds on the first
+// render (or when the caller explicitly asks) so that removing a saved
+// place doesn't yank the user out of the view they just panned/zoomed to.
+const renderPlaces = ({ fit }: { fit?: boolean } = {}) => {
+	const shouldFit = fit ?? !hasFitBoundsOnce;
+
 	markers.clearLayers();
 
 	places.forEach((place) => {
@@ -93,14 +99,17 @@ const renderPlaces = () => {
 		markers.addLayer(marker);
 	});
 
-	if (places.length > 0) {
-		const coords = places.map((p) => [p.lat, p.lon] as [number, number]);
-		map.fitBounds(leaflet.latLngBounds(coords), {
-			maxZoom: 14,
-			padding: [20, 20],
-		});
-	} else {
-		map.setView([20, 0], 2);
+	if (shouldFit) {
+		if (places.length > 0) {
+			const coords = places.map((p) => [p.lat, p.lon] as [number, number]);
+			map.fitBounds(leaflet.latLngBounds(coords), {
+				maxZoom: 14,
+				padding: [20, 20],
+			});
+			hasFitBoundsOnce = true;
+		} else {
+			map.setView([20, 0], 2);
+		}
 	}
 
 	// If the currently-open drawer's place was removed from the list,

--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -6,6 +6,7 @@ import AreaMerchantDrawer from "$components/area/AreaMerchantDrawer.svelte";
 import MapLoadingEmbed from "$components/MapLoadingEmbed.svelte";
 import { loadMapDependencies } from "$lib/map/imports";
 import {
+	applyThemeToBaseMaps,
 	attribution,
 	changeDefaultIcons,
 	generateIcon,
@@ -46,17 +47,9 @@ const closePopup = () => {
 
 $: $theme !== undefined && mapLoaded && closePopup();
 
-const toggleTheme = () => {
-	if ($theme === "dark") {
-		baseMaps["OpenFreeMap Liberty"].remove();
-		baseMaps["OpenFreeMap Dark"].addTo(map);
-	} else {
-		baseMaps["OpenFreeMap Dark"].remove();
-		baseMaps["OpenFreeMap Liberty"].addTo(map);
-	}
-};
-
-$: $theme !== undefined && mapLoaded && toggleTheme();
+$: $theme !== undefined &&
+	mapLoaded &&
+	applyThemeToBaseMaps($theme, baseMaps, map);
 
 onMount(async () => {
 	if (browser) {

--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { Map } from "leaflet";
+import type { FeatureGroup, Map } from "leaflet";
 import { onDestroy, onMount } from "svelte";
 
 import AreaMerchantDrawer from "$components/area/AreaMerchantDrawer.svelte";
@@ -85,25 +85,11 @@ onDestroy(() => {
 
 let initialRenderComplete = false;
 let dataInitialized = false;
+// markerClusterGroup extends FeatureGroup; its own type isn't bundled
+let markers: FeatureGroup;
 
-const initializeData = () => {
-	if (dataInitialized) return;
-
-	map = leaflet.map(mapElement, { attributionControl: false, maxZoom: 19 });
-
-	const layersResult = layers(leaflet, map);
-	baseMaps = layersResult.baseMaps;
-
-	leaflet.Icon.Default.prototype.options.imagePath = "/icons/";
-
-	attribution(leaflet, map);
-
-	// @ts-expect-error L is injected globally by leaflet.markercluster
-	const markers = L.markerClusterGroup();
-
-	geolocate(leaflet, map, LocateControl);
-
-	changeDefaultIcons(true, leaflet, mapElement, DomEvent);
+const renderPlaces = () => {
+	markers.clearLayers();
 
 	places.forEach((place) => {
 		const divIcon = generateIcon(leaflet, "currency_bitcoin", false, 0);
@@ -121,8 +107,6 @@ const initializeData = () => {
 		markers.addLayer(marker);
 	});
 
-	map.addLayer(markers);
-
 	if (places.length > 0) {
 		const coords = places.map((p) => [p.lat, p.lon] as [number, number]);
 		map.fitBounds(leaflet.latLngBounds(coords), {
@@ -133,17 +117,53 @@ const initializeData = () => {
 		map.setView([20, 0], 2);
 	}
 
+	// If the currently-open drawer's place was removed from the list,
+	// close it — the user's context is gone.
+	if (
+		selectedMerchantId !== null &&
+		!places.some((p) => p.id === selectedMerchantId)
+	) {
+		closeDrawer();
+	}
+};
+
+const initializeData = () => {
+	if (dataInitialized) return;
+
+	map = leaflet.map(mapElement, { attributionControl: false, maxZoom: 19 });
+
+	const layersResult = layers(leaflet, map);
+	baseMaps = layersResult.baseMaps;
+
+	leaflet.Icon.Default.prototype.options.imagePath = "/icons/";
+
+	attribution(leaflet, map);
+
+	// @ts-expect-error L is injected globally by leaflet.markercluster
+	markers = L.markerClusterGroup();
+	map.addLayer(markers);
+
+	geolocate(leaflet, map, LocateControl);
+
+	changeDefaultIcons(true, leaflet, mapElement, DomEvent);
+
 	map.on("click", () => {
 		if (selectedMerchantId) {
 			closeDrawer();
 		}
 	});
 
+	renderPlaces();
+
 	mapLoaded = true;
 	dataInitialized = true;
 };
 
-$: places && initialRenderComplete && !dataInitialized && initializeData();
+$: if (places && initialRenderComplete && !dataInitialized) {
+	initializeData();
+} else if (places && dataInitialized) {
+	renderPlaces();
+}
 </script>
 
 <section>

--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -34,6 +34,7 @@ const closeDrawer = () => {
 let mapElement: HTMLDivElement;
 let map: Map;
 let mapLoaded = false;
+let destroyed = false;
 
 let baseMaps: BaseMaps;
 
@@ -54,6 +55,9 @@ $: $theme !== undefined &&
 onMount(async () => {
 	if (browser) {
 		const deps = await loadMapDependencies();
+		// User may have navigated away while the dynamic imports were in
+		// flight; bail out before touching component state.
+		if (destroyed) return;
 		leaflet = deps.leaflet;
 		DomEvent = deps.leaflet.DomEvent;
 		LocateControl = deps.LocateControl;
@@ -63,6 +67,7 @@ onMount(async () => {
 });
 
 onDestroy(() => {
+	destroyed = true;
 	if (map) {
 		console.info("Unloading Leaflet map.");
 		map.remove();
@@ -143,7 +148,7 @@ const initializeData = () => {
 	changeDefaultIcons(true, leaflet, mapElement, DomEvent);
 
 	map.on("click", () => {
-		if (selectedMerchantId) {
+		if (selectedMerchantId !== null) {
 			closeDrawer();
 		}
 	});

--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -12,6 +12,7 @@ import TaggingIssues from "$components/TaggingIssues.svelte";
 import { GradeTable } from "$lib/constants";
 import { loadMapDependencies } from "$lib/map/imports";
 import {
+	applyThemeToBaseMaps,
 	attribution,
 	changeDefaultIcons,
 	generateIcon,
@@ -70,17 +71,9 @@ const closePopup = () => {
 
 $: $theme !== undefined && mapLoaded && closePopup();
 
-const toggleTheme = () => {
-	if ($theme === "dark") {
-		baseMaps["OpenFreeMap Liberty"].remove();
-		baseMaps["OpenFreeMap Dark"].addTo(map);
-	} else {
-		baseMaps["OpenFreeMap Dark"].remove();
-		baseMaps["OpenFreeMap Liberty"].addTo(map);
-	}
-};
-
-$: $theme !== undefined && mapLoaded && toggleTheme();
+$: $theme !== undefined &&
+	mapLoaded &&
+	applyThemeToBaseMaps($theme, baseMaps, map);
 
 onMount(async () => {
 	if (browser) {

--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -246,11 +246,11 @@ $: geoJSON &&
 			<!-- prettier-ignore -->
 			<div
 				bind:this={mapElement}
-				class="z-10 h-[300px] border border-gray-300 !bg-teal text-left md:h-[600px] dark:border-white/95 dark:!bg-[#202f33]"
+				class="z-10 h-[300px] rounded-b-3xl border border-gray-300 !bg-teal text-left md:h-[600px] dark:border-white/95 dark:!bg-[#202f33]"
 			/>
 			{#if !mapLoaded}
 				<MapLoadingEmbed
-					style="h-[300px] md:h-[600px] border border-gray-300 dark:border-white/95"
+					style="h-[300px] md:h-[600px] rounded-b-3xl border border-gray-300 dark:border-white/95"
 				/>
 			{/if}
 		</div>

--- a/src/lib/map/setup.ts
+++ b/src/lib/map/setup.ts
@@ -10,7 +10,7 @@ import { _ } from "$lib/i18n";
 import en from "$lib/i18n/locales/en.json";
 import { selectedMerchant } from "$lib/store";
 import { theme } from "$lib/theme";
-import type { DomEventType, Leaflet, Place } from "$lib/types";
+import type { BaseMaps, DomEventType, Leaflet, Place, Theme } from "$lib/types";
 import { userLocation } from "$lib/userLocationStore";
 import { errToast, humanizeIconName } from "$lib/utils";
 
@@ -91,6 +91,22 @@ export const layers = (leaflet: Leaflet, map: LeafletMap) => {
 export const attribution = (L: Leaflet, map: LeafletMap) => {
 	// Use Leaflet's default attribution control
 	L.control.attribution({ position: "bottomleft", prefix: false }).addTo(map);
+};
+
+// Swap the OpenFreeMap Liberty/Dark layers when the theme changes.
+// Callers invoke this from a reactive block once the map is initialized.
+export const applyThemeToBaseMaps = (
+	currentTheme: Theme | undefined,
+	baseMaps: BaseMaps,
+	map: LeafletMap,
+) => {
+	if (currentTheme === "dark") {
+		baseMaps["OpenFreeMap Liberty"].remove();
+		baseMaps["OpenFreeMap Dark"].addTo(map);
+	} else {
+		baseMaps["OpenFreeMap Dark"].remove();
+		baseMaps["OpenFreeMap Liberty"].addTo(map);
+	}
 };
 
 export type MapControlsTranslations = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -398,6 +398,14 @@ export type Tickets = GiteaIssue[] | "error" | "maintenance";
 
 export type Theme = "light" | "dark";
 
+// Shape returned by /api/session/saved-places (proxy of /v4/places/saved)
+export type SavedPlace = {
+	id: number;
+	name: string;
+	lat: number;
+	lon: number;
+};
+
 export type DonationType = "On-chain" | "Lightning";
 
 export type DropdownLink = {

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -22,6 +22,7 @@ import TopButton from "$components/TopButton.svelte";
 import { _, getDisplayLang, locale } from "$lib/i18n";
 import { loadMapDependencies } from "$lib/map/imports";
 import {
+	applyThemeToBaseMaps,
 	attribution,
 	calcVerifiedDate,
 	changeDefaultIcons,
@@ -235,17 +236,9 @@ onMount(async () => {
 	}
 });
 
-const toggleTheme = () => {
-	if ($theme === "dark") {
-		baseMaps["OpenFreeMap Liberty"].remove();
-		baseMaps["OpenFreeMap Dark"].addTo(map);
-	} else {
-		baseMaps["OpenFreeMap Dark"].remove();
-		baseMaps["OpenFreeMap Liberty"].addTo(map);
-	}
-};
-
-$: $theme !== undefined && mapLoaded && toggleTheme();
+$: $theme !== undefined &&
+	mapLoaded &&
+	applyThemeToBaseMaps($theme, baseMaps, map);
 
 // Update marker icon when boost or comment state changes
 $: if (merchantMarker && leaflet && mapLoaded && icon) {

--- a/src/routes/user/activity/+page.svelte
+++ b/src/routes/user/activity/+page.svelte
@@ -9,6 +9,7 @@ import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
 import { _ } from "$lib/i18n";
 import { session } from "$lib/session";
+import type { SavedPlace } from "$lib/types";
 
 import { goto } from "$app/navigation";
 import { resolve } from "$app/paths";
@@ -31,7 +32,6 @@ type ActivityItem = {
 	date: string;
 };
 
-type SavedPlace = { id: number; name: string };
 type SavedArea = { id: number; name: string };
 
 type Filter =

--- a/src/routes/user/saved/+page.svelte
+++ b/src/routes/user/saved/+page.svelte
@@ -2,6 +2,7 @@
 import { onMount } from "svelte";
 
 import Icon from "$components/Icon.svelte";
+import MultiPlaceMap from "$components/MultiPlaceMap.svelte";
 import api from "$lib/axios";
 import { _ } from "$lib/i18n";
 import { removeSavedItem, setSavedList } from "$lib/savedItems";
@@ -156,6 +157,7 @@ onMount(async () => {
 					<Icon type="material" icon="location_on" w="24" h="24" class="mr-1 inline align-middle" />
 					{$_("saved.places")}
 				</h2>
+				<MultiPlaceMap {places} />
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					{#each places as place (place.id)}
 						{@const placeLabel = place.name || `Place ${place.id}`}

--- a/src/routes/user/saved/+page.svelte
+++ b/src/routes/user/saved/+page.svelte
@@ -7,17 +7,11 @@ import api from "$lib/axios";
 import { _ } from "$lib/i18n";
 import { removeSavedItem, setSavedList } from "$lib/savedItems";
 import { session } from "$lib/session";
+import type { SavedPlace } from "$lib/types";
 import { errToast } from "$lib/utils";
 
 import { goto } from "$app/navigation";
 import { resolve } from "$app/paths";
-
-type SavedPlace = {
-	id: number;
-	name: string;
-	lat: number;
-	lon: number;
-};
 
 type SavedArea = {
 	id: number;

--- a/src/routes/user/saved/+page.svelte
+++ b/src/routes/user/saved/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMount } from "svelte";
+import { onDestroy, onMount } from "svelte";
 
 import Icon from "$components/Icon.svelte";
 import MultiPlaceMap from "$components/MultiPlaceMap.svelte";
@@ -35,6 +35,15 @@ let placesError = false;
 let areasError = false;
 let removingPlaces = new Set<number>();
 let removingAreas = new Set<number>();
+
+// Gate the heavy MultiPlaceMap on desktop viewports so mobile users
+// don't download Leaflet + MapLibre + plugins for a view they can't see.
+// Matches Tailwind's default `md` breakpoint (768px).
+let isDesktop = false;
+let desktopMql: MediaQueryList | undefined;
+const handleDesktopChange = (e: MediaQueryListEvent) => {
+	isDesktop = e.matches;
+};
 
 async function removePlace(id: number) {
 	if (!$session || removingPlaces.has(id)) return;
@@ -93,6 +102,10 @@ async function removeArea(id: number) {
 }
 
 onMount(async () => {
+	desktopMql = window.matchMedia("(min-width: 768px)");
+	isDesktop = desktopMql.matches;
+	desktopMql.addEventListener("change", handleDesktopChange);
+
 	// Ensure session is hydrated from localStorage before checking.
 	// Child onMount runs before layout onMount in Svelte, so we can't
 	// rely on the layout's session.init() having run yet.
@@ -124,6 +137,10 @@ onMount(async () => {
 	}
 
 	loading = false;
+});
+
+onDestroy(() => {
+	desktopMql?.removeEventListener("change", handleDesktopChange);
 });
 </script>
 
@@ -157,7 +174,9 @@ onMount(async () => {
 					<Icon type="material" icon="location_on" w="24" h="24" class="mr-1 inline align-middle" />
 					{$_("saved.places")}
 				</h2>
-				<MultiPlaceMap {places} />
+				{#if isDesktop}
+					<MultiPlaceMap {places} />
+				{/if}
 				<div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 					{#each places as place (place.id)}
 						{@const placeLabel = place.name || `Place ${place.id}`}


### PR DESCRIPTION
Desktop only

<img width="1293" height="1489" alt="image" src="https://github.com/user-attachments/assets/572238c2-0e97-4fa5-bb3d-ea986be13aa6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop-only interactive map for saved merchant locations with lazy-loaded map assets, marker clustering, and an integrated merchant drawer.

* **Refactor**
  * Centralized theme handling so map base layers update consistently across pages; map theme now reacts uniformly.

* **Style**
  * Updated map container visuals with rounded bottom corners.

* **Types**
  * Added a shared SavedPlace type for saved-places data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->