### PR TITLE
feat(map): increase max zoom level to 21

### DIFF
--- a/src/lib/map/setup.ts
+++ b/src/lib/map/setup.ts
@@ -49,7 +49,8 @@ export const layers = (leaflet: Leaflet, map: LeafletMap) => {
 		"https://tile.openstreetmap.org/{z}/{x}/{y}.png",
 		{
 			noWrap: true,
-			maxZoom: 19,
+			maxZoom: 21,
+			maxNativeZoom: 19,
 		},
 	);
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1123,7 +1123,7 @@ onMount(async () => {
 		const LocateControl = deps.LocateControl;
 
 		// add map and tiles
-		map = leaflet.map(mapElement, { maxZoom: 19, zoomControl: false });
+		map = leaflet.map(mapElement, { maxZoom: 21, zoomControl: false });
 		leaflet.control.zoom({ position: "topright" }).addTo(map);
 
 		// Setup map in logical steps


### PR DESCRIPTION
## Summary
- increase max zoom level from 19 to 21 on the main map
- update both the map initialization (`src/routes/map/+page.svelte`) and the OSM tile layer config (`src/lib/map/setup.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map zoom functionality improved: maximum zoom level increased from 19 to 21, enabling users to zoom deeper into maps for more detailed geographic exploration and location viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->