### PR TITLE
  feat(communities): improve community and country page SEO

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -38,11 +38,6 @@
 		<meta name="keywords" content="bitcoin, open source, map" />
 		<meta name="author" content="BTC Map" />
 		<meta property="og:type" content="website" />
-		<meta name="description" content="Easily find places to spend sats anywhere on the planet." />
-		<meta
-			name="twitter:description"
-			content="Easily find places to spend sats anywhere on the planet."
-		/>
 		<meta name="twitter:site" content="@btcmap" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="msapplication-TileColor" content="#0B9072" />

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -421,7 +421,9 @@
 		"merchant": "Merchant",
 		"country": "Country",
 		"community": "Community",
-		"supertagger": "Supertagger"
+		"supertagger": "Supertagger",
+		"communityFallbackDescription": "Find places to spend bitcoin in {name}. Browse merchants, see community stats, and connect with local contacts.",
+		"countryFallbackDescription": "Find places to spend bitcoin in {name}. Browse merchants, see country stats, and explore local communities."
 	},
 	"communityMap": {
 		"viewCommunity": "View Community",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -425,6 +425,7 @@ export type AreaPageProps = {
 	tickets: Tickets;
 	issues: RpcIssue[];
 	verifiedDate?: string;
+	description?: string;
 };
 
 // Nullable geographic coordinates (for optional geo data like IP-based location)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -426,6 +426,7 @@ export type AreaPageProps = {
 	issues: RpcIssue[];
 	verifiedDate?: string;
 	description?: string;
+	iconSquare?: string;
 };
 
 // Nullable geographic coordinates (for optional geo data like IP-based location)

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { Area } from "$lib/types";
 
 import {
+	buildMetaDescription,
 	calculateDistance,
 	formatDistance,
 	getCommunitiesAtCoordinates,
@@ -550,5 +551,51 @@ describe("getCommunitiesAtCoordinates", () => {
 		// Point at lon 0 (clearly outside) should still be rejected
 		const outside = getCommunitiesAtCoordinates(-17, 0, [fiji]);
 		expect(outside).toEqual([]);
+	});
+});
+
+describe("buildMetaDescription", () => {
+	const fallback = "Fallback description for {name}.";
+
+	it("uses description when present and short enough", () => {
+		expect(buildMetaDescription("A short bio.", fallback, 200)).toBe(
+			"A short bio.",
+		);
+	});
+
+	it("falls back when description is nullish or empty", () => {
+		expect(buildMetaDescription(null, fallback, 200)).toBe(fallback);
+		expect(buildMetaDescription(undefined, fallback, 200)).toBe(fallback);
+		expect(buildMetaDescription("", fallback, 200)).toBe(fallback);
+		expect(buildMetaDescription("   ", fallback, 200)).toBe(fallback);
+	});
+
+	it("collapses internal whitespace and trims", () => {
+		expect(buildMetaDescription("  foo\n\tbar   baz  ", fallback, 200)).toBe(
+			"foo bar baz",
+		);
+	});
+
+	it("truncates long descriptions at a word boundary with an ellipsis", () => {
+		const long = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
+		// max=20 → cut at 19 codepoints ("alpha beta gamma de"),
+		// then back off to the last word boundary inside that slice.
+		expect(buildMetaDescription(long, fallback, 20)).toBe("alpha beta gamma…");
+	});
+
+	it("does not split surrogate pairs when truncating near an emoji", () => {
+		// Each 🍊 is two UTF-16 code units but one code point.
+		const emojiHeavy = `${"ab ".repeat(6)}🍊🍊🍊🍊🍊🍊🍊🍊🍊🍊`;
+		const out = buildMetaDescription(emojiHeavy, fallback, 20);
+		// If a surrogate pair was split, the resulting string would
+		// contain an unpaired surrogate (U+D800-U+DFFF).
+		expect(out).not.toMatch(/[\uD800-\uDFFF](?![\uDC00-\uDFFF])/);
+		expect(out).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+	});
+
+	it("falls back to a hard cut when no word boundary is in the last 30%", () => {
+		// Single very long token with no spaces.
+		const out = buildMetaDescription("a".repeat(500), fallback, 20);
+		expect(out).toBe(`${"a".repeat(19)}…`);
 	});
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -519,3 +519,32 @@ export function formatDistance(km: number, useMetric: boolean): string {
 	}
 	return `${Math.round(miles)}mi`;
 }
+
+// Builds a meta description string: prefers `description` when present,
+// otherwise uses `fallback`. Normalizes whitespace and truncates at a
+// word boundary with an ellipsis. Uses Intl.Segmenter so it also works
+// for non-space-separated scripts (CJK, Thai), and operates on code
+// points so surrogate pairs (emoji etc.) are never split.
+export const buildMetaDescription = (
+	description: string | null | undefined,
+	fallback: string,
+	max: number,
+): string => {
+	const source = description?.replace(/\s+/g, " ").trim() || fallback.trim();
+	const codePoints = Array.from(source);
+	if (codePoints.length <= max) return source;
+
+	const cut = codePoints.slice(0, max - 1).join("");
+	const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
+	let lastBoundary = -1;
+	for (const { index } of segmenter.segment(cut)) {
+		if (index > 0) lastBoundary = index;
+	}
+
+	const threshold = (max - 1) * 0.7;
+	const truncated =
+		lastBoundary > threshold
+			? cut.slice(0, lastBoundary).trimEnd()
+			: cut.trimEnd();
+	return `${truncated}…`;
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -105,6 +105,16 @@ export let data;
 </script>
 
 <svelte:head>
+	{#if !data.pathname.startsWith('/community/') && !data.pathname.startsWith('/country/')}
+		<meta
+			name="description"
+			content="Easily find places to spend sats anywhere on the planet."
+		/>
+		<meta
+			name="twitter:description"
+			content="Easily find places to spend sats anywhere on the planet."
+		/>
+	{/if}
 	<meta
 		name="lightning"
 		content="lnurlp:LNURL1DP68GURN8GHJ7CM0WFJJUCN5VDKKZUPWDAEXWTMVDE6HYMRS9ARKXVN4W5EQPSYZ34"

--- a/src/routes/community/[area]/[section]/+page.server.ts
+++ b/src/routes/community/[area]/[section]/+page.server.ts
@@ -72,6 +72,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			issues: issues.result.requested_issues,
 			verifiedDate: fetchedArea.tags["verified:date"],
 			description: fetchedArea.tags.description,
+			iconSquare: fetchedArea.tags["icon:square"],
 		};
 	} catch (err) {
 		console.error(err);

--- a/src/routes/community/[area]/[section]/+page.server.ts
+++ b/src/routes/community/[area]/[section]/+page.server.ts
@@ -71,6 +71,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			tickets: tickets,
 			issues: issues.result.requested_issues,
 			verifiedDate: fetchedArea.tags["verified:date"],
+			description: fetchedArea.tags.description,
 		};
 	} catch (err) {
 		console.error(err);

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -20,9 +20,7 @@ $: metaDescription = buildMetaDescription(
 	200,
 );
 
-$: faviconUrl = data.iconSquare
-	? `https://btcmap.org/.netlify/images?url=${encodeURIComponent(data.iconSquare)}&fit=cover&w=64&h=64`
-	: null;
+$: faviconUrl = data.iconSquare || null;
 
 $: canonicalUrl = `https://btcmap.org/community/${encodeURIComponent(data.id)}/merchants`;
 </script>

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -31,10 +31,13 @@ function truncateAtWord(s: string, max: number): string {
 $: faviconUrl = iconSquare
 	? `https://btcmap.org/.netlify/images?url=${encodeURIComponent(iconSquare)}&fit=cover&w=64&h=64`
 	: null;
+
+$: canonicalUrl = `https://btcmap.org/community/${encodeURIComponent(id)}/merchants`;
 </script>
 
 <svelte:head>
 	<title>{name || $_('meta.community')}</title>
+	<link rel="canonical" href={canonicalUrl} />
 	<meta name="description" content={metaDescription} />
 	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
 	<meta property="og:title" content={name || $_('meta.community')} />

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -3,6 +3,7 @@ import AreaPage from "$components/area/AreaPage.svelte";
 import Breadcrumbs from "$components/Breadcrumbs.svelte";
 import { _ } from "$lib/i18n";
 import type { AreaPageProps } from "$lib/types";
+import { buildMetaDescription } from "$lib/utils";
 
 import type { PageData } from "./$types";
 
@@ -13,19 +14,11 @@ $: routes = [
 	{ name: data.name, url: `/community/${encodeURIComponent(data.id)}` },
 ];
 
-$: metaDescription = truncateAtWord(
-	data.description?.replace(/\s+/g, " ").trim() ||
-		$_("meta.communityFallbackDescription", { values: { name: data.name } }),
+$: metaDescription = buildMetaDescription(
+	data.description,
+	$_("meta.communityFallbackDescription", { values: { name: data.name } }),
 	200,
 );
-
-function truncateAtWord(s: string, max: number): string {
-	const codePoints = Array.from(s);
-	if (codePoints.length <= max) return s;
-	const cut = codePoints.slice(0, max - 1).join("");
-	const lastSpace = cut.lastIndexOf(" ");
-	return `${lastSpace > max * 0.7 ? cut.slice(0, lastSpace) : cut.trimEnd()}…`;
-}
 
 $: faviconUrl = data.iconSquare
 	? `https://btcmap.org/.netlify/images?url=${encodeURIComponent(data.iconSquare)}&fit=cover&w=64&h=64`

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -8,41 +8,40 @@ import type { PageData } from "./$types";
 
 export let data: PageData & AreaPageProps;
 
-const { name, id, description, iconSquare } = data;
-
 $: routes = [
 	{ name: $_("nav.communities"), url: "/communities" },
-	{ name, url: `/community/${encodeURIComponent(id)}` },
+	{ name: data.name, url: `/community/${encodeURIComponent(data.id)}` },
 ];
 
 $: metaDescription = truncateAtWord(
-	description?.replace(/\s+/g, " ").trim() ||
-		$_("meta.communityFallbackDescription", { values: { name } }),
+	data.description?.replace(/\s+/g, " ").trim() ||
+		$_("meta.communityFallbackDescription", { values: { name: data.name } }),
 	200,
 );
 
 function truncateAtWord(s: string, max: number): string {
-	if (s.length <= max) return s;
-	const cut = s.slice(0, max - 1);
+	const codePoints = Array.from(s);
+	if (codePoints.length <= max) return s;
+	const cut = codePoints.slice(0, max - 1).join("");
 	const lastSpace = cut.lastIndexOf(" ");
 	return `${lastSpace > max * 0.7 ? cut.slice(0, lastSpace) : cut.trimEnd()}…`;
 }
 
-$: faviconUrl = iconSquare
-	? `https://btcmap.org/.netlify/images?url=${encodeURIComponent(iconSquare)}&fit=cover&w=64&h=64`
+$: faviconUrl = data.iconSquare
+	? `https://btcmap.org/.netlify/images?url=${encodeURIComponent(data.iconSquare)}&fit=cover&w=64&h=64`
 	: null;
 
-$: canonicalUrl = `https://btcmap.org/community/${encodeURIComponent(id)}/merchants`;
+$: canonicalUrl = `https://btcmap.org/community/${encodeURIComponent(data.id)}/merchants`;
 </script>
 
 <svelte:head>
-	<title>{name || $_('meta.community')}</title>
+	<title>{data.name || $_('meta.community')}</title>
 	<link rel="canonical" href={canonicalUrl} />
 	<meta name="description" content={metaDescription} />
 	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
-	<meta property="og:title" content={name || $_('meta.community')} />
+	<meta property="og:title" content={data.name || $_('meta.community')} />
 	<meta property="og:description" content={metaDescription} />
-	<meta name="twitter:title" content={name || $_('meta.community')} />
+	<meta name="twitter:title" content={data.name || $_('meta.community')} />
 	<meta name="twitter:description" content={metaDescription} />
 	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
 	{#if faviconUrl}

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -15,10 +15,18 @@ $: routes = [
 	{ name, url: `/community/${encodeURIComponent(id)}` },
 ];
 
-$: metaDescription = (
+$: metaDescription = truncateAtWord(
 	description?.replace(/\s+/g, " ").trim() ||
-	$_("meta.communityFallbackDescription", { values: { name } })
-).slice(0, 200);
+		$_("meta.communityFallbackDescription", { values: { name } }),
+	200,
+);
+
+function truncateAtWord(s: string, max: number): string {
+	if (s.length <= max) return s;
+	const cut = s.slice(0, max - 1);
+	const lastSpace = cut.lastIndexOf(" ");
+	return `${lastSpace > max * 0.7 ? cut.slice(0, lastSpace) : cut.trimEnd()}…`;
+}
 
 $: faviconUrl = iconSquare
 	? `https://btcmap.org/.netlify/images?url=${encodeURIComponent(iconSquare)}&fit=cover&w=64&h=64`

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -8,7 +8,7 @@ import type { PageData } from "./$types";
 
 export let data: PageData & AreaPageProps;
 
-const { name, id, description } = data;
+const { name, id, description, iconSquare } = data;
 
 $: routes = [
 	{ name: $_("nav.communities"), url: "/communities" },
@@ -19,6 +19,10 @@ $: metaDescription = (
 	description?.replace(/\s+/g, " ").trim() ||
 	$_("meta.communityFallbackDescription", { values: { name } })
 ).slice(0, 200);
+
+$: faviconUrl = iconSquare
+	? `https://btcmap.org/.netlify/images?url=${encodeURIComponent(iconSquare)}&fit=cover&w=64&h=64`
+	: null;
 </script>
 
 <svelte:head>
@@ -30,6 +34,10 @@ $: metaDescription = (
 	<meta name="twitter:title" content={name || $_('meta.community')} />
 	<meta name="twitter:description" content={metaDescription} />
 	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
+	{#if faviconUrl}
+		<link rel="icon" href={faviconUrl} />
+		<link rel="apple-touch-icon" href={faviconUrl} />
+	{/if}
 </svelte:head>
 
 <Breadcrumbs {routes} />

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -8,19 +8,27 @@ import type { PageData } from "./$types";
 
 export let data: PageData & AreaPageProps;
 
-const { name, id } = data;
+const { name, id, description } = data;
 
 $: routes = [
 	{ name: $_("nav.communities"), url: "/communities" },
 	{ name, url: `/community/${encodeURIComponent(id)}` },
 ];
+
+$: metaDescription = (
+	description?.replace(/\s+/g, " ").trim() ||
+	$_("meta.communityFallbackDescription", { values: { name } })
+).slice(0, 200);
 </script>
 
 <svelte:head>
 	<title>{name || $_('meta.community')}</title>
+	<meta name="description" content={metaDescription} />
 	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
 	<meta property="og:title" content={name || $_('meta.community')} />
+	<meta property="og:description" content={metaDescription} />
 	<meta name="twitter:title" content={name || $_('meta.community')} />
+	<meta name="twitter:description" content={metaDescription} />
 	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
 </svelte:head>
 

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -22,6 +22,8 @@ $: metaDescription = buildMetaDescription(
 
 $: faviconUrl = data.iconSquare || null;
 
+$: ogImage = data.iconSquare || "https://btcmap.org/images/og/communities.png";
+
 $: canonicalUrl = `https://btcmap.org/community/${encodeURIComponent(data.id)}/merchants`;
 </script>
 
@@ -29,12 +31,12 @@ $: canonicalUrl = `https://btcmap.org/community/${encodeURIComponent(data.id)}/m
 	<title>{data.name || $_('meta.community')}</title>
 	<link rel="canonical" href={canonicalUrl} />
 	<meta name="description" content={metaDescription} />
-	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
+	<meta property="og:image" content={ogImage} />
 	<meta property="og:title" content={data.name || $_('meta.community')} />
 	<meta property="og:description" content={metaDescription} />
 	<meta name="twitter:title" content={data.name || $_('meta.community')} />
 	<meta name="twitter:description" content={metaDescription} />
-	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
+	<meta name="twitter:image" content={ogImage} />
 	{#if faviconUrl}
 		<link rel="icon" href={faviconUrl} />
 		<link rel="apple-touch-icon" href={faviconUrl} />

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -17,10 +17,10 @@ $: routes = [
 </script>
 
 <svelte:head>
-	<title>{name ? name + ' - ' : ''}BTC Map - {$_('meta.community')}</title>
+	<title>{name || $_('meta.community')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/communities.png" />
-	<meta property="og:title" content="{name ? name + ' - ' : ''}BTC Map - {$_('meta.community')}" />
-	<meta name="twitter:title" content="{name ? name + ' - ' : ''}BTC Map - {$_('meta.community')}" />
+	<meta property="og:title" content={name || $_('meta.community')} />
+	<meta name="twitter:title" content={name || $_('meta.community')} />
 	<meta name="twitter:image" content="https://btcmap.org/images/og/communities.png" />
 </svelte:head>
 

--- a/src/routes/community/[area]/[section]/+page.svelte
+++ b/src/routes/community/[area]/[section]/+page.svelte
@@ -6,6 +6,7 @@ import type { AreaPageProps } from "$lib/types";
 import { buildMetaDescription } from "$lib/utils";
 
 import type { PageData } from "./$types";
+import { browser } from "$app/environment";
 
 export let data: PageData & AreaPageProps;
 
@@ -21,6 +22,18 @@ $: metaDescription = buildMetaDescription(
 );
 
 $: faviconUrl = data.iconSquare || null;
+
+// Chrome prefers the site-wide SVG favicon from app.html over any PNG
+// we add in svelte:head, regardless of declaration order. Remove the
+// app.html icon links (keeping only our community one) so the community
+// icon actually shows in the tab.
+$: if (browser && faviconUrl) {
+	for (const link of document.querySelectorAll<HTMLLinkElement>(
+		'link[rel="icon"]',
+	)) {
+		if (link.href !== faviconUrl) link.remove();
+	}
+}
 
 $: ogImage = data.iconSquare || "https://btcmap.org/images/og/communities.png";
 

--- a/src/routes/country/[area]/[section]/+page.server.ts
+++ b/src/routes/country/[area]/[section]/+page.server.ts
@@ -72,6 +72,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			name: fetchedArea.tags.name,
 			tickets: tickets,
 			issues: issues.result.requested_issues,
+			description: fetchedArea.tags.description,
 		};
 	} catch (err) {
 		console.error(err);

--- a/src/routes/country/[area]/[section]/+page.svelte
+++ b/src/routes/country/[area]/[section]/+page.svelte
@@ -33,12 +33,20 @@ $: routes = [
 	},
 ];
 
-$: metaDescription = (
+$: metaDescription = truncateAtWord(
 	data.description?.replace(/\s+/g, " ").trim() ||
-	$_("meta.countryFallbackDescription", {
-		values: { name: countryDisplayName },
-	})
-).slice(0, 200);
+		$_("meta.countryFallbackDescription", {
+			values: { name: countryDisplayName },
+		}),
+	200,
+);
+
+function truncateAtWord(s: string, max: number): string {
+	if (s.length <= max) return s;
+	const cut = s.slice(0, max - 1);
+	const lastSpace = cut.lastIndexOf(" ");
+	return `${lastSpace > max * 0.7 ? cut.slice(0, lastSpace) : cut.trimEnd()}…`;
+}
 </script>
 
 <svelte:head>

--- a/src/routes/country/[area]/[section]/+page.svelte
+++ b/src/routes/country/[area]/[section]/+page.svelte
@@ -47,10 +47,13 @@ function truncateAtWord(s: string, max: number): string {
 	const lastSpace = cut.lastIndexOf(" ");
 	return `${lastSpace > max * 0.7 ? cut.slice(0, lastSpace) : cut.trimEnd()}…`;
 }
+
+$: canonicalUrl = `https://btcmap.org/country/${encodeURIComponent(data.id)}/merchants`;
 </script>
 
 <svelte:head>
 	<title>{countryDisplayName || $_('meta.country')}</title>
+	<link rel="canonical" href={canonicalUrl} />
 	<meta name="description" content={metaDescription} />
 	<meta property="og:image" content="https://btcmap.org/images/og/countries.png" />
 	<meta property="og:title" content={countryDisplayName || $_('meta.country')} />

--- a/src/routes/country/[area]/[section]/+page.svelte
+++ b/src/routes/country/[area]/[section]/+page.svelte
@@ -5,6 +5,7 @@ import AreaPage from "$components/area/AreaPage.svelte";
 import Breadcrumbs from "$components/Breadcrumbs.svelte";
 import { getCountryName } from "$lib/countryNames";
 import type { AreaPageProps } from "$lib/types";
+import { buildMetaDescription } from "$lib/utils";
 
 import type { PageData } from "./$types";
 
@@ -29,25 +30,17 @@ $: routes = [
 	{ name: $_(`nav.countries`), url: "/countries" },
 	{
 		name: countryDisplayName,
-		url: `/country/${data.id}`,
+		url: `/country/${encodeURIComponent(data.id)}`,
 	},
 ];
 
-$: metaDescription = truncateAtWord(
-	data.description?.replace(/\s+/g, " ").trim() ||
-		$_("meta.countryFallbackDescription", {
-			values: { name: countryDisplayName },
-		}),
+$: metaDescription = buildMetaDescription(
+	data.description,
+	$_("meta.countryFallbackDescription", {
+		values: { name: countryDisplayName },
+	}),
 	200,
 );
-
-function truncateAtWord(s: string, max: number): string {
-	const codePoints = Array.from(s);
-	if (codePoints.length <= max) return s;
-	const cut = codePoints.slice(0, max - 1).join("");
-	const lastSpace = cut.lastIndexOf(" ");
-	return `${lastSpace > max * 0.7 ? cut.slice(0, lastSpace) : cut.trimEnd()}…`;
-}
 
 $: canonicalUrl = `https://btcmap.org/country/${encodeURIComponent(data.id)}/merchants`;
 </script>

--- a/src/routes/country/[area]/[section]/+page.svelte
+++ b/src/routes/country/[area]/[section]/+page.svelte
@@ -32,13 +32,23 @@ $: routes = [
 		url: `/country/${data.id}`,
 	},
 ];
+
+$: metaDescription = (
+	data.description?.replace(/\s+/g, " ").trim() ||
+	$_("meta.countryFallbackDescription", {
+		values: { name: countryDisplayName },
+	})
+).slice(0, 200);
 </script>
 
 <svelte:head>
 	<title>{countryDisplayName || $_('meta.country')}</title>
+	<meta name="description" content={metaDescription} />
 	<meta property="og:image" content="https://btcmap.org/images/og/countries.png" />
 	<meta property="og:title" content={countryDisplayName || $_('meta.country')} />
+	<meta property="og:description" content={metaDescription} />
 	<meta name="twitter:title" content={countryDisplayName || $_('meta.country')} />
+	<meta name="twitter:description" content={metaDescription} />
 	<meta name="twitter:image" content="https://btcmap.org/images/og/countries.png" />
 </svelte:head>
 

--- a/src/routes/country/[area]/[section]/+page.svelte
+++ b/src/routes/country/[area]/[section]/+page.svelte
@@ -35,10 +35,10 @@ $: routes = [
 </script>
 
 <svelte:head>
-	<title>{countryDisplayName ? countryDisplayName + ' - ' : ''}BTC Map - {$_('meta.country')}</title>
+	<title>{countryDisplayName || $_('meta.country')}</title>
 	<meta property="og:image" content="https://btcmap.org/images/og/countries.png" />
-	<meta property="og:title" content="{countryDisplayName ? countryDisplayName + ' - ' : ''}BTC Map - {$_('meta.country')}" />
-	<meta name="twitter:title" content="{countryDisplayName ? countryDisplayName + ' - ' : ''}BTC Map - {$_('meta.country')}" />
+	<meta property="og:title" content={countryDisplayName || $_('meta.country')} />
+	<meta name="twitter:title" content={countryDisplayName || $_('meta.country')} />
 	<meta name="twitter:image" content="https://btcmap.org/images/og/countries.png" />
 </svelte:head>
 

--- a/src/routes/country/[area]/[section]/+page.svelte
+++ b/src/routes/country/[area]/[section]/+page.svelte
@@ -42,8 +42,9 @@ $: metaDescription = truncateAtWord(
 );
 
 function truncateAtWord(s: string, max: number): string {
-	if (s.length <= max) return s;
-	const cut = s.slice(0, max - 1);
+	const codePoints = Array.from(s);
+	if (codePoints.length <= max) return s;
+	const cut = codePoints.slice(0, max - 1).join("");
 	const lastSpace = cut.lastIndexOf(" ");
 	return `${lastSpace > max * 0.7 ? cut.slice(0, lastSpace) : cut.trimEnd()}…`;
 }


### PR DESCRIPTION
See favicon i.e. here in Chrome:
https://deploy-preview-945--btcmap.netlify.app/community/bitcoin-montenegro/merchants


   ## Summary

  Tightens on-page SEO for `/community/*` and `/country/*` pages so each one presents a clean, per-area signal to search engines and social cards instead of the generic site-wide metadata.

  ## What changed

  - **Titles** — dropped the `" - BTC Map - <type>"` boilerplate. Browser tab and SERP title are now just the area name (matches `og:title` and `twitter:title`).
  - **Per-page meta description** — renders the area's own `tags.description` when present; falls back to a localized sentence built from the area name. Normalized (whitespace collapsed, trimmed) and truncated at a word boundary with an
   ellipsis, capped at 200 chars to stay under SERP truncation. Uses `Intl.Segmenter` so the word boundary is respected for CJK/Thai too, and operates on code points so emoji can't be split. Mirrored to `og:description` and
  `twitter:description`.
  - **No more duplicate `<meta name="description">`** — the site-wide default used to live in `app.html` alongside the per-page one. Moved the default into the root layout behind a pathname guard so community/country routes only emit
  their own. Every other route keeps the same fallback it had before.
  - **Canonical URL** — every section (`/merchants`, `/stats`, `/activity`, `/maintain`) now emits `<link rel="canonical">` pointing at `/merchants`, consolidating ranking signal on one URL per area. The primary `/merchants` route gets
  a self-referencing canonical.
  - **Community favicon** — when an `icon:square` tag exists, the browser tab favicon becomes the community icon. Uses the raw `icon:square` URL (not Netlify's image CDN — that has a small `remote_images` allowlist and silently 400s for
   most hosts). Also removes the site-wide favicon links from the DOM on community routes so Chrome can't fall back to the global SVG favicon, which it would otherwise prefer regardless of declaration order. Country pages unchanged —
  they don't carry `icon:square` yet.
  - **Community share cards (OG / Twitter)** — `og:image` and `twitter:image` use the community's `icon:square` when available, falling back to the generic `communities.png` placeholder otherwise. Platforms will center-crop the square
  image, which is still better branding than the generic card.
  - **Reactive metadata on SPA navigation** — fixed a latent bug where destructuring `data` at setup left title/description/canonical/favicon pinned to the first-visited community when SvelteKit reused the page component across in-app
  navigation.
  - **Shared helper + tests** — extracted the normalization/truncation logic into `buildMetaDescription` in `$lib/utils` with unit tests covering fallback, whitespace normalization, word-boundary truncation, surrogate-pair safety, and
  the no-space-in-last-30% hard-cut fallback.
  - **Consistent URL encoding** — country breadcrumb now also wraps `data.id` in `encodeURIComponent` to match the community page and the canonical URL just below it.

  ## Not included / out of scope

  - **Broader `netlify.toml` `remote_images` allowlist** — only three hosts are allowlisted, so the Netlify image CDN silently 400s for most community icons (affects community cards, leaderboards, `AreaPage`, community map avatars).
  Favicons sidestep it in this PR via the raw URL, but the rest of the codebase is still affected — worth a separate PR.
  - **Dynamic OG image per community** as a true share card (wide format, composited with text) — would need a server-side image renderer (Satori / Netlify Edge).
  - **Account claiming / self-maintenance** and **community events** — both require API + auth work on `btcmap-api`.
  - **Title branding** (e.g. `{name} · BTC Map`) and **country intent keyword** (e.g. `Bitcoin in Germany`) — happy to follow up in a separate PR if desired; the opinion was the bare name is cleaner and better for personalization.
  - **`icon:wide` / `icon:og` priority** for share cards — trivial to add once those tags have CMS adoption.
  - **Localizing the new fallback descriptions** into non-English locales — `fallbackLocale: "en"` handles it for now; translators can fill in properly when convenient.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Area, community, and country pages now show optional area descriptions and square icons when available.
  * Enhanced SEO: dynamic meta titles, canonical links, and normalized/truncated meta descriptions used for page, Open Graph, and Twitter metadata.

* **Documentation**
  * Added localized fallback description strings for community and country pages.

* **Tests**
  * Added tests covering meta-description generation, trimming, truncation, and Unicode handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->