### PR TITLE
perf(images): skip Netlify image service for static icons #622

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -53,6 +53,7 @@ import type {
 } from "$lib/types.js";
 import { TipType } from "$lib/types.js";
 import {
+	areaIconSrc,
 	errToast,
 	formatVerifiedHuman,
 	parseDateSafely,
@@ -203,7 +204,7 @@ const initializeData = async () => {
 
 	avatar =
 		type === "community"
-			? `https://btcmap.org/.netlify/images?url=${area["icon:square"]}&fit=cover&w=256&h=256`
+			? areaIconSrc(area["icon:square"])
 			: `https://static.btcmap.org/images/countries/${areaFound.id}.svg`;
 	description = area.description;
 

--- a/src/components/leaderboard/AreaLeaderboardItemName.svelte
+++ b/src/components/leaderboard/AreaLeaderboardItemName.svelte
@@ -2,6 +2,7 @@
 import LeaderboardCountryName from "$components/leaderboard/LeaderboardCountryName.svelte";
 import { _ } from "$lib/i18n";
 import type { AreaType } from "$lib/types";
+import { areaIconSrc } from "$lib/utils";
 
 export let type: AreaType;
 export let avatar: string;
@@ -9,10 +10,7 @@ export let name: string;
 export let id: string;
 export let countryCode: string | undefined = undefined;
 
-$: avatarSrc =
-	type === "community"
-		? `https://btcmap.org/.netlify/images?url=${avatar}&fit=cover&w=256&h=256`
-		: avatar;
+$: avatarSrc = type === "community" ? areaIconSrc(avatar) : avatar;
 
 $: displayName = name || "Unknown";
 $: hasLongName = displayName?.match(/[^ ]{21}/);

--- a/src/components/leaderboard/AreaLeaderboardMobileCard.svelte
+++ b/src/components/leaderboard/AreaLeaderboardMobileCard.svelte
@@ -5,7 +5,7 @@ import GradeDisplay from "$components/leaderboard/GradeDisplay.svelte";
 import LeaderboardCountryName from "$components/leaderboard/LeaderboardCountryName.svelte";
 import { _ } from "$lib/i18n";
 import type { AreaType } from "$lib/types";
-import { isEven } from "$lib/utils";
+import { areaIconSrc, isEven } from "$lib/utils";
 
 export let table: Table<any>;
 export let type: AreaType;
@@ -71,7 +71,7 @@ export let type: AreaType;
 				<!-- Row 1: Larger Avatar -->
 				<div class="flex justify-center">
 					<img
-						src={`https://btcmap.org/.netlify/images?url=${area.icon || ''}&fit=cover&w=256&h=256`}
+						src={areaIconSrc(area.icon)}
 						alt="{area.name || 'Unknown'} avatar"
 						class="h-16 w-16 rounded-full object-cover"
 						on:error={(e) => {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -675,15 +675,9 @@ describe("areaIconSrc", () => {
 		);
 	});
 
-	it("handles null/undefined/empty inputs without throwing", () => {
-		expect(areaIconSrc(null)).toBe(
-			"https://btcmap.org/.netlify/images?url=&fit=cover&w=256&h=256",
-		);
-		expect(areaIconSrc(undefined)).toBe(
-			"https://btcmap.org/.netlify/images?url=&fit=cover&w=256&h=256",
-		);
-		expect(areaIconSrc("")).toBe(
-			"https://btcmap.org/.netlify/images?url=&fit=cover&w=256&h=256",
-		);
+	it("returns the bitcoin fallback for null/undefined/empty inputs", () => {
+		expect(areaIconSrc(null)).toBe("/images/bitcoin.svg");
+		expect(areaIconSrc(undefined)).toBe("/images/bitcoin.svg");
+		expect(areaIconSrc("")).toBe("/images/bitcoin.svg");
 	});
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { Area } from "$lib/types";
 
 import {
+	areaIconSrc,
 	buildMetaDescription,
 	calculateDistance,
 	formatDistance,
@@ -643,5 +644,46 @@ describe("isValidLongitude", () => {
 		expect(isValidLongitude(Number.NaN)).toBe(false);
 		expect(isValidLongitude(Number.POSITIVE_INFINITY)).toBe(false);
 		expect(isValidLongitude(Number.NEGATIVE_INFINITY)).toBe(false);
+	});
+});
+
+describe("areaIconSrc", () => {
+	it("returns the raw URL for static.btcmap.org/images/areas paths", () => {
+		const url = "https://static.btcmap.org/images/areas/abc.png";
+		expect(areaIconSrc(url)).toBe(url);
+		expect(areaIconSrc(url, 64)).toBe(url);
+	});
+
+	it("wraps non-static.btcmap.org URLs with the Netlify image service", () => {
+		const url = "https://ugc.production.linktr.ee/foo.webp";
+		expect(areaIconSrc(url)).toBe(
+			`https://btcmap.org/.netlify/images?url=${encodeURIComponent(url)}&fit=cover&w=256&h=256`,
+		);
+	});
+
+	it("respects a custom size", () => {
+		const url = "https://example.com/icon.png";
+		expect(areaIconSrc(url, 64)).toBe(
+			`https://btcmap.org/.netlify/images?url=${encodeURIComponent(url)}&fit=cover&w=64&h=64`,
+		);
+	});
+
+	it("does not bypass for paths outside /images/areas/", () => {
+		const url = "https://static.btcmap.org/images/countries/us.svg";
+		expect(areaIconSrc(url)).toBe(
+			`https://btcmap.org/.netlify/images?url=${encodeURIComponent(url)}&fit=cover&w=256&h=256`,
+		);
+	});
+
+	it("handles null/undefined/empty inputs without throwing", () => {
+		expect(areaIconSrc(null)).toBe(
+			"https://btcmap.org/.netlify/images?url=&fit=cover&w=256&h=256",
+		);
+		expect(areaIconSrc(undefined)).toBe(
+			"https://btcmap.org/.netlify/images?url=&fit=cover&w=256&h=256",
+		);
+		expect(areaIconSrc("")).toBe(
+			"https://btcmap.org/.netlify/images?url=&fit=cover&w=256&h=256",
+		);
 	});
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -554,3 +554,18 @@ export const buildMetaDescription = (
 			: cut.trimEnd();
 	return `${truncated}…`;
 };
+
+// Wraps an area icon URL with Netlify's image optimization service. Skips
+// the wrapper for icons already hosted on static.btcmap.org/images/areas/
+// since those are already 256×256 PNGs (re-optimizing is wasted work, and
+// the host allowlist also rejects most other origins). Issue #622.
+export const areaIconSrc = (
+	icon: string | null | undefined,
+	size = 256,
+): string => {
+	const src = icon ?? "";
+	if (src.startsWith("https://static.btcmap.org/images/areas/")) {
+		return src;
+	}
+	return `https://btcmap.org/.netlify/images?url=${encodeURIComponent(src)}&fit=cover&w=${size}&h=${size}`;
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -558,14 +558,18 @@ export const buildMetaDescription = (
 // Wraps an area icon URL with Netlify's image optimization service. Skips
 // the wrapper for icons already hosted on static.btcmap.org/images/areas/
 // since those are already 256×256 PNGs (re-optimizing is wasted work, and
-// the host allowlist also rejects most other origins). Issue #622.
+// the host allowlist also rejects most other origins). Falsy input
+// short-circuits to the bitcoin fallback to avoid a wasted 400 from
+// Netlify. Note: `size` is ignored for the static.btcmap.org passthrough —
+// callers requesting smaller sizes will receive the native 256 PNG and
+// rely on the browser to downscale. Issue #622.
 export const areaIconSrc = (
 	icon: string | null | undefined,
 	size = 256,
 ): string => {
-	const src = icon ?? "";
-	if (src.startsWith("https://static.btcmap.org/images/areas/")) {
-		return src;
+	if (!icon) return "/images/bitcoin.svg";
+	if (icon.startsWith("https://static.btcmap.org/images/areas/")) {
+		return icon;
 	}
-	return `https://btcmap.org/.netlify/images?url=${encodeURIComponent(src)}&fit=cover&w=${size}&h=${size}`;
+	return `https://btcmap.org/.netlify/images?url=${encodeURIComponent(icon)}&fit=cover&w=${size}&h=${size}`;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -556,13 +556,14 @@ export const buildMetaDescription = (
 };
 
 // Wraps an area icon URL with Netlify's image optimization service. Skips
-// the wrapper for icons already hosted on static.btcmap.org/images/areas/
-// since those are already 256×256 PNGs (re-optimizing is wasted work, and
-// the host allowlist also rejects most other origins). Falsy input
-// short-circuits to the bitcoin fallback to avoid a wasted 400 from
-// Netlify. Note: `size` is ignored for the static.btcmap.org passthrough —
-// callers requesting smaller sizes will receive the native 256 PNG and
-// rely on the browser to downscale. Issue #622.
+// the wrapper for icons under static.btcmap.org/images/areas/ — the new
+// standardized format there is 256×256 PNG. Migration to that format is
+// incremental, so legacy entries under the same path also bypass and are
+// served at their native size; we accept that trade-off to get the win on
+// already-migrated icons today. Falsy input short-circuits to the bitcoin
+// fallback to avoid a wasted 400 from Netlify. `size` is intentionally
+// ignored for the bypass path — callers asking for smaller sizes get the
+// native asset and rely on the browser to downscale. Issue #622.
 export const areaIconSrc = (
 	icon: string | null | undefined,
 	size = 256,

--- a/src/routes/about-us/components/AboutCommunity.svelte
+++ b/src/routes/about-us/components/AboutCommunity.svelte
@@ -3,6 +3,7 @@ import tippy from "tippy.js";
 
 import { _ } from "$lib/i18n";
 import type { Area } from "$lib/types";
+import { areaIconSrc } from "$lib/utils";
 
 import { resolve } from "$app/paths";
 
@@ -18,7 +19,7 @@ $: communityTooltip &&
 
 <a bind:this={communityTooltip} href={resolve(`/community/${encodeURIComponent(community.id)}`)}>
 	<img
-		src={`https://btcmap.org/.netlify/images?url=${community.tags['icon:square']}&fit=cover&w=256&h=256`}
+		src={areaIconSrc(community.tags['icon:square'])}
 		alt={$_('aria.avatarAlt')}
 		class="h-24 w-24 rounded-full object-cover"
 		on:error={function () {

--- a/src/routes/communities/[section]/components/CommunityCard.svelte
+++ b/src/routes/communities/[section]/components/CommunityCard.svelte
@@ -77,7 +77,7 @@ $: tip =
 		>
 			<img
 				loading="lazy"
-				src={image ? areaIconSrc(image) : '/images/bitcoin.svg'}
+				src={areaIconSrc(image)}
 				alt={tags.name}
 				class="mx-auto h-20 w-20 rounded-full object-cover"
 				on:error={function () {

--- a/src/routes/communities/[section]/components/CommunityCard.svelte
+++ b/src/routes/communities/[section]/components/CommunityCard.svelte
@@ -6,6 +6,7 @@ import Tip from "$components/Tip.svelte";
 import { getOrganizationDisplayName } from "$lib/organizationDisplayNames";
 import type { AreaTags } from "$lib/types";
 import { TipType } from "$lib/types";
+import { areaIconSrc } from "$lib/utils";
 
 import { resolve } from "$app/paths";
 
@@ -76,9 +77,7 @@ $: tip =
 		>
 			<img
 				loading="lazy"
-				src={image
-					? `https://btcmap.org/.netlify/images?url=${image}&fit=cover&w=256&h=256`
-					: '/images/bitcoin.svg'}
+				src={image ? areaIconSrc(image) : '/images/bitcoin.svg'}
 				alt={tags.name}
 				class="mx-auto h-20 w-20 rounded-full object-cover"
 				on:error={function () {

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -25,7 +25,7 @@ import { batchSync } from "$lib/sync/batchSync";
 import { reportsSync } from "$lib/sync/reports";
 import { theme } from "$lib/theme";
 import type { Leaflet, Theme } from "$lib/types";
-import { errToast } from "$lib/utils";
+import { areaIconSrc, errToast } from "$lib/utils";
 
 import { browser } from "$app/environment";
 import { resolve } from "$app/paths";
@@ -89,7 +89,7 @@ const initializeCommunities = () => {
 
 		popupContainer.innerHTML = `
 				<div class='text-center space-y-2'>
-					<img loading='lazy' src=${`https://btcmap.org/.netlify/images?url=${community.tags["icon:square"]}&fit=cover&w=256&h=256`} alt='${get(_)("communityMap.avatarAlt")}' class='w-24 h-24 rounded-full mx-auto' title='${get(_)("communityMap.communityIconTitle")}' onerror="this.src='/images/bitcoin.svg'" />
+					<img loading='lazy' src='${areaIconSrc(community.tags["icon:square"])}' alt='${get(_)("communityMap.avatarAlt")}' class='w-24 h-24 rounded-full mx-auto' title='${get(_)("communityMap.communityIconTitle")}' onerror="this.src='/images/bitcoin.svg'" />
 
 					<span class='text-primary dark:text-white font-semibold text-xl' title='${get(_)("communityMap.communityNameTitle")}'>${
 						community.tags.name

--- a/src/routes/map/components/CommunityRail.svelte
+++ b/src/routes/map/components/CommunityRail.svelte
@@ -14,7 +14,7 @@ import { merchantList } from "$lib/merchantListStore";
 import { areas } from "$lib/store";
 import { areasSync } from "$lib/sync/areas";
 import type { Area, Leaflet } from "$lib/types";
-import { getCommunitiesAtCoordinates } from "$lib/utils";
+import { areaIconSrc, getCommunitiesAtCoordinates } from "$lib/utils";
 
 import { resolve } from "$app/paths";
 
@@ -56,7 +56,7 @@ $: if (
 }
 
 const avatarUrl = (community: Area): string =>
-	`https://btcmap.org/.netlify/images?url=${encodeURIComponent(community.tags["icon:square"])}&fit=cover&w=64&h=64`;
+	areaIconSrc(community.tags["icon:square"], 64);
 
 const communityHref = (community: Area): string =>
 	resolve(`/community/${encodeURIComponent(community.id)}`);

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -42,6 +42,7 @@ import type {
 	PayMerchant,
 } from "$lib/types";
 import {
+	areaIconSrc,
 	formatOpeningHours,
 	formatVerifiedHuman,
 	isBoosted,
@@ -776,7 +777,7 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 							<div class="m-4 space-y-1 transition-transform hover:scale-110">
 								<a href={resolve(`/community/${encodeURIComponent(community.id)}`)}>
 									<img
-										src={`https://btcmap.org/.netlify/images?url=${community.tags['icon:square']}&fit=cover&w=256&h=256`}
+										src={areaIconSrc(community.tags['icon:square'])}
 										alt={$_('aria.logoAlt')}
 										class="mx-auto h-20 w-20 rounded-full object-cover"
 										on:error={function () {


### PR DESCRIPTION
Fixes: #622


  Re-routing static.btcmap.org/images/areas/ icons through the Netlify image optimization service is wasted work for the migrated assets (the new standardized format is 256×256 PNG already). Migration to that format is incremental, so
  legacy entries under the same path also bypass and are served at their native size — an accepted trade-off to get the win on migrated icons today. Anything outside /images/areas/ still goes through .netlify/images, where resizing
  matters and the remote_images allowlist in netlify.toml applies.

  Changes

  - New areaIconSrc(icon, size = 256) helper in src/lib/utils.ts:
    - Falsy input → returns /images/bitcoin.svg directly (avoids a wasted 400 from a malformed Netlify URL before onerror rescues).
    - https://static.btcmap.org/images/areas/... → returned as-is (size is intentionally ignored on this branch).
    - Everything else → wrapped in https://btcmap.org/.netlify/images?url=...&fit=cover&w=...&h=....
  - Replaces eight duplicated inline URL builders across components and routes (also adds consistent encodeURIComponent, which several call sites lacked).
  - Unit tests covering the bypass, the wrap, custom size, non-/images/areas/ static paths, and falsy input.

  Review-feedback adjustments

  - Null-safety: initial helper produced ?url=&w=256&h=256 for null/undefined/"" and Netlify 400'd; the <img> waited for the failed roundtrip before onerror swapped in the bitcoin fallback. Now short-circuits to /images/bitcoin.svg
  directly. Mainly helps AreaLeaderboardMobileCard, the only call site that passes area.icon unguarded.
  - Migration scope: the helper comment originally claimed all /images/areas/ icons are 256×256; corrected to reflect that the migration is incremental and the bypass is intentionally broad to capture migrated icons now while legacy
  ones ride along at native size.
  - size for the bypass branch: documented as intentionally ignored — CommunityRail requests size=64 and will receive the native asset; the browser downscales.

  Verification

  - pnpm run format:fix && pnpm run check && pnpm run lint && pnpm run test --run — all green (286 tests).
  - Manual sanity check: pages with missing icon:square render the bitcoin SVG with no .netlify/images 400 in the Network tab; community card grid, area leaderboard mobile, and AreaPage avatar still render real icons.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized community/area avatar sourcing site‑wide using a shared image URL helper for consistent, reliable avatars.
* **Bug Fixes**
  * Improved handling so communities without a specific icon still resolve and display a proper avatar.
* **Tests**
  * Added tests verifying image URL generation, sizing behavior, bypass rules, and fallback to the default icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->