### PR TITLE
fix(area-page): render community page when icon:square is missing

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -176,7 +176,6 @@ const initializeData = async () => {
 				area.tags.type === "community" &&
 				area.tags.geo_json &&
 				area.tags.name &&
-				area.tags["icon:square"] &&
 				area.tags.continent
 			);
 		} else {


### PR DESCRIPTION
Communities without an `icon:square` tag previously failed the find() predicate in AreaPage.initializeData() and were redirected to /404. Drop the icon requirement and fall back to /images/bitcoin.svg when the tag is absent, matching the existing on:error handler behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Community areas now appear correctly even when a square icon tag is missing.
* **Enhancements**
  * Avatar images for communities are now sourced consistently, improving display and fallback to the default bitcoin icon when needed.
* **Tests**
  * Added coverage to ensure icon URL handling and fallbacks behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->