### PR TITLE
Improve mobile modal UX with bottom sheet style

### DIFF
--- a/src/components/AppDownloadModal.svelte
+++ b/src/components/AppDownloadModal.svelte
@@ -3,7 +3,7 @@ import Modal from "$components/Modal.svelte";
 import type { AppConfig, StoreKey } from "$lib/apps";
 import IconApps from "$lib/icons/IconApps.svelte";
 
-export let app: AppConfig;
+export let app: AppConfig | null;
 export let open = false;
 
 const platformLabels: Record<string, string> = {
@@ -15,10 +15,11 @@ const platformLabels: Record<string, string> = {
 	mac: "macOS",
 };
 
-$: modalTitle =
-	app.tag === "btcmap"
+$: modalTitle = app
+	? app.tag === "btcmap"
 		? (platformLabels[app.stores[0]?.platform] ?? app.name)
-		: app.name;
+		: app.name
+	: "";
 
 const storeLabels: Record<StoreKey, string> = {
 	"app-store": "App Store",
@@ -33,19 +34,21 @@ const storeLabels: Record<StoreKey, string> = {
 </script>
 
 <Modal bind:open title={modalTitle} titleId="app-download-modal-title">
-	<ul class="space-y-2">
-		{#each app.stores as entry (entry.store + entry.platform)}
-			<li>
-				<a
-					href={entry.url}
-					target={entry.store === 'web' ? null : '_blank'}
-					rel={entry.store === 'web' ? null : 'noopener noreferrer'}
-					class="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left transition-colors hover:bg-gray-100 text-body dark:hover:bg-white/5 dark:text-white"
-				>
-					<IconApps icon={entry.store} w="20" h="20" />
-					<span class="text-sm font-medium">{storeLabels[entry.store]}</span>
-				</a>
-			</li>
-		{/each}
-	</ul>
+	{#if app}
+		<ul class="space-y-2">
+			{#each app.stores as entry (entry.store + entry.platform)}
+				<li>
+					<a
+						href={entry.url}
+						target={entry.store === 'web' ? null : '_blank'}
+						rel={entry.store === 'web' ? null : 'noopener noreferrer'}
+						class="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left transition-colors hover:bg-gray-100 text-body dark:hover:bg-white/5 dark:text-white"
+					>
+						<IconApps icon={entry.store} w="20" h="20" />
+						<span class="text-sm font-medium">{storeLabels[entry.store]}</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	{/if}
 </Modal>

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-import { tick } from "svelte";
+import { onDestroy, tick } from "svelte";
 import { fade, fly } from "svelte/transition";
 
 import CloseButton from "$components/CloseButton.svelte";
+import { lockBodyScroll, unlockBodyScroll } from "$lib/bodyScrollLock";
 
 export let open = false;
 export let title: string;
@@ -11,17 +12,13 @@ export let titleId: string = "modal-title";
 let triggerEl: HTMLElement | null = null;
 let modalEl: HTMLDivElement;
 let hasBeenOpened = false;
-let originalOverflow = "";
 
 $: if (open) {
 	hasBeenOpened = true;
 	if (!triggerEl && typeof document !== "undefined") {
 		triggerEl = document.activeElement as HTMLElement | null;
 	}
-	if (typeof document !== "undefined") {
-		originalOverflow = document.body.style.overflow;
-		document.body.style.overflow = "hidden";
-	}
+	lockBodyScroll();
 	tick().then(() => {
 		modalEl?.querySelector<HTMLElement>("button, a, [tabindex]")?.focus();
 	});
@@ -30,10 +27,12 @@ $: if (open) {
 		triggerEl?.focus();
 		triggerEl = null;
 	});
-	if (typeof document !== "undefined") {
-		document.body.style.overflow = originalOverflow || "";
-	}
+	unlockBodyScroll();
 }
+
+onDestroy(() => {
+	if (open) unlockBodyScroll();
+});
 
 function handleKeydown(e: KeyboardEvent) {
 	if (e.key === "Escape" && open) open = false;

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { tick } from "svelte";
-import { fly } from "svelte/transition";
+import { fade, fly } from "svelte/transition";
 
 import CloseButton from "$components/CloseButton.svelte";
 
@@ -50,6 +50,7 @@ export function setTrigger(el: HTMLElement) {
 	<!-- svelte-ignore a11y-no-static-element-interactions - Backdrop click closes modal, keyboard handled by dialog -->
 	<!-- svelte-ignore a11y-click-events-have-key-events - Keyboard close handled by global Escape listener and dialog focus -->
 	<div
+		transition:fade={{ duration: 200 }}
 		class="fixed inset-0 z-[1000] bg-black/40 dark:bg-black/60"
 		on:click={() => (open = false)}
 		aria-hidden="true"

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 import { tick } from "svelte";
 import { fly } from "svelte/transition";
-import OutClick from "svelte-outclick";
 
 import CloseButton from "$components/CloseButton.svelte";
 
@@ -12,11 +11,16 @@ export let titleId: string = "modal-title";
 let triggerEl: HTMLElement | null = null;
 let modalEl: HTMLDivElement;
 let hasBeenOpened = false;
+let originalOverflow = "";
 
 $: if (open) {
 	hasBeenOpened = true;
 	if (!triggerEl && typeof document !== "undefined") {
 		triggerEl = document.activeElement as HTMLElement | null;
+	}
+	if (typeof document !== "undefined") {
+		originalOverflow = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
 	}
 	tick().then(() => {
 		modalEl?.querySelector<HTMLElement>("button, a, [tabindex]")?.focus();
@@ -26,6 +30,9 @@ $: if (open) {
 		triggerEl?.focus();
 		triggerEl = null;
 	});
+	if (typeof document !== "undefined") {
+		document.body.style.overflow = originalOverflow || "";
+	}
 }
 
 function handleKeydown(e: KeyboardEvent) {
@@ -40,25 +47,31 @@ export function setTrigger(el: HTMLElement) {
 <svelte:window on:keydown={handleKeydown} />
 
 {#if open}
-	<OutClick on:outclick={() => (open = false)}>
-		<div
-			bind:this={modalEl}
-			transition:fly={{ y: 200, duration: 300 }}
-			role="dialog"
-			aria-modal="true"
-			aria-labelledby={titleId}
-			class="z-[2000] flex flex-col overflow-hidden border border-gray-300 bg-white shadow-2xl fixed inset-x-4 bottom-4 max-h-[85dvh] rounded-2xl dark:border-white/95 dark:bg-dark sm:inset-auto sm:top-1/2 sm:left-1/2 sm:w-80 sm:max-h-[90vh] sm:h-auto sm:rounded-xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:px-6 sm:py-6 px-5 py-5"
-		>
-			<div class="mb-4 flex items-center justify-between">
-				<h2 id={titleId} class="text-lg font-semibold text-primary dark:text-white">
-					{title}
-				</h2>
-				<CloseButton on:click={() => (open = false)} />
-			</div>
+	<!-- svelte-ignore a11y-no-static-element-interactions - Backdrop click closes modal, keyboard handled by dialog -->
+	<!-- svelte-ignore a11y-click-events-have-key-events - Keyboard close handled by global Escape listener and dialog focus -->
+	<div
+		class="fixed inset-0 z-[1000] bg-black/40 dark:bg-black/60"
+		on:click={() => (open = false)}
+		aria-hidden="true"
+	/>
 
-			<div class="flex-1 overflow-y-auto -mx-5 px-5">
-				<slot />
-			</div>
+	<div
+		bind:this={modalEl}
+		transition:fly={{ y: 200, duration: 300 }}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby={titleId}
+		class="fixed inset-x-4 bottom-4 z-[2000] flex max-h-[85dvh] flex-col overflow-hidden rounded-2xl border border-gray-300 bg-white px-5 py-5 shadow-2xl dark:border-white/95 dark:bg-dark sm:inset-auto sm:top-1/2 sm:left-1/2 sm:h-auto sm:w-80 sm:max-h-[90vh] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-xl sm:px-6 sm:py-6"
+	>
+		<div class="mb-4 flex items-center justify-between">
+			<h2 id={titleId} class="text-lg font-semibold text-primary dark:text-white">
+				{title}
+			</h2>
+			<CloseButton on:click={() => (open = false)} />
 		</div>
-	</OutClick>
+
+		<div class="min-h-0 flex-1 overflow-y-auto -mx-5 px-5 sm:-mx-6 sm:px-6">
+			<slot />
+		</div>
+	</div>
 {/if}

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -47,7 +47,7 @@ export function setTrigger(el: HTMLElement) {
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby={titleId}
-			class="z-[2000] flex flex-col overflow-auto border border-gray-300 bg-white p-6 shadow-2xl fixed inset-0 w-full h-full dark:border-white/95 dark:bg-dark md:inset-auto md:top-1/2 md:left-1/2 md:w-80 md:max-h-[90vh] md:h-auto md:rounded-xl md:translate-x-[-50%] md:translate-y-[-50%]"
+			class="z-[2000] flex flex-col overflow-hidden border border-gray-300 bg-white shadow-2xl fixed inset-x-4 bottom-4 max-h-[85dvh] rounded-2xl dark:border-white/95 dark:bg-dark sm:inset-auto sm:top-1/2 sm:left-1/2 sm:w-80 sm:max-h-[90vh] sm:h-auto sm:rounded-xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:px-6 sm:py-6 px-5 py-5"
 		>
 			<div class="mb-4 flex items-center justify-between">
 				<h2 id={titleId} class="text-lg font-semibold text-primary dark:text-white">
@@ -56,7 +56,9 @@ export function setTrigger(el: HTMLElement) {
 				<CloseButton on:click={() => (open = false)} />
 			</div>
 
-			<slot />
+			<div class="flex-1 overflow-y-auto -mx-5 px-5">
+				<slot />
+			</div>
 		</div>
 	</OutClick>
 {/if}

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -12,13 +12,17 @@ export let titleId: string = "modal-title";
 let triggerEl: HTMLElement | null = null;
 let modalEl: HTMLDivElement;
 let hasBeenOpened = false;
+let scrollLocked = false;
 
 $: if (open) {
 	hasBeenOpened = true;
 	if (!triggerEl && typeof document !== "undefined") {
 		triggerEl = document.activeElement as HTMLElement | null;
 	}
-	lockBodyScroll();
+	if (!scrollLocked) {
+		lockBodyScroll();
+		scrollLocked = true;
+	}
 	tick().then(() => {
 		modalEl?.querySelector<HTMLElement>("button, a, [tabindex]")?.focus();
 	});
@@ -27,11 +31,14 @@ $: if (open) {
 		triggerEl?.focus();
 		triggerEl = null;
 	});
-	unlockBodyScroll();
+	if (scrollLocked) {
+		unlockBodyScroll();
+		scrollLocked = false;
+	}
 }
 
 onDestroy(() => {
-	if (open) unlockBodyScroll();
+	if (scrollLocked) unlockBodyScroll();
 });
 
 function handleKeydown(e: KeyboardEvent) {

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -53,8 +53,6 @@ export function setTrigger(el: HTMLElement) {
 <svelte:window on:keydown={handleKeydown} />
 
 {#if open}
-	<!-- svelte-ignore a11y-no-static-element-interactions - Backdrop click closes modal, keyboard handled by dialog -->
-	<!-- svelte-ignore a11y-click-events-have-key-events - Keyboard close handled by global Escape listener and dialog focus -->
 	<div
 		transition:fade={{ duration: 200 }}
 		class="fixed inset-0 z-[1000] bg-black/40 dark:bg-black/60"

--- a/src/lib/bodyScrollLock.ts
+++ b/src/lib/bodyScrollLock.ts
@@ -1,0 +1,20 @@
+// Ref-counted body scroll lock so multiple components can independently
+// lock/unlock without clobbering each other.
+let lockCount = 0;
+
+export function lockBodyScroll(): void {
+	if (typeof document === "undefined") return;
+	if (lockCount === 0) {
+		document.body.style.overflow = "hidden";
+	}
+	lockCount++;
+}
+
+export function unlockBodyScroll(): void {
+	if (typeof document === "undefined") return;
+	if (lockCount <= 0) return;
+	lockCount--;
+	if (lockCount === 0) {
+		document.body.style.overflow = "";
+	}
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,7 +32,7 @@ const platformLabels: Record<string, string> = {
 	web: "Web",
 };
 
-$: if (!modalOpen) activeApp = null;
+$: if (!modalOpen) setTimeout(() => (activeApp = null), 300);
 
 function openAppModal(app: AppConfig) {
 	if (app.stores.length === 1) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { tick } from "svelte";
 import { _ } from "svelte-i18n";
 
 import AppDownloadModal from "$components/AppDownloadModal.svelte";
@@ -43,7 +44,9 @@ function openAppModal(app: AppConfig) {
 		}
 	} else {
 		activeApp = app;
-		modalOpen = true;
+		tick().then(() => {
+			modalOpen = true;
+		});
 	}
 }
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { tick } from "svelte";
 import { _ } from "svelte-i18n";
 
 import AppDownloadModal from "$components/AppDownloadModal.svelte";
@@ -57,9 +56,7 @@ function openAppModal(app: AppConfig) {
 		}
 	} else {
 		activeApp = app;
-		tick().then(() => {
-			modalOpen = true;
-		});
+		modalOpen = true;
 	}
 }
 </script>
@@ -78,9 +75,7 @@ function openAppModal(app: AppConfig) {
 		class="absolute top-0 right-0 xl:hidden dark:opacity-10"
 	/>
 	<Header />
-	{#if activeApp}
-		<AppDownloadModal app={activeApp} bind:open={modalOpen} />
-	{/if}
+	<AppDownloadModal app={activeApp} bind:open={modalOpen} />
 
 	<div class="relative mx-auto w-10/12 xl:w-[1200px]">
 		<section id="hero" class="items-center justify-between pt-10 pb-20 xl:flex xl:pt-0">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -19,6 +19,7 @@ const btcmapApps = appConfigs.filter((a) => a.tag === "btcmap");
 
 let activeApp: AppConfig | null = null;
 let modalOpen = false;
+let clearActiveAppTimer: ReturnType<typeof setTimeout> | null = null;
 
 const platformIcons: Record<string, AppIconName> = {
 	android: "android",
@@ -32,7 +33,19 @@ const platformLabels: Record<string, string> = {
 	web: "Web",
 };
 
-$: if (!modalOpen) setTimeout(() => (activeApp = null), 300);
+$: handleModalOpenChange(modalOpen);
+
+function handleModalOpenChange(open: boolean) {
+	if (!open && clearActiveAppTimer === null) {
+		clearActiveAppTimer = setTimeout(() => {
+			activeApp = null;
+			clearActiveAppTimer = null;
+		}, 300);
+	} else if (open && clearActiveAppTimer !== null) {
+		clearTimeout(clearActiveAppTimer);
+		clearActiveAppTimer = null;
+	}
+}
 
 function openAppModal(app: AppConfig) {
 	if (app.stores.length === 1) {

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -5,6 +5,7 @@ import Icon from "$components/Icon.svelte";
 import LoadingSpinner from "$components/LoadingSpinner.svelte";
 import SearchInput from "$components/SearchInput.svelte";
 import { trackEvent } from "$lib/analytics";
+import { lockBodyScroll, unlockBodyScroll } from "$lib/bodyScrollLock";
 import {
 	CATEGORY_ENTRIES,
 	type CategoryCounts,
@@ -75,7 +76,7 @@ let searchInputComponent: SearchInput;
 // Local filter for nearby mode (client-side filtering by name)
 let nearbyFilter = "";
 
-// Body scroll lock for mobile (prevents iOS background scroll)
+// Body scroll lock state for mobile (prevents iOS background scroll)
 let scrollLockActive = false;
 
 // Reference for focus trap
@@ -256,10 +257,10 @@ $: if (browser && isOpen !== undefined) {
 	const isMobile = window.innerWidth < BREAKPOINTS.md;
 	const shouldLock = isOpen && isMobile;
 	if (shouldLock && !scrollLockActive) {
-		document.body.style.overflow = "hidden";
+		lockBodyScroll();
 		scrollLockActive = true;
 	} else if (!shouldLock && scrollLockActive) {
-		document.body.style.overflow = "";
+		unlockBodyScroll();
 		scrollLockActive = false;
 	}
 }
@@ -338,7 +339,8 @@ function handleWindowKeydown(event: KeyboardEvent) {
 // Cleanup scroll lock when component is destroyed
 onDestroy(() => {
 	if (browser && scrollLockActive) {
-		document.body.style.overflow = "";
+		unlockBodyScroll();
+		scrollLockActive = false;
 	}
 });
 </script>


### PR DESCRIPTION
## Does this PR address a related issue?

No related issue.

## Description

Makes language and apps modals more mobile-friendly with:
- Bottom sheet style on mobile (slides up from bottom with rounded corners)
- Better spacing with padding on mobile
- Scrollable content area with proper overflow handling
- Desktop modal remains centered with standard styling

### Review fixes applied on top of #901:
- Add full-viewport backdrop to prevent clicks on underlying content when modal is open
- Add `min-h-0` to scrollable flex child for proper overflow/scroll behaviour
- Fix responsive padding alignment at `sm+` breakpoint (`sm:-mx-6 sm:px-6`)
- Lock body scroll while modal is open, restore on close
- Add `fade` transition to backdrop so it eases in alongside the sheet slide-up

## Screenshots

N/A

## Additional context

Supersedes #901 (cross-repo PR from fork — review fixes could not be pushed back to the fork branch).

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backdrop clicks consistently close modals.
  * Background page scrolling is reliably locked while modals or panels are open.
  * Modal transitions smoothed for cleaner open/close animation.

* **New Features**
  * Modals remain mounted briefly after close to prevent flicker; content may temporarily be empty if no app is selected.
  * Download links are hidden when no app is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->