### PR TITLE
feat(apps): add Aqua as sponsor with explicit sponsor ordering

### DIFF
--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -25,6 +25,8 @@ export type AppConfig = {
 	logo: string;
 	tag: AppTag;
 	sponsor: boolean;
+	// explicit display order for sponsor cards; non-sponsors are sorted alphabetically after
+	sponsorOrder?: number;
 	stores: AppStoreEntry[];
 };
 
@@ -121,6 +123,7 @@ export const appConfigs: AppConfig[] = [
 		logo: "/images/apps/wos.png",
 		tag: "powered-by-btcmap",
 		sponsor: true,
+		sponsorOrder: 2,
 		stores: [
 			{
 				store: "google-play",
@@ -168,7 +171,8 @@ export const appConfigs: AppConfig[] = [
 		name: "Aqua",
 		logo: "/images/apps/aqua.png",
 		tag: "powered-by-btcmap",
-		sponsor: false,
+		sponsor: true,
+		sponsorOrder: 4,
 		stores: [
 			{
 				store: "google-play",
@@ -193,6 +197,7 @@ export const appConfigs: AppConfig[] = [
 		logo: "/images/apps/cash-app.webp",
 		tag: "powered-by-btcmap",
 		sponsor: true,
+		sponsorOrder: 1,
 		stores: [
 			{
 				store: "google-play",
@@ -212,6 +217,7 @@ export const appConfigs: AppConfig[] = [
 		logo: "/images/apps/coinos.webp",
 		tag: "powered-by-btcmap",
 		sponsor: true,
+		sponsorOrder: 3,
 		stores: [
 			{
 				store: "zapstore",

--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -18,17 +18,18 @@ export type AppStoreEntry = {
 	url: string;
 };
 
-export type AppConfig = {
+type AppConfigBase = {
 	id: string;
 	name: string;
 	// path in /static, e.g. '/images/apps/btcmap.png'
 	logo: string;
 	tag: AppTag;
-	sponsor: boolean;
-	// explicit display order for sponsor cards; non-sponsors are sorted alphabetically after
-	sponsorOrder?: number;
 	stores: AppStoreEntry[];
 };
+
+export type AppConfig =
+	| (AppConfigBase & { sponsor: true; sponsorOrder: number })
+	| (AppConfigBase & { sponsor: false; sponsorOrder?: never });
 
 export const appConfigs: AppConfig[] = [
 	{

--- a/src/routes/apps/+page.svelte
+++ b/src/routes/apps/+page.svelte
@@ -9,7 +9,13 @@ import AppCard from "./components/AppCard.svelte";
 const btcmapApps = appConfigs.filter((a) => a.tag === "btcmap");
 const poweredByApps = appConfigs
 	.filter((a) => a.tag === "powered-by-btcmap")
-	.sort((a, b) => Number(b.sponsor) - Number(a.sponsor));
+	.sort((a, b) => {
+		const aOrder = a.sponsorOrder ?? Infinity;
+		const bOrder = b.sponsorOrder ?? Infinity;
+		if (aOrder !== bOrder) return aOrder - bOrder;
+		// non-sponsors (both Infinity) fall through to alphabetical
+		return a.name.localeCompare(b.name);
+	});
 const comingSoonApps = appConfigs.filter((a) => a.tag === "coming-soon");
 </script>
 


### PR DESCRIPTION
## Summary

- Adds Aqua wallet as a sponsor on the `/apps` page
- Introduces an optional `sponsorOrder` field on `AppConfig` for explicit control over sponsor card display order
- Sponsors now display in order: **Cash App → Wallet of Satoshi → Coinos → Aqua**
- Non-sponsor apps follow alphabetically after all sponsors