### PR TITLE
fix(i18n): remove trailing periods from EN H1 headings

### DIFF
--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1,6 +1,6 @@
 {
 	"home": {
-		"hero": "Find places to spend sats wherever you are.",
+		"hero": "Find places to spend sats wherever you are",
 		"openMap": "Open Map",
 		"addLocation": "Add Location",
 		"description": "We use {osmLink} to tag places that accept bitcoin and we display those merchants in our beautiful apps.",
@@ -495,7 +495,7 @@
 		"captchaPlaceholder": "Please enter the captcha text."
 	},
 	"addLocation": {
-		"hero": "Accept bitcoin? Get found.",
+		"hero": "Accept bitcoin? Get found",
 		"businessOwner": "If you're a business owner, please read our",
 		"bestPractices": "Merchant Best Practices",
 		"guide": "guide.",
@@ -547,7 +547,7 @@
 		"submitAnother": "Submit another {type}"
 	},
 	"verifyLocation": {
-		"hero": "Help improve the data for everyone.",
+		"hero": "Help improve the data for everyone",
 		"heading": "Verify Location",
 		"subheading": "(Ensure the information is still accurate and update it otherwise.)",
 		"descriptionPart1": "Please fill out the following form and one of our volunteer community members will update your location on the map. Did you know you can update this data yourself on",
@@ -631,7 +631,7 @@
 		"of": "of"
 	},
 	"communities": {
-		"hero": "Join the bitcoin map community.",
+		"hero": "Join the bitcoin map community",
 		"description": "Take ownership of your local bitcoin mapping data and help drive adoption. Bitcoin communities are the spark that ignites the movement. Join your friends, onboard businesses and have fun!",
 		"leaderboardHero": "Top Communities",
 		"leaderboardDescription": "Bitcoin mapping communities maintain their local datasets and strive to have the most accurate information. They also help onboard new merchants in their area!",
@@ -894,7 +894,7 @@
 		"tableTitle": "Global Issues"
 	},
 	"countries": {
-		"hero": "Bitcoin adoption by countries.",
+		"hero": "Bitcoin adoption by countries",
 		"description": "Your country? Your map!",
 		"viewLeaderboard": "View leaderboard",
 		"viewDirectory": "View directory",
@@ -983,7 +983,7 @@
 		}
 	},
 	"apps": {
-		"hero": "Find merchants on any platform.",
+		"hero": "Find merchants on any platform",
 		"subheading": "We have you covered on whatever device and OS you choose.",
 		"btcmap": "BTC Map Apps",
 		"poweredBy": "Powered by BTC Map",
@@ -1031,7 +1031,7 @@
 	},
 	"supporters": {
 		"title": "Supporters",
-		"hero": "Help place bitcoin on the map.",
+		"hero": "Help place bitcoin on the map",
 		"tiers": {
 			"explorer": { "headline": "Loving what we do" },
 			"wayfinder": { "headline": "Supporting the mission" },

--- a/tests/areas.spec.ts
+++ b/tests/areas.spec.ts
@@ -32,7 +32,7 @@ test.describe('Areas', () => {
 		await expect(page).toHaveURL(/communities/);
 
 		const communityHeading = page.getByRole('heading', {
-			name: 'Join the bitcoin map community.'
+			name: 'Join the bitcoin map community'
 		});
 		await expect(communityHeading).toBeVisible();
 

--- a/tests/countries.spec.ts
+++ b/tests/countries.spec.ts
@@ -9,7 +9,7 @@ test.describe('Countries', () => {
 
 		// Wait for the page to load
 		const heading = page.getByRole('heading', {
-			name: 'Bitcoin adoption by countries.'
+			name: 'Bitcoin adoption by countries'
 		});
 		await heading.waitFor({ state: 'visible' });
 		await expect(heading).toBeVisible();
@@ -29,7 +29,7 @@ test.describe('Countries', () => {
 
 		// Wait for the page to load
 		const heading = page.getByRole('heading', {
-			name: 'Bitcoin adoption by countries.'
+			name: 'Bitcoin adoption by countries'
 		});
 		await heading.waitFor({ state: 'visible' });
 

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -7,12 +7,12 @@ test.describe('Home Page', () => {
 		await page.waitForLoadState('domcontentloaded');
 
 		const heading = page.getByRole('heading', {
-			name: 'Find places to spend sats wherever you are.'
+			name: 'Find places to spend sats wherever you are'
 		});
 		await expect(heading).toBeVisible();
 
 		await page.getByRole('link', { name: 'Add Location' }).click();
 
-		await expect(page.getByRole('heading', { name: 'Accept bitcoin? Get found.' })).toBeVisible();
+		await expect(page.getByRole('heading', { name: 'Accept bitcoin? Get found' })).toBeVisible();
 	});
 });


### PR DESCRIPTION
## Summary

- Removes trailing periods from all English H1 heading strings in `en.json`
- Affected keys: `home.hero`, `apps.hero`, `addLocation.hero`, `communities.hero`, `countries.hero`, `supporters.hero`, `verifyLocation.hero`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated English text formatting by removing trailing punctuation from hero section strings across multiple pages, including home, location verification, communities, countries, apps, and supporters sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->