### PR TITLE
fix: align 12-month recency state across all views #964

### DIFF
--- a/src/components/area/AreaMerchantDrawer.svelte
+++ b/src/components/area/AreaMerchantDrawer.svelte
@@ -5,14 +5,13 @@ import CloseButton from "$components/CloseButton.svelte";
 import MerchantDetailsContent from "$components/MerchantDetailsContent.svelte";
 import {
 	handleBoost as boostMerchant,
-	calcVerifiedDate,
 	isBoosted as checkBoosted,
-	isUpToDate as checkUpToDate,
 	clearBoostState,
 	fetchMerchantDetails,
 } from "$lib/merchantDrawerLogic";
 import { boost } from "$lib/store";
 import type { Place } from "$lib/types";
+import { isUpToDate as checkUpToDate } from "$lib/verification";
 
 export let merchantId: number | null = null;
 export let onClose: () => void;
@@ -22,8 +21,7 @@ let isLoading = false;
 let lastFetchedId: number | null = null;
 let abortController: AbortController | null = null;
 
-const verifiedDate = calcVerifiedDate();
-$: isUpToDate = checkUpToDate(merchant, verifiedDate);
+$: isUpToDate = checkUpToDate(merchant);
 $: isBoosted = checkBoosted(merchant);
 
 let boostLoading = false;

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -10,7 +10,6 @@ export let data: AreaPageProps;
 
 import rewind from "@mapbox/geojson-rewind";
 import { geoContains } from "d3-geo";
-import { differenceInMonths } from "date-fns/differenceInMonths";
 import { onMount } from "svelte";
 
 import AreaActivity from "$components/area/AreaActivity.svelte";
@@ -56,9 +55,9 @@ import {
 	areaIconSrc,
 	errToast,
 	formatVerifiedHuman,
-	parseDateSafely,
 	validateContinents,
 } from "$lib/utils";
+import { isRecentlyVerified } from "$lib/verification";
 
 onMount(() => {
 	batchSync([areasSync, reportsSync, eventsSync, usersSync]);
@@ -258,7 +257,7 @@ const initializeData = async () => {
 			signal
 		);
 		verifiedDate = data.verifiedDate || area["verified:date"];
-		isVerifiedDateStale = calculateStaleness(verifiedDate);
+		isVerifiedDateStale = !isRecentlyVerified(verifiedDate);
 
 		if (area["tips:lightning_address"]) {
 			lightning = {
@@ -363,14 +362,7 @@ let signal: string | undefined;
 let verifiedDate: string | undefined = data.verifiedDate;
 let hasContact = false;
 
-const calculateStaleness = (dateStr: string | undefined): boolean => {
-	if (!dateStr) return false;
-	const date = parseDateSafely(dateStr);
-	if (!date) return false;
-	return differenceInMonths(new Date(), date) > 12;
-};
-
-let isVerifiedDateStale: boolean = calculateStaleness(data.verifiedDate);
+let isVerifiedDateStale: boolean = !isRecentlyVerified(data.verifiedDate);
 let lightning: { destination: string; type: TipType } | undefined;
 
 let taggers: Tagger[] = [];

--- a/src/components/area/MerchantCard.svelte
+++ b/src/components/area/MerchantCard.svelte
@@ -6,9 +6,10 @@ import tippy, { type Instance } from "tippy.js";
 import BoostButton from "$components/BoostButton.svelte";
 import Icon from "$components/Icon.svelte";
 import { _ } from "$lib/i18n";
-import { calcVerifiedDate, verifiedArr } from "$lib/map/setup";
+import { verifiedArr } from "$lib/map/setup";
 import type { Place } from "$lib/types";
 import { fetchEnhancedPlace, formatOpeningHours, isBoosted } from "$lib/utils";
+import { calcVerifiedDate } from "$lib/verification";
 
 import { resolve } from "$app/paths";
 

--- a/src/components/area/MerchantCard.svelte
+++ b/src/components/area/MerchantCard.svelte
@@ -6,10 +6,9 @@ import tippy, { type Instance } from "tippy.js";
 import BoostButton from "$components/BoostButton.svelte";
 import Icon from "$components/Icon.svelte";
 import { _ } from "$lib/i18n";
-import { verifiedArr } from "$lib/map/setup";
 import type { Place } from "$lib/types";
 import { fetchEnhancedPlace, formatOpeningHours, isBoosted } from "$lib/utils";
-import { isRecentlyVerified } from "$lib/verification";
+import { isRecentlyVerified, verifiedArr } from "$lib/verification";
 
 import { resolve } from "$app/paths";
 

--- a/src/components/area/MerchantCard.svelte
+++ b/src/components/area/MerchantCard.svelte
@@ -13,7 +13,7 @@ import {
 	formatVerifiedHuman,
 	isBoosted,
 } from "$lib/utils";
-import { isRecentlyVerified, verifiedArr } from "$lib/verification";
+import { isRecentlyVerified } from "$lib/verification";
 
 import { resolve } from "$app/paths";
 
@@ -69,7 +69,7 @@ $: email = displayMerchant?.email;
 $: twitter = displayMerchant?.twitter;
 $: instagram = displayMerchant?.instagram;
 $: facebook = displayMerchant?.facebook;
-$: verified = displayMerchant ? verifiedArr(displayMerchant) : [];
+$: verifiedAt = displayMerchant?.verified_at;
 
 let outdatedTooltip: HTMLDivElement;
 let outdatedTooltipInstance: Instance | null = null;
@@ -225,15 +225,15 @@ onDestroy(() => {
 	</div>
 
 	<div class="w-full space-y-2 border-t border-gray-300 pt-3 dark:border-gray-300/25">
-		{#if verified.length}
+		{#if verifiedAt}
 			<div class="flex items-center space-x-1">
 				<p class="text-sm font-semibold text-gray-500 dark:text-gray-400">
 					Last Surveyed: <span class="text-primary dark:text-white"
-						>{formatVerifiedHuman(verified[0])}</span
+						>{formatVerifiedHuman(verifiedAt)}</span
 					>
 				</p>
 
-				{#if !isRecentlyVerified(verified[0])}
+				{#if !isRecentlyVerified(verifiedAt)}
 					<div bind:this={outdatedTooltip} class="text-primary dark:text-white">
 						<Icon w="16" h="16" icon="error_outline" type="material" class="shrink-0" />
 					</div>

--- a/src/components/area/MerchantCard.svelte
+++ b/src/components/area/MerchantCard.svelte
@@ -7,7 +7,12 @@ import BoostButton from "$components/BoostButton.svelte";
 import Icon from "$components/Icon.svelte";
 import { _ } from "$lib/i18n";
 import type { Place } from "$lib/types";
-import { fetchEnhancedPlace, formatOpeningHours, isBoosted } from "$lib/utils";
+import {
+	fetchEnhancedPlace,
+	formatOpeningHours,
+	formatVerifiedHuman,
+	isBoosted,
+} from "$lib/utils";
 import { isRecentlyVerified, verifiedArr } from "$lib/verification";
 
 import { resolve } from "$app/paths";
@@ -223,7 +228,9 @@ onDestroy(() => {
 		{#if verified.length}
 			<div class="flex items-center space-x-1">
 				<p class="text-sm font-semibold text-gray-500 dark:text-gray-400">
-					Last Surveyed: <span class="text-primary dark:text-white">{verified[0]}</span>
+					Last Surveyed: <span class="text-primary dark:text-white"
+						>{formatVerifiedHuman(verified[0])}</span
+					>
 				</p>
 
 				{#if !isRecentlyVerified(verified[0])}

--- a/src/components/area/MerchantCard.svelte
+++ b/src/components/area/MerchantCard.svelte
@@ -9,7 +9,7 @@ import { _ } from "$lib/i18n";
 import { verifiedArr } from "$lib/map/setup";
 import type { Place } from "$lib/types";
 import { fetchEnhancedPlace, formatOpeningHours, isBoosted } from "$lib/utils";
-import { calcVerifiedDate } from "$lib/verification";
+import { isRecentlyVerified } from "$lib/verification";
 
 import { resolve } from "$app/paths";
 
@@ -66,7 +66,6 @@ $: twitter = displayMerchant?.twitter;
 $: instagram = displayMerchant?.instagram;
 $: facebook = displayMerchant?.facebook;
 $: verified = displayMerchant ? verifiedArr(displayMerchant) : [];
-const verifiedDate = calcVerifiedDate();
 
 let outdatedTooltip: HTMLDivElement;
 let outdatedTooltipInstance: Instance | null = null;
@@ -228,7 +227,7 @@ onDestroy(() => {
 					Last Surveyed: <span class="text-primary dark:text-white">{verified[0]}</span>
 				</p>
 
-				{#if !(Date.parse(verified[0]) > verifiedDate)}
+				{#if !isRecentlyVerified(verified[0])}
 					<div bind:this={outdatedTooltip} class="text-primary dark:text-white">
 						<Icon w="16" h="16" icon="error_outline" type="material" class="shrink-0" />
 					</div>

--- a/src/lib/map/setup.ts
+++ b/src/lib/map/setup.ts
@@ -603,12 +603,6 @@ export const dataRefresh = (
 	DomEvent.disableClickPropagation(dataRefreshButton);
 };
 
-export const calcVerifiedDate = () => {
-	const verifiedDate = new Date();
-	const previousYear = verifiedDate.getFullYear() - 1;
-	return verifiedDate.setFullYear(previousYear);
-};
-
 export const generateLocationIcon = (L: Leaflet) => {
 	return L.divIcon({
 		className: "div-icon",

--- a/src/lib/map/setup.ts
+++ b/src/lib/map/setup.ts
@@ -11,7 +11,7 @@ import en from "$lib/i18n/locales/en.json";
 import { session } from "$lib/session";
 import { selectedMerchant } from "$lib/store";
 import { theme } from "$lib/theme";
-import type { BaseMaps, DomEventType, Leaflet, Place, Theme } from "$lib/types";
+import type { BaseMaps, DomEventType, Leaflet, Theme } from "$lib/types";
 import { userLocation } from "$lib/userLocationStore";
 import { errToast, humanizeIconName } from "$lib/utils";
 
@@ -746,58 +746,6 @@ export const generateIcon = (
 	}) as DivIconWithInstances;
 	divIcon._iconInstances = instances;
 	return divIcon;
-};
-
-// Cache verification arrays keyed by id + updated_at so stale entries are
-// naturally displaced when a Place object is updated. Falls back to id-only
-// when updated_at is absent. MAX_CACHE_SIZE caps memory in long sessions.
-const MAX_CACHE_SIZE = 100;
-const verifiedCache = new Map<string, string[]>();
-
-export const verifiedArr = (place: Place): string[] => {
-	const cacheKey = `${place.id}:${place.updated_at ?? ""}`;
-
-	if (verifiedCache.has(cacheKey)) {
-		// Move to end (most recently used)
-		const cached = verifiedCache.get(cacheKey)!;
-		verifiedCache.delete(cacheKey);
-		verifiedCache.set(cacheKey, cached);
-		return cached;
-	}
-
-	const verified: string[] = [];
-
-	if (place["osm:survey:date"] && Date.parse(place["osm:survey:date"])) {
-		verified.push(place["osm:survey:date"]);
-	}
-
-	if (place["osm:check_date"] && Date.parse(place["osm:check_date"])) {
-		verified.push(place["osm:check_date"]);
-	}
-
-	if (
-		place["osm:check_date:currency:XBT"] &&
-		Date.parse(place["osm:check_date:currency:XBT"])
-	) {
-		verified.push(place["osm:check_date:currency:XBT"]);
-	}
-
-	if (verified.length > 1) {
-		verified.sort((a, b) => Date.parse(b) - Date.parse(a));
-	}
-
-	// Add to cache with eviction if needed
-	if (verifiedCache.size >= MAX_CACHE_SIZE) {
-		// Remove first entry (least recently used)
-		const firstKey = verifiedCache.keys().next().value;
-		if (firstKey !== undefined) {
-			verifiedCache.delete(firstKey);
-		}
-	}
-
-	verifiedCache.set(cacheKey, verified);
-
-	return verified;
 };
 
 export const generateMarker = ({

--- a/src/lib/merchantDrawerLogic.ts
+++ b/src/lib/merchantDrawerLogic.ts
@@ -11,32 +11,6 @@ import { boost } from "$lib/store";
 import type { Boost, Place } from "$lib/types";
 import { errToast } from "$lib/utils";
 
-// Memoize verified date calculation - recompute only once per day
-let cachedVerifiedDate: number | null = null;
-let cachedDay: number | null = null;
-
-export function calcVerifiedDate(): number {
-	const today = new Date().getDate();
-	if (cachedVerifiedDate !== null && cachedDay === today) {
-		return cachedVerifiedDate;
-	}
-
-	const verifiedDate = new Date();
-	const previousYear = verifiedDate.getFullYear() - 1;
-	cachedVerifiedDate = verifiedDate.setFullYear(previousYear);
-	cachedDay = today;
-	return cachedVerifiedDate;
-}
-
-export function isUpToDate(
-	merchant: Place | null,
-	verifiedDate: number,
-): boolean {
-	return !!(
-		merchant?.verified_at && Date.parse(merchant.verified_at) > verifiedDate
-	);
-}
-
 export function isBoosted(merchant: Place | null): boolean {
 	return !!(
 		merchant?.boosted_until && Date.parse(merchant.boosted_until) > Date.now()

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,7 +142,6 @@ export type MerchantPageData = {
 	hours?: string;
 	payment?: PayMerchant;
 	boosted?: string;
-	verified: string[];
 	phone?: string;
 	website?: string;
 	email?: string;

--- a/src/lib/verification.test.ts
+++ b/src/lib/verification.test.ts
@@ -2,21 +2,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Place } from "$lib/types";
 
+import {
+	calcVerifiedDate,
+	isRecentlyVerified,
+	isUpToDate,
+} from "./verification";
+
 const FIXED_NOW = new Date("2026-05-04T12:00:00Z").getTime();
 
 const daysAgo = (days: number) =>
 	new Date(FIXED_NOW - days * 24 * 60 * 60 * 1000).toISOString();
 
-// calcVerifiedDate memoizes per calendar day at module scope, so reset
-// modules before each test to get a fresh cache under the fake clock.
-type VerificationModule = typeof import("./verification");
-let logic: VerificationModule;
-
-beforeEach(async () => {
+beforeEach(() => {
 	vi.useFakeTimers();
 	vi.setSystemTime(new Date(FIXED_NOW));
-	vi.resetModules();
-	logic = await import("./verification");
 });
 
 afterEach(() => {
@@ -25,21 +24,38 @@ afterEach(() => {
 
 describe("calcVerifiedDate", () => {
 	it("returns exactly one year before now", () => {
-		const result = logic.calcVerifiedDate();
+		const result = calcVerifiedDate();
 		const oneYearAgo = new Date(FIXED_NOW);
 		oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
 		expect(result).toBe(oneYearAgo.getTime());
+	});
+
+	// Regression: an earlier version cached the result keyed on
+	// Date.getDate() (day-of-month, 1-31), so May 15 and Jun 15 collided
+	// and a process spanning a month boundary on the same day number
+	// returned a stale value. Verify the result tracks the current date
+	// across consecutive calls under a moving clock.
+	it("does not return a stale value across month boundaries", () => {
+		vi.setSystemTime(new Date("2026-05-15T12:00:00Z"));
+		const may = calcVerifiedDate();
+
+		vi.setSystemTime(new Date("2026-06-15T12:00:00Z"));
+		const june = calcVerifiedDate();
+
+		expect(june).toBeGreaterThan(may);
+		const expectedJune = new Date("2025-06-15T12:00:00Z").getTime();
+		expect(june).toBe(expectedJune);
 	});
 });
 
 describe("isRecentlyVerified", () => {
 	it("returns true for a date well within the 12-month window", () => {
-		expect(logic.isRecentlyVerified(daysAgo(30))).toBe(true);
-		expect(logic.isRecentlyVerified(daysAgo(180))).toBe(true);
+		expect(isRecentlyVerified(daysAgo(30))).toBe(true);
+		expect(isRecentlyVerified(daysAgo(180))).toBe(true);
 	});
 
 	it("returns false for a date older than 12 months", () => {
-		expect(logic.isRecentlyVerified(daysAgo(400))).toBe(false);
+		expect(isRecentlyVerified(daysAgo(400))).toBe(false);
 	});
 
 	// Regression for issue #964: AreaPage previously used
@@ -50,14 +66,14 @@ describe("isRecentlyVerified", () => {
 		const date = new Date(FIXED_NOW);
 		date.setFullYear(date.getFullYear() - 1);
 		date.setDate(date.getDate() - 15);
-		expect(logic.isRecentlyVerified(date.toISOString())).toBe(false);
+		expect(isRecentlyVerified(date.toISOString())).toBe(false);
 	});
 
 	it("returns false for undefined, null, empty, or invalid input", () => {
-		expect(logic.isRecentlyVerified(undefined)).toBe(false);
-		expect(logic.isRecentlyVerified(null)).toBe(false);
-		expect(logic.isRecentlyVerified("")).toBe(false);
-		expect(logic.isRecentlyVerified("not-a-date")).toBe(false);
+		expect(isRecentlyVerified(undefined)).toBe(false);
+		expect(isRecentlyVerified(null)).toBe(false);
+		expect(isRecentlyVerified("")).toBe(false);
+		expect(isRecentlyVerified("not-a-date")).toBe(false);
 	});
 });
 
@@ -66,15 +82,15 @@ describe("isUpToDate", () => {
 		({ id: 1, verified_at }) as unknown as Place;
 
 	it("returns true when verified_at is within the window", () => {
-		expect(logic.isUpToDate(place(daysAgo(30)))).toBe(true);
+		expect(isUpToDate(place(daysAgo(30)))).toBe(true);
 	});
 
 	it("returns false when verified_at is outside the window", () => {
-		expect(logic.isUpToDate(place(daysAgo(400)))).toBe(false);
+		expect(isUpToDate(place(daysAgo(400)))).toBe(false);
 	});
 
 	it("returns false when merchant or verified_at is missing", () => {
-		expect(logic.isUpToDate(null)).toBe(false);
-		expect(logic.isUpToDate(place(undefined))).toBe(false);
+		expect(isUpToDate(null)).toBe(false);
+		expect(isUpToDate(place(undefined))).toBe(false);
 	});
 });

--- a/src/lib/verification.test.ts
+++ b/src/lib/verification.test.ts
@@ -6,7 +6,6 @@ import {
 	calcVerifiedDate,
 	isRecentlyVerified,
 	isUpToDate,
-	verifiedArr,
 } from "./verification";
 
 const FIXED_NOW = new Date("2026-05-04T12:00:00Z").getTime();
@@ -75,70 +74,6 @@ describe("isRecentlyVerified", () => {
 		expect(isRecentlyVerified(null)).toBe(false);
 		expect(isRecentlyVerified("")).toBe(false);
 		expect(isRecentlyVerified("not-a-date")).toBe(false);
-	});
-});
-
-describe("verifiedArr", () => {
-	const place = (overrides: Partial<Place> = {}): Place =>
-		({ id: 1, ...overrides }) as unknown as Place;
-
-	it("returns an empty array when no OSM date tags are present", () => {
-		expect(verifiedArr(place())).toEqual([]);
-	});
-
-	it("returns the OSM date tags that are present", () => {
-		expect(
-			verifiedArr(
-				place({
-					"osm:survey:date": "2025-07-18",
-					"osm:check_date": "2025-03-01",
-				}),
-			),
-		).toEqual(["2025-07-18", "2025-03-01"]);
-	});
-
-	it("sorts multiple dates with the most recent first", () => {
-		expect(
-			verifiedArr(
-				place({
-					"osm:check_date": "2025-03-01",
-					"osm:survey:date": "2025-07-18",
-					"osm:check_date:currency:XBT": "2024-12-15",
-				}),
-			),
-		).toEqual(["2025-07-18", "2025-03-01", "2024-12-15"]);
-	});
-
-	it("ignores invalid date strings", () => {
-		expect(
-			verifiedArr(
-				place({
-					"osm:survey:date": "not-a-date",
-					"osm:check_date": "2025-07-18",
-				}),
-			),
-		).toEqual(["2025-07-18"]);
-	});
-
-	// Regression for issue #964: MerchantCard renders the same place twice -
-	// first with the stripped MAP_SYNC shape (no OSM date tags), then again
-	// after fetchEnhancedPlace populates COMPLETE_PLACE fields. A previous
-	// module-scope cache keyed on `${id}:${updated_at}` returned the empty
-	// first result for the enhanced second call, leaving cards stuck on
-	// "Not recently verified" even when the place had a fresh date.
-	it("does not return a stale empty result when the same record is later enriched", () => {
-		const id = 42;
-		const updated_at = "2025-07-19T00:00:00Z";
-
-		const stripped = place({ id, updated_at });
-		expect(verifiedArr(stripped)).toEqual([]);
-
-		const enriched = place({
-			id,
-			updated_at,
-			"osm:survey:date": "2025-07-18",
-		});
-		expect(verifiedArr(enriched)).toEqual(["2025-07-18"]);
 	});
 });
 

--- a/src/lib/verification.test.ts
+++ b/src/lib/verification.test.ts
@@ -6,6 +6,7 @@ import {
 	calcVerifiedDate,
 	isRecentlyVerified,
 	isUpToDate,
+	verifiedArr,
 } from "./verification";
 
 const FIXED_NOW = new Date("2026-05-04T12:00:00Z").getTime();
@@ -74,6 +75,70 @@ describe("isRecentlyVerified", () => {
 		expect(isRecentlyVerified(null)).toBe(false);
 		expect(isRecentlyVerified("")).toBe(false);
 		expect(isRecentlyVerified("not-a-date")).toBe(false);
+	});
+});
+
+describe("verifiedArr", () => {
+	const place = (overrides: Partial<Place> = {}): Place =>
+		({ id: 1, ...overrides }) as unknown as Place;
+
+	it("returns an empty array when no OSM date tags are present", () => {
+		expect(verifiedArr(place())).toEqual([]);
+	});
+
+	it("returns the OSM date tags that are present", () => {
+		expect(
+			verifiedArr(
+				place({
+					"osm:survey:date": "2025-07-18",
+					"osm:check_date": "2025-03-01",
+				}),
+			),
+		).toEqual(["2025-07-18", "2025-03-01"]);
+	});
+
+	it("sorts multiple dates with the most recent first", () => {
+		expect(
+			verifiedArr(
+				place({
+					"osm:check_date": "2025-03-01",
+					"osm:survey:date": "2025-07-18",
+					"osm:check_date:currency:XBT": "2024-12-15",
+				}),
+			),
+		).toEqual(["2025-07-18", "2025-03-01", "2024-12-15"]);
+	});
+
+	it("ignores invalid date strings", () => {
+		expect(
+			verifiedArr(
+				place({
+					"osm:survey:date": "not-a-date",
+					"osm:check_date": "2025-07-18",
+				}),
+			),
+		).toEqual(["2025-07-18"]);
+	});
+
+	// Regression for issue #964: MerchantCard renders the same place twice -
+	// first with the stripped MAP_SYNC shape (no OSM date tags), then again
+	// after fetchEnhancedPlace populates COMPLETE_PLACE fields. A previous
+	// module-scope cache keyed on `${id}:${updated_at}` returned the empty
+	// first result for the enhanced second call, leaving cards stuck on
+	// "Not recently verified" even when the place had a fresh date.
+	it("does not return a stale empty result when the same record is later enriched", () => {
+		const id = 42;
+		const updated_at = "2025-07-19T00:00:00Z";
+
+		const stripped = place({ id, updated_at });
+		expect(verifiedArr(stripped)).toEqual([]);
+
+		const enriched = place({
+			id,
+			updated_at,
+			"osm:survey:date": "2025-07-18",
+		});
+		expect(verifiedArr(enriched)).toEqual(["2025-07-18"]);
 	});
 });
 

--- a/src/lib/verification.test.ts
+++ b/src/lib/verification.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Place } from "$lib/types";
+
+const FIXED_NOW = new Date("2026-05-04T12:00:00Z").getTime();
+
+const daysAgo = (days: number) =>
+	new Date(FIXED_NOW - days * 24 * 60 * 60 * 1000).toISOString();
+
+// calcVerifiedDate memoizes per calendar day at module scope, so reset
+// modules before each test to get a fresh cache under the fake clock.
+type VerificationModule = typeof import("./verification");
+let logic: VerificationModule;
+
+beforeEach(async () => {
+	vi.useFakeTimers();
+	vi.setSystemTime(new Date(FIXED_NOW));
+	vi.resetModules();
+	logic = await import("./verification");
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("calcVerifiedDate", () => {
+	it("returns exactly one year before now", () => {
+		const result = logic.calcVerifiedDate();
+		const oneYearAgo = new Date(FIXED_NOW);
+		oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+		expect(result).toBe(oneYearAgo.getTime());
+	});
+});
+
+describe("isRecentlyVerified", () => {
+	it("returns true for a date well within the 12-month window", () => {
+		expect(logic.isRecentlyVerified(daysAgo(30))).toBe(true);
+		expect(logic.isRecentlyVerified(daysAgo(180))).toBe(true);
+	});
+
+	it("returns false for a date older than 12 months", () => {
+		expect(logic.isRecentlyVerified(daysAgo(400))).toBe(false);
+	});
+
+	// Regression for issue #964: AreaPage previously used
+	// differenceInMonths(now, date) > 12 (whole-month rounding), so a place
+	// 12 months + 15 days old looked "current" there while MerchantCard's
+	// ms-precision check called it outdated. Both must agree.
+	it("returns false for a date 12 months and 15 days old", () => {
+		const date = new Date(FIXED_NOW);
+		date.setFullYear(date.getFullYear() - 1);
+		date.setDate(date.getDate() - 15);
+		expect(logic.isRecentlyVerified(date.toISOString())).toBe(false);
+	});
+
+	it("returns false for undefined, null, empty, or invalid input", () => {
+		expect(logic.isRecentlyVerified(undefined)).toBe(false);
+		expect(logic.isRecentlyVerified(null)).toBe(false);
+		expect(logic.isRecentlyVerified("")).toBe(false);
+		expect(logic.isRecentlyVerified("not-a-date")).toBe(false);
+	});
+});
+
+describe("isUpToDate", () => {
+	const place = (verified_at: string | undefined): Place =>
+		({ id: 1, verified_at }) as unknown as Place;
+
+	it("returns true when verified_at is within the window", () => {
+		expect(logic.isUpToDate(place(daysAgo(30)))).toBe(true);
+	});
+
+	it("returns false when verified_at is outside the window", () => {
+		expect(logic.isUpToDate(place(daysAgo(400)))).toBe(false);
+	});
+
+	it("returns false when merchant or verified_at is missing", () => {
+		expect(logic.isUpToDate(null)).toBe(false);
+		expect(logic.isUpToDate(place(undefined))).toBe(false);
+	});
+});

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -27,3 +27,36 @@ export function isRecentlyVerified(
 export function isUpToDate(merchant: Place | null): boolean {
 	return isRecentlyVerified(merchant?.verified_at);
 }
+
+// Returns the place's OSM verification dates (most recent first).
+// Intentionally uncached: an earlier version keyed a module-scope
+// cache on `${id}:${updated_at}`, which collided when MerchantCard
+// rendered the same record twice — first with the stripped MAP_SYNC
+// shape (no OSM date tags), then with the enhanced COMPLETE_PLACE
+// shape (tags present). The first call cached `[]` and the enhanced
+// call hit that stale entry, leaving every area card stuck on
+// "Not recently verified" even when the place had a fresh date.
+export function verifiedArr(place: Place): string[] {
+	const verified: string[] = [];
+
+	if (place["osm:survey:date"] && Date.parse(place["osm:survey:date"])) {
+		verified.push(place["osm:survey:date"]);
+	}
+
+	if (place["osm:check_date"] && Date.parse(place["osm:check_date"])) {
+		verified.push(place["osm:check_date"]);
+	}
+
+	if (
+		place["osm:check_date:currency:XBT"] &&
+		Date.parse(place["osm:check_date:currency:XBT"])
+	) {
+		verified.push(place["osm:check_date:currency:XBT"]);
+	}
+
+	if (verified.length > 1) {
+		verified.sort((a, b) => Date.parse(b) - Date.parse(a));
+	}
+
+	return verified;
+}

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -1,0 +1,34 @@
+import type { Place } from "$lib/types";
+
+// Memoize verified date calculation - recompute only once per day
+let cachedVerifiedDate: number | null = null;
+let cachedDay: number | null = null;
+
+export function calcVerifiedDate(): number {
+	const today = new Date().getDate();
+	if (cachedVerifiedDate !== null && cachedDay === today) {
+		return cachedVerifiedDate;
+	}
+
+	const verifiedDate = new Date();
+	const previousYear = verifiedDate.getFullYear() - 1;
+	cachedVerifiedDate = verifiedDate.setFullYear(previousYear);
+	cachedDay = today;
+	return cachedVerifiedDate;
+}
+
+// True if the given verification date is within the "recently verified"
+// window (currently 12 months). Use this everywhere we render a recency
+// state so summary and detail views can never disagree on the same date.
+export function isRecentlyVerified(
+	dateStr: string | undefined | null,
+): boolean {
+	if (!dateStr) return false;
+	const parsed = Date.parse(dateStr);
+	if (Number.isNaN(parsed)) return false;
+	return parsed > calcVerifiedDate();
+}
+
+export function isUpToDate(merchant: Place | null): boolean {
+	return isRecentlyVerified(merchant?.verified_at);
+}

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -1,20 +1,15 @@
 import type { Place } from "$lib/types";
 
-// Memoize verified date calculation - recompute only once per day
-let cachedVerifiedDate: number | null = null;
-let cachedDay: number | null = null;
-
+// Returns the timestamp exactly 12 months before "now". Intentionally
+// uncached: the previous module-scope cache keyed on Date.getDate()
+// (day-of-month, 1-31) would return a stale value when a process
+// crossed a month boundary on the same day number (e.g. May 15 → Jun
+// 15). This bites both long-lived browser sessions and SSR workers.
+// The computation is trivial, so just recompute.
 export function calcVerifiedDate(): number {
-	const today = new Date().getDate();
-	if (cachedVerifiedDate !== null && cachedDay === today) {
-		return cachedVerifiedDate;
-	}
-
-	const verifiedDate = new Date();
-	const previousYear = verifiedDate.getFullYear() - 1;
-	cachedVerifiedDate = verifiedDate.setFullYear(previousYear);
-	cachedDay = today;
-	return cachedVerifiedDate;
+	const d = new Date();
+	d.setFullYear(d.getFullYear() - 1);
+	return d.getTime();
 }
 
 // True if the given verification date is within the "recently verified"

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -27,36 +27,3 @@ export function isRecentlyVerified(
 export function isUpToDate(merchant: Place | null): boolean {
 	return isRecentlyVerified(merchant?.verified_at);
 }
-
-// Returns the place's OSM verification dates (most recent first).
-// Intentionally uncached: an earlier version keyed a module-scope
-// cache on `${id}:${updated_at}`, which collided when MerchantCard
-// rendered the same record twice — first with the stripped MAP_SYNC
-// shape (no OSM date tags), then with the enhanced COMPLETE_PLACE
-// shape (tags present). The first call cached `[]` and the enhanced
-// call hit that stale entry, leaving every area card stuck on
-// "Not recently verified" even when the place had a fresh date.
-export function verifiedArr(place: Place): string[] {
-	const verified: string[] = [];
-
-	if (place["osm:survey:date"] && Date.parse(place["osm:survey:date"])) {
-		verified.push(place["osm:survey:date"]);
-	}
-
-	if (place["osm:check_date"] && Date.parse(place["osm:check_date"])) {
-		verified.push(place["osm:check_date"]);
-	}
-
-	if (
-		place["osm:check_date:currency:XBT"] &&
-		Date.parse(place["osm:check_date:currency:XBT"])
-	) {
-		verified.push(place["osm:check_date:currency:XBT"]);
-	}
-
-	if (verified.length > 1) {
-		verified.sort((a, b) => Date.parse(b) - Date.parse(a));
-	}
-
-	return verified;
-}

--- a/src/routes/map/components/MerchantDrawerDesktop.svelte
+++ b/src/routes/map/components/MerchantDrawerDesktop.svelte
@@ -15,9 +15,7 @@ import {
 import { _ } from "$lib/i18n";
 import {
 	handleBoost as boostMerchant,
-	calcVerifiedDate,
 	isBoosted as checkBoosted,
-	isUpToDate as checkUpToDate,
 	clearBoostState,
 	handleBoostComplete as completeBoost,
 	ensureBoostData,
@@ -25,6 +23,7 @@ import {
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import { merchantList } from "$lib/merchantListStore";
 import { boost, resetBoost } from "$lib/store";
+import { isUpToDate as checkUpToDate } from "$lib/verification";
 
 import { invalidateAll } from "$app/navigation";
 
@@ -50,8 +49,7 @@ $: if (isOpen && drawerElement) {
 	});
 }
 
-const verifiedDate = calcVerifiedDate();
-$: isUpToDate = checkUpToDate(merchant, verifiedDate);
+$: isUpToDate = checkUpToDate(merchant);
 $: isBoosted = checkBoosted(merchant);
 
 let boostLoading = false;

--- a/src/routes/map/components/MerchantDrawerMobile.svelte
+++ b/src/routes/map/components/MerchantDrawerMobile.svelte
@@ -9,15 +9,14 @@ import { drawerGesture } from "$lib/drawerGestureController";
 import { _ } from "$lib/i18n";
 import {
 	handleBoost as boostMerchant,
-	calcVerifiedDate,
 	isBoosted as checkBoosted,
-	isUpToDate as checkUpToDate,
 	clearBoostState,
 	handleBoostComplete as completeBoost,
 	ensureBoostData,
 } from "$lib/merchantDrawerLogic";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import { boost, resetBoost } from "$lib/store";
+import { isUpToDate as checkUpToDate } from "$lib/verification";
 
 import MerchantPeekContentMobile from "./MerchantPeekContentMobile.svelte";
 import { browser } from "$app/environment";
@@ -88,8 +87,7 @@ function handleFocusOut(event: FocusEvent) {
 	}
 }
 
-const verifiedDate = calcVerifiedDate();
-$: isUpToDate = checkUpToDate(merchant, verifiedDate);
+$: isUpToDate = checkUpToDate(merchant);
 $: isBoosted = checkBoosted(merchant);
 
 let boostLoading = false;

--- a/src/routes/map/components/MerchantListItem.svelte
+++ b/src/routes/map/components/MerchantListItem.svelte
@@ -6,18 +6,15 @@ import {
 	getIconColorWithFallback,
 } from "$lib/categoryMapping";
 import { _ } from "$lib/i18n";
-import {
-	isBoosted as checkBoosted,
-	isUpToDate as checkUpToDate,
-} from "$lib/merchantDrawerLogic";
+import { isBoosted as checkBoosted } from "$lib/merchantDrawerLogic";
 import type { Place } from "$lib/types";
 import { userLocation } from "$lib/userLocationStore";
 import { calculateDistance, formatDistance } from "$lib/utils";
+import { isUpToDate as checkUpToDate } from "$lib/verification";
 
 export let merchant: Place;
 export let enrichedData: Place | null = null;
 export let isSelected: boolean = false;
-export let verifiedDate: number;
 export let onclick: (merchant: Place) => void = () => {};
 export let onmouseenter: (merchant: Place) => void = () => {};
 export let onmouseleave: (merchant: Place) => void = () => {};
@@ -25,7 +22,7 @@ export let onmouseleave: (merchant: Place) => void = () => {};
 $: showSkeleton = !enrichedData;
 $: displayData = enrichedData || merchant;
 
-$: isVerified = checkUpToDate(displayData, verifiedDate);
+$: isVerified = checkUpToDate(displayData);
 $: isBoosted = checkBoosted(merchant);
 
 $: userLoc = $userLocation.location;

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -18,7 +18,6 @@ import {
 	MERCHANT_LIST_MIN_ZOOM,
 } from "$lib/constants";
 import { _ } from "$lib/i18n";
-import { calcVerifiedDate } from "$lib/merchantDrawerLogic";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import type { MerchantListMode } from "$lib/merchantListStore";
 import { merchantList } from "$lib/merchantListStore";
@@ -28,9 +27,6 @@ import { errToast, formatNearbyCount } from "$lib/utils";
 
 import MerchantListItem from "./MerchantListItem.svelte";
 import { browser } from "$app/environment";
-
-// Compute once for all list items
-const verifiedDate = calcVerifiedDate();
 
 // Get translated category label
 function getCategoryLabel(key: CategoryKey): string {
@@ -580,7 +576,6 @@ onDestroy(() => {
 								{merchant}
 								enrichedData={merchant}
 								isSelected={selectedId === merchant.id}
-								{verifiedDate}
 								onclick={handleItemClick}
 								onmouseenter={handleMouseEnter}
 								onmouseleave={handleMouseLeave}
@@ -641,7 +636,6 @@ onDestroy(() => {
 								{merchant}
 								enrichedData={placeDetailsCache.get(merchant.id) || null}
 								isSelected={selectedId === merchant.id}
-								{verifiedDate}
 								onclick={handleItemClick}
 								onmouseenter={handleMouseEnter}
 								onmouseleave={handleMouseLeave}

--- a/src/routes/merchant/[id]/+page.server.ts
+++ b/src/routes/merchant/[id]/+page.server.ts
@@ -17,7 +17,6 @@ import type {
 	Place,
 } from "$lib/types";
 import { isValidPlaceId } from "$lib/utils";
-import { verifiedArr } from "$lib/verification";
 
 import type { PageServerLoad } from "./$types";
 
@@ -93,7 +92,6 @@ export const load: PageServerLoad<MerchantPageData> = async ({
 
 		const payment = mapPayment(placeData);
 		const boosted = getBoosted(placeData);
-		const verified = verifiedArr(placeData);
 		const contact = getContactFields(placeData);
 		const { phone, website, email, twitter, instagram, facebook } = contact;
 
@@ -120,7 +118,6 @@ export const load: PageServerLoad<MerchantPageData> = async ({
 			hours,
 			payment,
 			boosted,
-			verified,
 			phone,
 			website,
 			email,

--- a/src/routes/merchant/[id]/+page.server.ts
+++ b/src/routes/merchant/[id]/+page.server.ts
@@ -2,7 +2,6 @@ import { error, isHttpError } from "@sveltejs/kit";
 
 import { API_BASE } from "$lib/api-base";
 import { buildFieldsParam, PLACE_FIELD_SETS } from "$lib/api-fields";
-import { verifiedArr } from "$lib/map/setup";
 import {
 	buildOsmTags,
 	getBoosted,
@@ -18,6 +17,7 @@ import type {
 	Place,
 } from "$lib/types";
 import { isValidPlaceId } from "$lib/utils";
+import { verifiedArr } from "$lib/verification";
 
 import type { PageServerLoad } from "./$types";
 

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -25,7 +25,6 @@ import {
 	applyThemeToBaseMaps,
 	attachIconCleanup,
 	attribution,
-	calcVerifiedDate,
 	changeDefaultIcons,
 	disposeMarker,
 	generateIcon,
@@ -50,6 +49,7 @@ import {
 	isBoosted,
 	shareMerchant,
 } from "$lib/utils";
+import { calcVerifiedDate } from "$lib/verification";
 
 import CommentAddButton from "./components/CommentAddButton.svelte";
 import MerchantAction from "./components/MerchantAction.svelte";

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -169,7 +169,6 @@ $: filteredCommunities = data.areas;
 $: merchantEvents = data.activity;
 $: name = data.name;
 let boosted: string | undefined;
-let verified: string[];
 let shareConfirm = false;
 let shareTimeout: ReturnType<typeof setTimeout>;
 
@@ -177,8 +176,7 @@ let shareTimeout: ReturnType<typeof setTimeout>;
 let comments: typeof data.comments;
 $: comments = data.comments;
 
-// Initialize verified and boosted immediately from server data (don't wait for store sync)
-$: verified = data.verified || [];
+$: verifiedAt = data.placeData?.verified_at;
 // Make boosted reactive to both server data and store updates, but only if boost is still active
 $: {
 	const placeInStore = $placesById.get(Number(data.id));
@@ -531,9 +529,9 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 				<h3 slot="header" class="text-2xl font-semibold">{$_('verification.lastSurveyed')}</h3>
 
 				<div slot="body" class="p-4">
-					{#if verified.length}
+					{#if verifiedAt}
 						<div class="flex items-center justify-center dark:text-white">
-							{#if isRecentlyVerified(verified[0])}
+							{#if isRecentlyVerified(verifiedAt)}
 								<span bind:this={verifiedTooltip}>
 									<Icon
 										w="30"
@@ -554,7 +552,7 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 									/>
 								</span>
 							{/if}
-							<strong>{formatVerifiedHuman(verified?.[0])}</strong>
+							<strong>{formatVerifiedHuman(verifiedAt)}</strong>
 						</div>
 					{:else}
 						<p class="font-semibold dark:text-white">{$_('verification.notSurveyed')}</p>

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -49,7 +49,7 @@ import {
 	isBoosted,
 	shareMerchant,
 } from "$lib/utils";
-import { calcVerifiedDate } from "$lib/verification";
+import { isRecentlyVerified } from "$lib/verification";
 
 import CommentAddButton from "./components/CommentAddButton.svelte";
 import MerchantAction from "./components/MerchantAction.svelte";
@@ -172,7 +172,6 @@ let boosted: string | undefined;
 let verified: string[];
 let shareConfirm = false;
 let shareTimeout: ReturnType<typeof setTimeout>;
-const verifiedDate = calcVerifiedDate();
 
 // Make comments reactive to server data updates (from invalidateAll() after adding comment)
 let comments: typeof data.comments;
@@ -534,7 +533,7 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 				<div slot="body" class="p-4">
 					{#if verified.length}
 						<div class="flex items-center justify-center dark:text-white">
-							{#if Date.parse(verified[0]) > verifiedDate}
+							{#if isRecentlyVerified(verified[0])}
 								<span bind:this={verifiedTooltip}>
 									<Icon
 										w="30"


### PR DESCRIPTION
  Closes the recency-state half of #964 (terminology rename will follow
  in a separate PR).

  The screenshots in #964 show a place verified 2025-07-18 rendering
  "Not recently verified" sad face on the community page but a green
  badge on the merchant detail page. Two bugs were stacking up:

  1. **Threshold inconsistency.** AreaPage used
     `differenceInMonths(now, date) > 12` (whole-month rounding) while
     MerchantCard and the merchant detail page used a strict
     ms-precision comparison against exactly 12 months ago. Dates near
     the boundary classified differently across views. `calcVerifiedDate`
     was duplicated in two files; `isUpToDate` had a redundant second
     arg callers had to plumb through.
  2. **Stale `verifiedArr` cache.** MerchantCard renders the same place
     twice — first with the stripped `MAP_SYNC` shape (no OSM date
     tags), then again after `fetchEnhancedPlace` populates
     `COMPLETE_PLACE` fields. The cache keyed on `${id}:${updated_at}`
     was identical for both shapes, so the empty first result hit on
     the second call and every area card stayed on "Not recently
     verified" regardless of the actual date.

  This PR:

  - Extracts `calcVerifiedDate`, `isRecentlyVerified`, and `isUpToDate`
    into a new pure `src/lib/verification.ts` so summary and detail
    views share one threshold definition. Removes the duplicate
    `calcVerifiedDate` from `lib/map/setup.ts` and simplifies
    `isUpToDate(merchant)` to a single argument.
  - Replaces AreaPage's `calculateStaleness` with `isRecentlyVerified`.
  - Drops the `calcVerifiedDate` memoization. The cache keyed on
    `Date.getDate()` (1–31), so a process spanning a month boundary on
    the same day number returned a stale threshold for up to ~30 days
    — bad in long-lived browser sessions and SSR workers. Recomputing
    is two ops; not worth caching.
  - Drops the `verifiedArr` cache that conflated stripped vs enriched
    Place shapes.
  - Switches `MerchantCard` from raw ISO date display to the shared
    `formatVerifiedHuman` helper so it reads "17 days ago" /
    "15 October" consistently with every other view.
  - Stops reimplementing the API's recency-date logic in the client.
    `verifiedArr` walked `osm:survey:date` / `osm:check_date` /
    `osm:check_date:currency:XBT` and returned a sorted array; the
    API's `verified_at` is the max of those three plus
    `osm:source:date` (see `btcmap-api/service/overpass.rs
    verification_date`). The client never fetched `source:date`, so a
    place whose only recent tag was `source:date` would silently
    disagree with the authoritative API value. `verifiedArr` is now
    gone — `MerchantCard`, the merchant detail page, and the page
    server load all read `place.verified_at` directly. The OSM date
    tags stay in `PLACE_FIELDS.POPUP` because `buildOsmTags` still
    shows them in the "Show Tags" modal.

  **Behavior change worth flagging:** a place whose only verification
  tag is `osm:source:date` (no `survey:date` / `check_date` /
  `check_date:XBT`) previously rendered as "needs to be surveyed" on
  the area card and is now rendered as "Last Surveyed: <date>". This
  matches what the API and the merchant detail page already say for
  that place, so the visible flip is a correction rather than a
  regression — but it's a maintainer call whether `source:date`
  provenance counts as "verified".