### PR TITLE
fix(merchant): only render tag issues icon when issues exist (#965)

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -153,6 +153,8 @@ export type MerchantPageData = {
 	paymentMethod?: string;
 	// OSM data for tag functionality
 	osmTags: OSMTags;
+	// Per-element issues fetched from /v2/elements (v4 doesn't expose them yet)
+	issues: Issue[];
 	// Place data for BoostButton and other components
 	placeData: Place;
 	osmViewUrl: string;
@@ -177,7 +179,7 @@ export type IssueType =
 export type Issue = {
 	description: string;
 	severity: number;
-	type: IssueType;
+	type: string;
 };
 
 export type IssueIcon =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -171,6 +171,7 @@ export type RpcIssue = {
 export type IssueType =
 	| "date_format"
 	| "misspelled_tag"
+	| "missing_currency_xbt"
 	| "missing_icon"
 	| "not_verified"
 	| "out_of_date"
@@ -179,7 +180,7 @@ export type IssueType =
 export type Issue = {
 	description: string;
 	severity: number;
-	type: string;
+	type: IssueType;
 };
 
 export type IssueIcon =

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -177,10 +177,10 @@ export const getIssueIcon = (issue_code: string): IssueIcon => {
 	if (issue_code === "not_verified") {
 		return "fa-clipboard-question";
 	}
-	if (issue_code === "outdated") {
+	if (issue_code === "outdated" || issue_code === "out_of_date") {
 		return "fa-hourglass-end";
 	}
-	if (issue_code === "outdated_soon") {
+	if (issue_code === "outdated_soon" || issue_code === "out_of_date_soon") {
 		return "fa-hourglass-half";
 	}
 	return "fa-list-check";
@@ -189,7 +189,9 @@ export const getIssueIcon = (issue_code: string): IssueIcon => {
 export const getIssueHelpLink = (issue_code: string) => {
 	if (
 		issue_code === "outdated" ||
+		issue_code === "out_of_date" ||
 		issue_code === "outdated_soon" ||
+		issue_code === "out_of_date_soon" ||
 		issue_code === "not_verified"
 	) {
 		return "https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Verifying-Existing-Merchants";

--- a/src/routes/merchant/[id]/+page.server.ts
+++ b/src/routes/merchant/[id]/+page.server.ts
@@ -11,6 +11,7 @@ import {
 	mapPayment,
 } from "$lib/transforms/place";
 import type {
+	Issue,
 	MerchantActivityEvent,
 	MerchantArea,
 	MerchantComment,
@@ -70,8 +71,8 @@ export const load: PageServerLoad<MerchantPageData> = async ({
 
 		const encodedId = encodeURIComponent(id);
 
-		// Fetch comments, areas, and activity in parallel — failures return empty arrays
-		const [comments, areas, activity] = await Promise.all([
+		// Fetch comments, areas, activity, and v2 element in parallel — failures return empty arrays / null
+		const [comments, areas, activity, elementV2] = await Promise.all([
 			fetchJson<MerchantComment[]>(
 				fetch,
 				`${API_BASE}/v4/places/${encodedId}/comments`,
@@ -84,6 +85,12 @@ export const load: PageServerLoad<MerchantPageData> = async ({
 				fetch,
 				`${API_BASE}/v4/places/${encodedId}/activity`,
 			).then((data) => data ?? []),
+			placeData.osm_id
+				? fetchJson<{ tags?: { issues?: Issue[] } }>(
+						fetch,
+						`${API_BASE}/v2/elements/${encodeURIComponent(placeData.osm_id)}`,
+					)
+				: Promise.resolve(null),
 		]);
 
 		// Process all merchant data server-side
@@ -103,6 +110,13 @@ export const load: PageServerLoad<MerchantPageData> = async ({
 
 		// Build osmTags from Place data for the OSM tag modal
 		const osmTags = buildOsmTags(placeData, contact);
+
+		// v4 /v4/places doesn't expose per-place issues yet; pull them from the
+		// v2 element response so the merchant page's tag-issues icon and modal work.
+		const issues = elementV2?.tags?.issues;
+		if (issues?.length) {
+			osmTags.issues = issues;
+		}
 
 		return {
 			id: placeData.id.toString(),

--- a/src/routes/merchant/[id]/+page.server.ts
+++ b/src/routes/merchant/[id]/+page.server.ts
@@ -112,11 +112,10 @@ export const load: PageServerLoad<MerchantPageData> = async ({
 		const osmTags = buildOsmTags(placeData, contact);
 
 		// v4 /v4/places doesn't expose per-place issues yet; pull them from the
-		// v2 element response so the merchant page's tag-issues icon and modal work.
-		const issues = elementV2?.tags?.issues;
-		if (issues?.length) {
-			osmTags.issues = issues;
-		}
+		// v2 element response. Returned as a separate field (not inside osmTags)
+		// because osmTags is also passed to the Show Tags modal, which iterates
+		// it as string key/value pairs.
+		const issues = elementV2?.tags?.issues ?? [];
 
 		return {
 			id: placeData.id.toString(),
@@ -145,6 +144,7 @@ export const load: PageServerLoad<MerchantPageData> = async ({
 			paymentMethod,
 			// OSM data for edit links and tag functionality
 			osmTags,
+			issues,
 			// Place data for BoostButton and other components
 			placeData,
 			osmViewUrl: placeData.osm_url ?? "",

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -502,10 +502,10 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 					/>
 				</span>
 
-				{#if data.osmTags?.issues?.length}
+				{#if data.issues.length}
 					<span id="tagging-issues">
 						<MerchantAction
-							on:click={() => ($taggingIssues = data.osmTags.issues)}
+							on:click={() => ($taggingIssues = data.issues)}
 							icon="issues"
 							text={$_('merchant.tagIssues')}
 						/>

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -502,13 +502,15 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 					/>
 				</span>
 
-				<span id="tagging-issues">
-					<MerchantAction
-						on:click={() => ($taggingIssues = data.osmTags?.issues || [])}
-						icon="issues"
-						text={$_('merchant.tagIssues')}
-					/>
-				</span>
+				{#if data.osmTags?.issues?.length}
+					<span id="tagging-issues">
+						<MerchantAction
+							on:click={() => ($taggingIssues = data.osmTags.issues)}
+							icon="issues"
+							text={$_('merchant.tagIssues')}
+						/>
+					</span>
+				{/if}
 
 				<MerchantAction
 					link={`${data.osmViewUrl}`}


### PR DESCRIPTION
**Does this PR address a related issue?**

Yes, closes https://github.com/teambtcmap/btcmap.org/issues/965.

**A description of the changes proposed in the pull request**

Wraps the "Tag Issues" action icon on the merchant detail page (src/routes/merchant/[id]/+page.svelte) in {#if data.osmTags?.issues?.length}, matching the conditional rendering pattern already used in the same file for phone, email, website, twitter, instagram, and facebook. The click handler is also simplified by dropping the now-unnecessary || [] fallback, since {#if} guarantees the array is non-empty inside the block.

Result: the icon only renders when there's at least one issue to show — no more empty modal on click.

**Screenshots**

Before:
<img width="1509" height="800" alt="image" src="https://github.com/user-attachments/assets/e89f71d9-6d65-46bd-850f-65fcadd3189c" />

After:
<img width="1635" height="757" alt="image" src="https://github.com/user-attachments/assets/e2ca4625-77a7-4163-8703-a80251e49fb8" />

**Additional context**

⚠️ Heads-up flagged by Claude (AI assistant) while implementing this fix, please double-check against project history before treating as a real bug.

The AI noticed what looks like a separate, deeper gap and asked me to surface it here so maintainers (who have full project context) can validate. If this analysis is wrong — e.g. there's a code path it missed, the array is populated only in production, or this is a known intentional state — feel free to ignore.

In the current codebase, data.osmTags.issues appears to be never populated, which means after this fix the icon will be hidden for every merchant, not just those without issues.

Trace:

The merchant +page.server.ts only fetches /v4/places/${id} with the COMPLETE_PLACE field set (src/lib/api-fields.ts), which doesn't include any issues field.
buildOsmTags() (src/lib/transforms/place.ts) builds osmTags from a fixed list of explicit fields; issues isn't one of them.
No client-side code attaches issues to osmTags afterwards either.
Meanwhile, the /tagging-issues page does load real issues, but via a completely separate path: JSON-RPC get_element_issues (area 662), returning RpcIssue { element_osm_type, element_osm_id, element_name, issue_code }. The merchant modal expects Issue { description, severity, type }, different shape, different vocabulary (outdated vs out_of_date). The two systems don't appear to be connected.

If that's accurate, this PR still satisfies https://github.com/teambtcmap/btcmap.org/issues/965 ("only render when issues exist"), but the underlying per-merchant tagging-issues feature would itself need to be wired (RPC plumbing + shape conversion between RpcIssue and Issue) for the icon to ever actually show. Probably a separate ticket if the team confirms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merchant pages now fetch and include per-place issue data so tagging issues reflect the latest information.

* **Bug Fixes**
  * The tagging-issues UI only appears when actual issues exist, preventing empty/irrelevant displays.

* **Enhancements**
  * Support for additional issue variants (including a new missing_currency_xbt type) and consolidated icon/help-link handling for related out-of-date variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->