### PR TITLE
feat(supporters): add mailto subject lines for sponsorship enquiries

### DIFF
--- a/src/routes/supporters/+page.svelte
+++ b/src/routes/supporters/+page.svelte
@@ -144,7 +144,7 @@ const plebTier = sponsorshipTiers.find((t) => t.level === "Pleb")!;
 				{t("supporters.sponsors.description")}
 			</p>
 			<a
-				href="mailto:hello@btcmap.org"
+				href="mailto:hello@btcmap.org?subject=Sponsorship%20enquiry"
 				class="inline-block rounded-xl bg-link px-6 py-3 font-semibold text-white transition-colors hover:bg-hover"
 			>
 				{t("supporters.supporters.becomeSponsor")}

--- a/src/routes/supporters/components/SupportSection.svelte
+++ b/src/routes/supporters/components/SupportSection.svelte
@@ -67,7 +67,7 @@ $: t = $_;
 			class="flex w-full items-center justify-center self-center rounded-xl border border-dashed border-link/40 bg-white/50 p-4 text-center dark:bg-slate-900/40 {compact ? 'min-h-[80px]' : 'min-h-[120px]'}"
 		>
 			<a
-				href="mailto:hello@btcmap.org"
+				href="mailto:hello@btcmap.org?subject=Sponsorship%20enquiry%3A%20{encodeURIComponent(tier.level)}"
 				class="text-sm font-semibold uppercase tracking-wide text-link"
 				>Become a {tier.level}</a
 			>


### PR DESCRIPTION
## Summary

- Added `mailto:` subject lines to all sponsorship enquiry links on the Supporters page.
- The general **"Become a Supporter"** button in the Industry Supporters section now includes the subject `Sponsorship enquiry`.
- Each industry tier's **"Become a {tier.level}"** placeholder now includes the subject `Sponsorship enquiry: {tier.level}` (e.g. `Sponsorship enquiry: Pioneer`).

## Files Changed

- `src/routes/supporters/+page.svelte`
- `src/routes/supporters/components/SupportSection.svelte`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sponsorship inquiry emails now include pre-filled subject lines, streamlining communications for potential sponsors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->