### PR TITLE
refactor(buttons): add TextLink component and consolidate

### DIFF
--- a/src/components/IssueCell.svelte
+++ b/src/components/IssueCell.svelte
@@ -2,6 +2,7 @@
 import { _ } from "svelte-i18n";
 
 import IssueIcon from "$components/IssueIcon.svelte";
+import TextLink from "$components/TextLink.svelte";
 
 export let id: "icon" | "name" | "type" | "viewLink" | "editLink" | "helpLink";
 export let value: string;
@@ -14,30 +15,15 @@ export let value: string;
 {:else if id === 'type'}
 	{value}
 {:else if id === 'viewLink'}
-	<a
-		href="https://www.openstreetmap.org/{value}"
-		target="_blank"
-		rel="noreferrer"
-		class="text-link transition-colors hover:text-hover"
-	>
+	<TextLink link="https://www.openstreetmap.org/{value}" external>
 		{$_(`maintain.view`)}
-	</a>
+	</TextLink>
 {:else if id === 'editLink'}
-	<a
-		href="https://www.openstreetmap.org/edit?{value}"
-		target="_blank"
-		rel="noreferrer"
-		class="text-link transition-colors hover:text-hover"
-	>
+	<TextLink link="https://www.openstreetmap.org/edit?{value}" external>
 		{$_(`maintain.edit`)}
-	</a>
+	</TextLink>
 {:else if id === 'helpLink' && value}
-	<a
-		href={value}
-		target="_blank"
-		rel="noreferrer"
-		class="text-link transition-colors hover:text-hover"
-	>
+	<TextLink link={value} external>
 		{$_(`maintain.help`)}
-	</a>
+	</TextLink>
 {/if}

--- a/src/components/PrimaryButton.svelte
+++ b/src/components/PrimaryButton.svelte
@@ -18,7 +18,7 @@ $: combinedStyles = `${baseStyles} ${style}`;
 	<a
 		href={link}
 		target={external ? '_blank' : undefined}
-		rel={external ? 'noreferrer' : undefined}
+		rel={external ? 'noopener noreferrer' : undefined}
 		class={combinedStyles}
 		{...$$restProps}
 	>

--- a/src/components/TaggingIssues.svelte
+++ b/src/components/TaggingIssues.svelte
@@ -6,6 +6,7 @@ import OutClick from "svelte-outclick";
 import CloseButton from "$components/CloseButton.svelte";
 import Icon from "$components/Icon.svelte";
 import IssueIcon from "$components/IssueIcon.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { taggingIssues } from "$lib/store";
 import { getIssueHelpLink, getIssueIcon } from "$lib/utils";
 
@@ -27,14 +28,9 @@ const closeModal = () => ($taggingIssues = undefined);
 							<IssueIcon icon={getIssueIcon(issue.type)} />
 							<p>{issue.description}</p>
 							{#if getIssueHelpLink(issue.type)}
-								<a
-									href={getIssueHelpLink(issue.type)}
-									target="_blank"
-									rel="noreferrer"
-									class="text-link transition-colors hover:text-hover"
-								>
+								<TextLink link={getIssueHelpLink(issue.type)} external>
 									{$_(`maintain.help`)}
-								</a>
+								</TextLink>
 							{/if}
 						</div>
 					{/each}

--- a/src/components/TextLink.svelte
+++ b/src/components/TextLink.svelte
@@ -1,17 +1,13 @@
 <script lang="ts">
-import LoadingSpinner from "$components/LoadingSpinner.svelte";
-
-export let style: string;
+export let style: string = "";
 export let link: undefined | string = undefined;
 export let type: undefined | "button" | "submit" = undefined;
 export let external: undefined | boolean = undefined;
 export let disabled: undefined | boolean = undefined;
-export let loading: undefined | boolean = undefined;
 
-const baseStyles =
-	"block bg-link text-center font-semibold text-white hover:bg-hover transition-colors";
+const baseStyles = "text-link transition-colors hover:text-hover";
 
-$: combinedStyles = `${baseStyles} ${style}`;
+$: combinedStyles = style ? `${baseStyles} ${style}` : baseStyles;
 </script>
 
 {#if link}
@@ -19,6 +15,7 @@ $: combinedStyles = `${baseStyles} ${style}`;
 		href={link}
 		target={external ? '_blank' : undefined}
 		rel={external ? 'noreferrer' : undefined}
+		on:click
 		class={combinedStyles}
 		{...$$restProps}
 	>
@@ -26,10 +23,6 @@ $: combinedStyles = `${baseStyles} ${style}`;
 	</a>
 {:else}
 	<button on:click {type} {disabled} class={combinedStyles} {...$$restProps}>
-		{#if loading}
-			<LoadingSpinner />
-		{:else}
-			<slot />
-		{/if}
+		<slot />
 	</button>
 {/if}

--- a/src/components/TextLink.svelte
+++ b/src/components/TextLink.svelte
@@ -14,7 +14,7 @@ $: combinedStyles = style ? `${baseStyles} ${style}` : baseStyles;
 	<a
 		href={link}
 		target={external ? '_blank' : undefined}
-		rel={external ? 'noreferrer' : undefined}
+		rel={external ? 'noopener noreferrer' : undefined}
 		on:click
 		class={combinedStyles}
 		{...$$restProps}

--- a/src/components/area/AreaMerchantHighlights.svelte
+++ b/src/components/area/AreaMerchantHighlights.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import MerchantCard from "$components/area/MerchantCard.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { _ } from "$lib/i18n";
 import type { Place } from "$lib/types";
 import { isBoosted } from "$lib/utils";
@@ -79,9 +80,8 @@ $: latest = filteredPlaces?.toSorted((a, b) => b.id - a.id).slice(0, 6);
 				</div>
 			{:else}
 				<p class="text-center text-primary sm:text-left dark:text-white">
-					{$_('areaHighlights.noLatest')} <a
-						href={resolve('/add-location')}
-						class="text-link transition-colors hover:text-hover">{$_('areaHighlights.addNewMerchant')}</a
+					{$_('areaHighlights.noLatest')} <TextLink
+						link={resolve('/add-location')}>{$_('areaHighlights.addNewMerchant')}</TextLink
 					> {$_('areaHighlights.now')}
 				</p>
 			{/if}

--- a/src/components/area/AreaStats.svelte
+++ b/src/components/area/AreaStats.svelte
@@ -5,6 +5,7 @@ import { _ } from "svelte-i18n";
 
 import Icon from "$components/Icon.svelte";
 import ProfileStat from "$components/ProfileStat.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { theme } from "$lib/theme";
 import type { AreaTags, Report } from "$lib/types.js";
 import { updateChartThemes } from "$lib/utils";
@@ -399,11 +400,9 @@ onMount(async () => {
 </section>
 
 <p class="text-center text-sm text-body md:text-left dark:text-white">
-	{$_(`areaStats.tagsInfo`)} <a
-		href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance"
-		target="_blank"
-		rel="noreferrer"
-		class="text-link transition-colors hover:text-hover">{$_(`areaStats.here`)}</a
+	{$_(`areaStats.tagsInfo`)} <TextLink
+		link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance"
+		external>{$_(`areaStats.here`)}</TextLink
 	>.
 	<br />
 	{$_(`areaStats.chartDataNote`)}

--- a/src/components/area/AreaTickets.svelte
+++ b/src/components/area/AreaTickets.svelte
@@ -3,6 +3,7 @@ import { _ } from "svelte-i18n";
 
 import InfoTooltip from "$components/InfoTooltip.svelte";
 import OpenTicket from "$components/OpenTicket.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { GITEA_LABELS } from "$lib/constants";
 import type { GiteaIssue, GiteaLabel } from "$lib/types";
 import type { Tickets } from "$lib/types.js";
@@ -155,11 +156,9 @@ $: totalTickets = add.length + verify.length + community.length;
 			<p
 				class="border-t border-gray-300 p-5 text-center text-body dark:border-white/95 dark:text-white"
 			>
-				{$_(`maintain.underMaintenance`)} <a
-					href="https://gitea.btcmap.org/teambtcmap/btcmap-data/issues"
-					target="_blank"
-					rel="noreferrer"
-					class="text-link transition-colors hover:text-hover">{$_(`maintain.viewOnGitea`)}</a
+				{$_(`maintain.underMaintenance`)} <TextLink
+					link="https://gitea.btcmap.org/teambtcmap/btcmap-data/issues"
+					external>{$_(`maintain.viewOnGitea`)}</TextLink
 				>
 			</p>
 		{:else if ticketError}

--- a/src/components/auth/LoginForm.svelte
+++ b/src/components/auth/LoginForm.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 import { get } from "svelte/store";
 
+import PrimaryButton from "$components/PrimaryButton.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { trackEvent } from "$lib/analytics";
 import api from "$lib/axios";
 import { _ } from "$lib/i18n";
@@ -91,26 +93,24 @@ async function handleSubmit() {
 		/>
 	</div>
 
-	<button
+	<PrimaryButton
 		type="submit"
 		disabled={loading || !username.trim() || !password}
-		class="w-full rounded-lg bg-link px-4 py-2 font-semibold text-white transition-colors hover:bg-hover disabled:opacity-50"
+		style="w-full rounded-lg px-4 py-2 disabled:opacity-50"
 	>
 		{loading ? $_("login.loggingIn") : $_("login.submit")}
-	</button>
+	</PrimaryButton>
 </form>
 
 {#if !compact}
 	<p class="mt-4 text-center text-sm text-body dark:text-white/70">
 		{$_("login.noAccount")}
-		<a
-			href="https://developer.btcmap.org"
-			target="_blank"
-			rel="noopener noreferrer"
+		<TextLink
+			link="https://developer.btcmap.org"
+			external
 			on:click={() => trackEvent("login_create_account_click")}
-			class="text-link transition-colors hover:text-hover"
 		>
 			{$_("login.createAccount")}
-		</a>
+		</TextLink>
 	</p>
 {/if}

--- a/src/components/auth/SaveAuthPrompt.svelte
+++ b/src/components/auth/SaveAuthPrompt.svelte
@@ -5,6 +5,8 @@ import { get } from "svelte/store";
 import BackupCredentials from "$components/auth/BackupCredentials.svelte";
 import LoginForm from "$components/auth/LoginForm.svelte";
 import Modal from "$components/Modal.svelte";
+import PrimaryButton from "$components/PrimaryButton.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { trackEvent } from "$lib/analytics";
 import { _ } from "$lib/i18n";
 import type { SavedItemType } from "$lib/savedItems";
@@ -141,14 +143,14 @@ function handleDone() {
 			{$_(promptDescriptionKey)}
 		</p>
 		<div class="space-y-3">
-			<button
+			<PrimaryButton
 				type="button"
 				on:click={handleCreateAccount}
 				disabled={creating}
-				class="w-full rounded-lg bg-link px-4 py-2 font-semibold text-white transition-colors hover:bg-hover disabled:opacity-50"
+				style="w-full rounded-lg px-4 py-2 disabled:opacity-50"
 			>
 				{$_("save.prompt.createAccount")}
-			</button>
+			</PrimaryButton>
 			<button
 				type="button"
 				on:click={() => {
@@ -162,13 +164,13 @@ function handleDone() {
 		</div>
 	{:else if view === "login"}
 		<LoginForm compact onSuccess={handleLoginSuccess} />
-		<button
+		<TextLink
 			type="button"
 			on:click={() => (view = "choice")}
-			class="mt-4 text-sm text-link transition-colors hover:text-hover"
+			style="mt-4 text-sm"
 		>
 			← {$_("save.prompt.back")}
-		</button>
+		</TextLink>
 	{:else if view === "backup" && $session}
 		<p class="mb-4 text-sm text-body dark:text-white/70">
 			{$_("backup.description")}
@@ -178,12 +180,12 @@ function handleDone() {
 			username={$session.username}
 			password={$session.password}
 		/>
-		<button
+		<PrimaryButton
 			type="button"
 			on:click={handleDone}
-			class="mt-6 w-full rounded-lg bg-link px-4 py-2 font-semibold text-white transition-colors hover:bg-hover"
+			style="mt-6 w-full rounded-lg px-4 py-2"
 		>
 			{$_("save.prompt.done")}
-		</button>
+		</PrimaryButton>
 	{/if}
 </Modal>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@ import AppDownloadModal from "$components/AppDownloadModal.svelte";
 import Footer from "$components/layout/Footer.svelte";
 import Header from "$components/layout/Header.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
+import PrimaryButton from "$components/PrimaryButton.svelte";
 import type { AppConfig } from "$lib/apps";
 import { appConfigs } from "$lib/apps";
 import IconApps from "$lib/icons/IconApps.svelte";
@@ -115,16 +116,16 @@ function openAppModal(app: AppConfig) {
 							class="mx-2 my-2 space-y-1 text-center font-semibold text-body md:my-0 dark:text-white"
 						>
 							<p>{label}</p>
-							<button
+							<PrimaryButton
 								type="button"
 								aria-label={platform === 'web'
 									? $_('home.openWebAppAria', { values: { type: label } })
 									: $_('home.downloadForAria', { values: { type: label } })}
-								class="mx-auto inline-flex cursor-pointer rounded-full bg-link p-3 text-white transition-colors hover:bg-hover"
+								style="mx-auto inline-flex cursor-pointer rounded-full p-3"
 								on:click={() => openAppModal(app)}
 							>
 								<IconApps w="32" h="32" {icon} />
-							</button>
+							</PrimaryButton>
 						</div>
 					{/if}
 				{/each}

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -4,6 +4,7 @@ import { onMount } from "svelte";
 import LatestTagger from "$components/LatestTagger.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import TaggerSkeleton from "$components/TaggerSkeleton.svelte";
+import TextLink from "$components/TextLink.svelte";
 import TopButton from "$components/TopButton.svelte";
 import { API_BASE } from "$lib/api-base";
 import { _ } from "$lib/i18n";
@@ -132,9 +133,8 @@ $: latestTaggers = !!(supertaggers?.length && !elementsLoading);
 	</h2>
 
 	<p class="text-center text-xl text-primary lg:text-left dark:text-white">
-		{$_('activityPage.cta')} <a
-			href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers-"
-			class="text-link transition-colors hover:text-hover">{$_('activityPage.getTaggin')}</a
+		{$_('activityPage.cta')} <TextLink
+			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers-">{$_('activityPage.getTaggin')}</TextLink
 		>
 	</p>
 

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -13,6 +13,7 @@ import InfoTooltip from "$components/InfoTooltip.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import MapLoadingEmbed from "$components/MapLoadingEmbed.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { _, locale } from "$lib/i18n";
 import { loadMapDependencies } from "$lib/map/imports";
 import {
@@ -394,11 +395,9 @@ $: $theme !== undefined && mapLoaded === true && toggleTheme();
 	</p>
 
 	<p class="mt-10 text-center text-lg font-semibold text-primary md:text-xl dark:text-white">
-		{$_('addLocation.businessOwner')} <a
-			href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Merchant-Best-Practices"
-			target="_blank"
-			rel="noreferrer"
-				class="text-link transition-colors hover:text-hover">{$_('addLocation.bestPractices')}</a
+		{$_('addLocation.businessOwner')} <TextLink
+			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Merchant-Best-Practices"
+			external>{$_('addLocation.bestPractices')}</TextLink
 		> {$_('addLocation.guide')}
 	</p>
 

--- a/src/routes/communities/[section]/components/CommunityCard.svelte
+++ b/src/routes/communities/[section]/components/CommunityCard.svelte
@@ -2,6 +2,7 @@
 import OrgBadge from "$components/OrgBadge.svelte";
 import Socials from "$components/Socials.svelte";
 import SponsorBadge from "$components/SponsorBadge.svelte";
+import TextLink from "$components/TextLink.svelte";
 import Tip from "$components/Tip.svelte";
 import { getOrganizationDisplayName } from "$lib/organizationDisplayNames";
 import type { AreaTags } from "$lib/types";
@@ -71,9 +72,9 @@ $: tip =
 	class="rounded-3xl border border-gray-300 shadow transition-shadow hover:shadow-2xl dark:border-white/95 dark:bg-white/10"
 >
 	<div class="my-4 space-y-2 p-4">
-		<a
-			href={resolve(`/community/${encodeURIComponent(id)}`)}
-			class="space-y-2 text-link transition-colors hover:text-hover"
+		<TextLink
+			link={resolve(`/community/${encodeURIComponent(id)}`)}
+			style="space-y-2"
 		>
 			<img
 				loading="lazy"
@@ -86,7 +87,7 @@ $: tip =
 			/>
 
 			<span class="block text-center text-lg font-semibold">{tags.name}</span>
-		</a>
+		</TextLink>
 		{#if tags.organization}
 			<OrgBadge org={getOrganizationDisplayName(tags.organization)} />
 		{/if}

--- a/src/routes/communities/add/+page.svelte
+++ b/src/routes/communities/add/+page.svelte
@@ -10,6 +10,7 @@ import Icon from "$components/Icon.svelte";
 import InfoTooltip from "$components/InfoTooltip.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { theme } from "$lib/theme";
 import type { NominatimResponse } from "$lib/types";
 import { errToast, successToast, warningToast } from "$lib/utils";
@@ -307,18 +308,14 @@ onMount(async () => {
 					>{$_('addCommunityForm.lightningLabel')} <span class="font-normal">({$_('addCommunityForm.iconOptional')})</span></label
 				>
 				<p class="mb-2 text-sm">
-					{$_('addCommunityForm.lightningHint')} <a
-						href="https://lightningaddress.com/"
-						target="_blank"
-						rel="noreferrer"
-						class="text-link transition-colors hover:text-hover">{$_('addCommunityForm.lightningAddress')}</a
+					{$_('addCommunityForm.lightningHint')} <TextLink
+						link="https://lightningaddress.com/"
+						external>{$_('addCommunityForm.lightningAddress')}</TextLink
 					>
 					{$_('addCommunityForm.lightningOr')}
-					<a
-						href="https://github.com/fiatjaf/lnurl-rfc#lnurl-documents"
-						target="_blank"
-						rel="noreferrer"
-						class="text-link transition-colors hover:text-hover">{$_('addCommunityForm.lightningLnurl')}</a
+					<TextLink
+						link="https://github.com/fiatjaf/lnurl-rfc#lnurl-documents"
+						external>{$_('addCommunityForm.lightningLnurl')}</TextLink
 					> {$_('addCommunityForm.lightningSuffix')}
 				</p>
 				<input

--- a/src/routes/countries/[section]/components/CountryCard.svelte
+++ b/src/routes/countries/[section]/components/CountryCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { locale } from "svelte-i18n";
 
+import TextLink from "$components/TextLink.svelte";
 import { getCountryName } from "$lib/countryNames";
 
 import { resolve } from "$app/paths";
@@ -28,9 +29,9 @@ $: {
 	class="rounded-3xl border border-gray-300 shadow transition-shadow hover:shadow-2xl dark:border-white/95 dark:bg-white/10"
 >
 	<div class="my-4 space-y-2 p-4">
-		<a
-			href={resolve(`/country/${id}`)}
-			class="space-y-2 text-link transition-colors hover:text-hover"
+		<TextLink
+			link={resolve(`/country/${id}`)}
+			style="space-y-2"
 		>
 			<img
 				src={`https://static.btcmap.org/images/countries/${id}.svg`}
@@ -46,6 +47,6 @@ $: {
 				class="block text-center text-lg font-semibold"
 				>{localizedName}</span
 			>
-		</a>
+		</TextLink>
 	</div>
 </div>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -9,6 +9,7 @@ import { onDestroy, onMount } from "svelte";
 import { get } from "svelte/store";
 
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { _ } from "$lib/i18n";
 import { theme } from "$lib/theme";
 import type { ChartHistory } from "$lib/types";
@@ -411,11 +412,9 @@ $: {
 	</section>
 
 	<p class="text-center text-sm text-body md:text-left dark:text-white">
-		{$_('dashboard.tagsNotePart1')} <a
-			href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance"
-			target="_blank"
-			rel="noreferrer"
-			class="text-link transition-colors hover:text-hover">{$_('dashboard.tagsNoteLink')}</a
+		{$_('dashboard.tagsNotePart1')} <TextLink
+			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance"
+			external>{$_('dashboard.tagsNoteLink')}</TextLink
 		>{$_('dashboard.tagsNotePart2')}
 	</p>
 </div>

--- a/src/routes/license/+page.svelte
+++ b/src/routes/license/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import TextLink from "$components/TextLink.svelte";
 import { _ } from "$lib/i18n";
 </script>
 
@@ -16,9 +17,9 @@ import { _ } from "$lib/i18n";
 		<br />
 		Copyright &#169; 2022-{new Date().getFullYear()} BTC Map
 		<br />
-		<a
-			href="mailto:hello@btcmap.org"
-			class="font-normal text-link transition-colors hover:text-hover">hello@btcmap.org</a
+		<TextLink
+			link="mailto:hello@btcmap.org"
+			style="font-normal">hello@btcmap.org</TextLink
 		>
 	</p>
 	<p>
@@ -42,9 +43,8 @@ import { _ } from "$lib/i18n";
 	</h1>
 
 	<p>
-		Copyright (C) 2007 Free Software Foundation, Inc. <a
-			href="https://fsf.org/"
-			class="text-link transition-colors hover:text-hover">https://fsf.org/</a
+		Copyright (C) 2007 Free Software Foundation, Inc. <TextLink
+			link="https://fsf.org/">https://fsf.org/</TextLink
 		>
 		Everyone is permitted to copy and distribute verbatim copies of this license document, but changing
 		it is not allowed.

--- a/src/routes/tagging-issues/+page.svelte
+++ b/src/routes/tagging-issues/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import IssuesTable from "$components/IssuesTable.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { _ } from "$lib/i18n";
 import { theme } from "$lib/theme";
 import type { RpcIssue } from "$lib/types";
@@ -36,9 +37,8 @@ let issues: RpcIssue[] = data.rpcResult.requested_issues;
 	</h2>
 
 	<p class="text-center text-xl text-primary lg:text-left dark:text-white">
-		{$_("taggingIssues.descriptionPart1")}<a
-			href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants"
-			class="text-link transition-colors hover:text-hover">{$_("taggingIssues.linkText")}</a
+		{$_("taggingIssues.descriptionPart1")}<TextLink
+			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants">{$_("taggingIssues.linkText")}</TextLink
 		>{$_("taggingIssues.descriptionPart2")}
 	</p>
 	<IssuesTable title={$_("taggingIssues.tableTitle")} {issues} loading={false} initialPageSize={50} />

--- a/src/routes/tickets/+page.svelte
+++ b/src/routes/tickets/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import OpenTicket from "$components/OpenTicket.svelte";
+import TextLink from "$components/TextLink.svelte";
 import TopButton from "$components/TopButton.svelte";
 import { GITEA_LABELS } from "$lib/constants";
 import { _ } from "$lib/i18n";
@@ -80,9 +81,8 @@ const isMaintenance = data.maintenance ?? false;
 	</h2>
 
 	<p class="text-center text-xl text-primary lg:text-left dark:text-white">
-		{$_('maintain.taggingInstructionsIntro')} <a
-			href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers"
-			class="text-link transition-colors hover:text-hover">{$_('maintain.taggingInstructionsLink')}</a
+		{$_('maintain.taggingInstructionsIntro')} <TextLink
+			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers">{$_('maintain.taggingInstructionsLink')}</TextLink
 		>.
 	</p>
 
@@ -90,11 +90,9 @@ const isMaintenance = data.maintenance ?? false;
 		<div class="w-full rounded-3xl border border-gray-300 dark:border-white/95 dark:bg-white/10">
 			{#if isMaintenance}
 				<p class="p-5 text-center text-body dark:text-white">
-					{$_('maintain.underMaintenance')} <a
-						href="https://gitea.btcmap.org/teambtcmap/btcmap-data/issues"
-						target="_blank"
-						rel="noreferrer"
-						class="text-link transition-colors hover:text-hover">{$_('maintain.viewOnGitea')}</a
+					{$_('maintain.underMaintenance')} <TextLink
+						link="https://gitea.btcmap.org/teambtcmap/btcmap-data/issues"
+						external>{$_('maintain.viewOnGitea')}</TextLink
 					>
 				</p>
 			{:else}
@@ -181,11 +179,9 @@ const isMaintenance = data.maintenance ?? false;
 						<p
 							class="border-t border-gray-300 p-5 text-center font-semibold text-primary dark:border-white/95 dark:text-white"
 						>
-							{$_('maintain.viewAllOnGitea')} <a
-								href="https://gitea.btcmap.org/teambtcmap/btcmap-data/issues"
-								target="_blank"
-								rel="noreferrer"
-								class="text-link transition-colors hover:text-hover">{$_('maintain.giteaLinkText')}</a
+							{$_('maintain.viewAllOnGitea')} <TextLink
+								link="https://gitea.btcmap.org/teambtcmap/btcmap-data/issues"
+								external>{$_('maintain.giteaLinkText')}</TextLink
 							>.
 						</p>
 					{/if}

--- a/src/routes/verify-location/+page.svelte
+++ b/src/routes/verify-location/+page.svelte
@@ -11,6 +11,7 @@ import Icon from "$components/Icon.svelte";
 import InfoTooltip from "$components/InfoTooltip.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
+import TextLink from "$components/TextLink.svelte";
 import { _ } from "$lib/i18n";
 import { placesError } from "$lib/store";
 import { theme } from "$lib/theme";
@@ -145,17 +146,13 @@ onMount(async () => {
 		</h2>
 
 		<p class="mb-10 w-full text-center text-primary dark:text-white">
-			{$_('verifyLocation.descriptionPart1')} <a
-				href="https://www.openstreetmap.org"
-				target="_blank"
-				rel="noreferrer"
-				class="text-link transition-colors hover:text-hover">{$_('verifyLocation.osmLinkText')}</a
+			{$_('verifyLocation.descriptionPart1')} <TextLink
+				link="https://www.openstreetmap.org"
+				external>{$_('verifyLocation.osmLinkText')}</TextLink
 			>{$_('verifyLocation.descriptionPart2')}
-			<a
-				href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers"
-				target="_blank"
-				rel="noreferrer"
-				class="text-link transition-colors hover:text-hover">{$_('verifyLocation.wikiLinkText')}</a
+			<TextLink
+				link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers"
+				external>{$_('verifyLocation.wikiLinkText')}</TextLink
 			>
 			{$_('verifyLocation.descriptionPart3')} <InfoTooltip
 				tooltip={$_('verifyLocation.tooltip')}


### PR DESCRIPTION
  Introduce a `TextLink` component for the repeating `text-link transition-colors hover:text-hover` pattern (~70 inline  usages spotted across the codebase) and migrate the cleanest ~23 sites to it. Also migrate three raw button holdouts to  `PrimaryButton` (LoginForm submit, SaveAuthPrompt create/done, home app icon buttons). Both components now forward  `$$restProps` so callers can pass `aria-label`, `title`, etc.

  **Scope:** Tier 1 of a wider button-consolidation effort. ~40 additional text-link sites remain — cases with conditional  classes, dark-mode overrides, `group-hover`, or HTML-string templates — and can be picked up in follow-up passes.

  **Net:** 20 files changed, +128/−126. No behavior change intended; visual output is identical.

  ## Test plan

  - [x] **Home (`/`)** — app icon buttons (Android/Web/iOS) render with correct background, hover, and aria-labels
  - [x] **Login (`/login`)** — submit button shows disabled opacity when empty; "create account" link styled correctly and  opens developer.btcmap.org in new tab; analytics `login_create_account_click` fires
  - [x] **License (`/license`)** — `hello@btcmap.org` and `https://fsf.org/` links styled correctly
  - [x] **Tickets (`/tickets`)** — "tagging instructions" link and "view on Gitea" link styled correctly
  - [x] **Tagging issues (`/tagging-issues`)** — wiki link in description paragraph styled correctly
  - [x] **Activity (`/activity`)** — "get taggin'" link styled correctly
  - [x] **Dashboard (`/dashboard`)** — tags-note gitea link styled correctly
  - [x] **Add location (`/add-location`)** — best-practices link styled correctly; form submit still works
  - [ ] **Verify location (`/verify-location?id=<id>`)** — OpenStreetMap and Wiki links inline in description paragraph
  - [x] **Communities list (`/communities/all`)** — community card image + name link clickable, styled correctly
  - [ ] **Communities add (`/communities/add`)** — Lightning Address and LNURL doc links styled correctly; form submit still   works
  - [ ] **Countries list (`/countries/all`)** — country flag + name card clickable, styled correctly
  - [ ] **Area page (any `/community/<id>`)** — `AreaStats` "here" tagging-guide link; `AreaTickets` maintenance gitea link;
   `AreaMerchantHighlights` "add new merchant" link
  - [ ] **Save-auth prompt** — trigger via Save on a place/area when logged out: "create account" primary button works;  "login" secondary still styled (not migrated); "back" ghost link returns to choice view; "done" primary closes modal
  - [ ] **Issue/tagging tables** — "view", "edit", "help" cell links open in new tab with correct styling
  - [x] **Dark mode toggle** — confirm migrated links/buttons still render correctly in dark theme
  - [x] **Mobile viewport** — sanity-check responsive layout on the home app buttons and verify-location paragraph

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated link and button rendering across the application for improved consistency and code maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/992)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->