### PR TITLE
refactor(buttons): add IconButton component

### DIFF
--- a/src/components/IconButton.svelte
+++ b/src/components/IconButton.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+export let style: string = "";
+export let link: undefined | string = undefined;
+export let type: undefined | "button" | "submit" = undefined;
+export let external: undefined | boolean = undefined;
+export let disabled: undefined | boolean = undefined;
+
+const baseStyles =
+	"rounded-lg border border-gray-300 p-2 transition-colors hover:bg-gray-100 dark:border-white/20 dark:hover:bg-white/10";
+
+$: combinedStyles = style ? `${baseStyles} ${style}` : baseStyles;
+</script>
+
+{#if link}
+	<a
+		href={link}
+		target={external ? '_blank' : undefined}
+		rel={external ? 'noopener noreferrer' : undefined}
+		on:click
+		class={combinedStyles}
+		{...$$restProps}
+	>
+		<slot />
+	</a>
+{:else}
+	<button on:click {type} {disabled} class={combinedStyles} {...$$restProps}>
+		<slot />
+	</button>
+{/if}

--- a/src/components/auth/BackupCredentials.svelte
+++ b/src/components/auth/BackupCredentials.svelte
@@ -94,6 +94,7 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 					on:click={() => copyToClipboard(password ?? "", "password")}
 					style="shrink-0"
 					title={$_("backup.copy")}
+					aria-label={$_("backup.copy")}
 				>
 					<Icon
 						type="material"

--- a/src/components/auth/BackupCredentials.svelte
+++ b/src/components/auth/BackupCredentials.svelte
@@ -45,6 +45,7 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 				on:click={() => copyToClipboard(username, "username")}
 				style="shrink-0"
 				title={$_("backup.copy")}
+				aria-label={$_("backup.copy")}
 			>
 				<Icon
 					type="material"

--- a/src/components/auth/BackupCredentials.svelte
+++ b/src/components/auth/BackupCredentials.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Icon from "$components/Icon.svelte";
+import IconButton from "$components/IconButton.svelte";
 import { trackEvent } from "$lib/analytics";
 import { _ } from "$lib/i18n";
 import { errToast, successToast } from "$lib/utils";
@@ -39,10 +40,10 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 				value={username}
 				class="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-primary dark:border-white/20 dark:bg-white/5 dark:text-white"
 			/>
-			<button
+			<IconButton
 				type="button"
 				on:click={() => copyToClipboard(username, "username")}
-				class="shrink-0 rounded-lg border border-gray-300 p-2 transition-colors hover:bg-gray-100 dark:border-white/20 dark:hover:bg-white/10"
+				style="shrink-0"
 				title={$_("backup.copy")}
 			>
 				<Icon
@@ -52,7 +53,7 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 					h="16"
 					class="text-primary dark:text-white"
 				/>
-			</button>
+			</IconButton>
 		</div>
 	</div>
 	<div>
@@ -70,10 +71,10 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 				value={password || $_("backup.unavailable")}
 				class="w-full rounded-lg border border-gray-300 bg-gray-50 px-3 py-2 text-sm text-primary dark:border-white/20 dark:bg-white/5 dark:text-white"
 			/>
-			<button
+			<IconButton
 				type="button"
 				on:click={() => (showPassword = !showPassword)}
-				class="shrink-0 rounded-lg border border-gray-300 p-2 transition-colors hover:bg-gray-100 dark:border-white/20 dark:hover:bg-white/10"
+				style="shrink-0"
 				title={showPassword ? $_("backup.hide") : $_("backup.show")}
 			>
 				<Icon
@@ -83,12 +84,12 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 					h="16"
 					class="text-primary dark:text-white"
 				/>
-			</button>
+			</IconButton>
 			{#if password}
-				<button
+				<IconButton
 					type="button"
 					on:click={() => copyToClipboard(password ?? "", "password")}
-					class="shrink-0 rounded-lg border border-gray-300 p-2 transition-colors hover:bg-gray-100 dark:border-white/20 dark:hover:bg-white/10"
+					style="shrink-0"
 					title={$_("backup.copy")}
 				>
 					<Icon
@@ -98,7 +99,7 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 						h="16"
 						class="text-primary dark:text-white"
 					/>
-				</button>
+				</IconButton>
 			{/if}
 		</div>
 	</div>

--- a/src/components/auth/BackupCredentials.svelte
+++ b/src/components/auth/BackupCredentials.svelte
@@ -77,6 +77,8 @@ async function copyToClipboard(text: string, field: "username" | "password") {
 				on:click={() => (showPassword = !showPassword)}
 				style="shrink-0"
 				title={showPassword ? $_("backup.hide") : $_("backup.show")}
+				aria-label={showPassword ? $_("backup.hide") : $_("backup.show")}
+				aria-pressed={showPassword}
 			>
 				<Icon
 					type="material"


### PR DESCRIPTION


Consolidate the three identical outlined icon buttons in BackupCredentials (copy username, show/hide password, copy password) into a shared IconButton component. Mirrors PrimaryButton/TextLink API ($$restProps forwarded, link or button rendering, noopener noreferrer on external links).

SecondaryButton was considered but skipped — only one firm migration site (SaveAuthPrompt login button), with the other outlined patterns (SaveButton conditional, Tip's hover-inversion) being structurally different and not benefitting from a shared component yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

