### PR TITLE
fix(layout): reserve scrollbar gutter to prevent header jump #972

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -11,6 +11,7 @@
 	html {
 		font-family: Manrope, sans-serif;
 		@apply text-base;
+		scrollbar-gutter: stable;
 	}
 
 	::selection {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -122,6 +122,10 @@ export let data;
 			content="Easily find places to spend sats anywhere on the planet."
 		/>
 	{/if}
+	{#if ['/map', '/communities/map'].includes(data.pathname)}
+		<!-- Fullscreen map routes have no scrollbar; skip the reserved gutter so the map fills the viewport -->
+		<style>html { scrollbar-gutter: auto; }</style>
+	{/if}
 	<meta
 		name="lightning"
 		content="lnurlp:LNURL1DP68GURN8GHJ7CM0WFJJUCN5VDKKZUPWDAEXWTMVDE6HYMRS9ARKXVN4W5EQPSYZ34"


### PR DESCRIPTION
Adds scrollbar-gutter: stable on html so the layout stays put when navigating between pages with and without a vertical scrollbar. Overrides back to auto for /map and /communities/map via svelte:head so those fullscreen leaflet views still fill the viewport edge-to-edge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented layout shifting caused by scrollbar appearance and disappearance across the application
  * Improved fullscreen map view stability with consistent viewport spacing

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/994)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->