### PR TITLE
feat(lnurlp): add zaps@btcmap.org forwarding

### DIFF
--- a/src/lib/lnurlpForwarder.ts
+++ b/src/lib/lnurlpForwarder.ts
@@ -1,0 +1,92 @@
+import { json } from "@sveltejs/kit";
+
+const TIMEOUT_MS = 5000;
+const CORS_HEADERS = { "Access-Control-Allow-Origin": "*" };
+
+type ForwardLnurlpOptions = {
+	fetch: typeof fetch;
+	upstream: string;
+	identifier: string;
+};
+
+const isMetadataEntry = (entry: unknown): entry is [string, string] =>
+	Array.isArray(entry) &&
+	entry.length === 2 &&
+	typeof entry[0] === "string" &&
+	typeof entry[1] === "string";
+
+const rewriteMetadataIdentifier = (
+	metadata: string,
+	identifier: string,
+): string => {
+	try {
+		const parsed: unknown = JSON.parse(metadata);
+
+		if (!Array.isArray(parsed) || !parsed.every(isMetadataEntry)) {
+			return metadata;
+		}
+
+		return JSON.stringify(
+			parsed.map(([type, value]) =>
+				type === "text/identifier" ? [type, identifier] : [type, value],
+			),
+		);
+	} catch {
+		return metadata;
+	}
+};
+
+export const forwardLnurlp = async ({
+	fetch,
+	upstream,
+	identifier,
+}: ForwardLnurlpOptions): Promise<Response> => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+	let res: Response;
+	try {
+		res = await fetch(upstream, { signal: controller.signal });
+	} catch {
+		return json(
+			{ status: "ERROR", reason: "Upstream unavailable" },
+			{ status: 502, headers: CORS_HEADERS },
+		);
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	if (!res.ok) {
+		return json(
+			{ status: "ERROR", reason: "Upstream error" },
+			{ status: 502, headers: CORS_HEADERS },
+		);
+	}
+
+	let data: Record<string, unknown>;
+	try {
+		const parsed: unknown = await res.json();
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		) {
+			return json(
+				{ status: "ERROR", reason: "Invalid upstream response" },
+				{ status: 502, headers: CORS_HEADERS },
+			);
+		}
+		data = parsed as Record<string, unknown>;
+	} catch {
+		return json(
+			{ status: "ERROR", reason: "Invalid upstream response" },
+			{ status: 502, headers: CORS_HEADERS },
+		);
+	}
+
+	if (typeof data.metadata === "string") {
+		data.metadata = rewriteMetadataIdentifier(data.metadata, identifier);
+	}
+
+	return json(data, { headers: CORS_HEADERS });
+};

--- a/src/routes/.well-known/lnurlp/donations/+server.ts
+++ b/src/routes/.well-known/lnurlp/donations/+server.ts
@@ -1,71 +1,12 @@
-import { json } from "@sveltejs/kit";
+import { forwardLnurlp } from "$lib/lnurlpForwarder";
 
 import type { RequestHandler } from "./$types";
 
 const UPSTREAM = "https://rizful.com/.well-known/lnurlp/btcmap";
-const TIMEOUT_MS = 5000;
 
-const CORS_HEADERS = { "Access-Control-Allow-Origin": "*" };
-
-export const GET: RequestHandler = async ({ fetch }) => {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-	let res: Response;
-	try {
-		res = await fetch(UPSTREAM, { signal: controller.signal });
-	} catch {
-		return json(
-			{ status: "ERROR", reason: "Upstream unavailable" },
-			{ status: 502, headers: CORS_HEADERS },
-		);
-	} finally {
-		clearTimeout(timeout);
-	}
-
-	if (!res.ok) {
-		return json(
-			{ status: "ERROR", reason: "Upstream error" },
-			{ status: 502, headers: CORS_HEADERS },
-		);
-	}
-
-	let data: Record<string, unknown>;
-	try {
-		const parsed: unknown = await res.json();
-		if (
-			parsed === null ||
-			typeof parsed !== "object" ||
-			Array.isArray(parsed)
-		) {
-			return json(
-				{ status: "ERROR", reason: "Invalid upstream response" },
-				{ status: 502, headers: CORS_HEADERS },
-			);
-		}
-		data = parsed as Record<string, unknown>;
-	} catch {
-		return json(
-			{ status: "ERROR", reason: "Invalid upstream response" },
-			{ status: 502, headers: CORS_HEADERS },
-		);
-	}
-
-	// Rewrite the text/identifier in metadata so wallets show donations@btcmap.org
-	if (typeof data.metadata === "string") {
-		try {
-			const parsed: [string, string][] = JSON.parse(data.metadata);
-			data.metadata = JSON.stringify(
-				parsed.map(([type, value]) =>
-					type === "text/identifier"
-						? [type, "donations@btcmap.org"]
-						: [type, value],
-				),
-			);
-		} catch {
-			// leave metadata as-is if parsing fails
-		}
-	}
-
-	return json(data, { headers: CORS_HEADERS });
-};
+export const GET: RequestHandler = ({ fetch }) =>
+	forwardLnurlp({
+		fetch,
+		upstream: UPSTREAM,
+		identifier: "donations@btcmap.org",
+	});

--- a/src/routes/.well-known/lnurlp/zaps/+server.ts
+++ b/src/routes/.well-known/lnurlp/zaps/+server.ts
@@ -1,71 +1,8 @@
-import { json } from "@sveltejs/kit";
+import { forwardLnurlp } from "$lib/lnurlpForwarder";
 
 import type { RequestHandler } from "./$types";
 
 const UPSTREAM = "https://rizful.com/.well-known/lnurlp/btcmap-zaps";
-const TIMEOUT_MS = 5000;
 
-const CORS_HEADERS = { "Access-Control-Allow-Origin": "*" };
-
-export const GET: RequestHandler = async ({ fetch }) => {
-	const controller = new AbortController();
-	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
-
-	let res: Response;
-	try {
-		res = await fetch(UPSTREAM, { signal: controller.signal });
-	} catch {
-		return json(
-			{ status: "ERROR", reason: "Upstream unavailable" },
-			{ status: 502, headers: CORS_HEADERS },
-		);
-	} finally {
-		clearTimeout(timeout);
-	}
-
-	if (!res.ok) {
-		return json(
-			{ status: "ERROR", reason: "Upstream error" },
-			{ status: 502, headers: CORS_HEADERS },
-		);
-	}
-
-	let data: Record<string, unknown>;
-	try {
-		const parsed: unknown = await res.json();
-		if (
-			parsed === null ||
-			typeof parsed !== "object" ||
-			Array.isArray(parsed)
-		) {
-			return json(
-				{ status: "ERROR", reason: "Invalid upstream response" },
-				{ status: 502, headers: CORS_HEADERS },
-			);
-		}
-		data = parsed as Record<string, unknown>;
-	} catch {
-		return json(
-			{ status: "ERROR", reason: "Invalid upstream response" },
-			{ status: 502, headers: CORS_HEADERS },
-		);
-	}
-
-	// Rewrite the text/identifier in metadata so wallets show zaps@btcmap.org
-	if (typeof data.metadata === "string") {
-		try {
-			const parsed: [string, string][] = JSON.parse(data.metadata);
-			data.metadata = JSON.stringify(
-				parsed.map(([type, value]) =>
-					type === "text/identifier"
-						? [type, "zaps@btcmap.org"]
-						: [type, value],
-				),
-			);
-		} catch {
-			// leave metadata as-is if parsing fails
-		}
-	}
-
-	return json(data, { headers: CORS_HEADERS });
-};
+export const GET: RequestHandler = ({ fetch }) =>
+	forwardLnurlp({ fetch, upstream: UPSTREAM, identifier: "zaps@btcmap.org" });

--- a/src/routes/.well-known/lnurlp/zaps/+server.ts
+++ b/src/routes/.well-known/lnurlp/zaps/+server.ts
@@ -1,0 +1,71 @@
+import { json } from "@sveltejs/kit";
+
+import type { RequestHandler } from "./$types";
+
+const UPSTREAM = "https://rizful.com/.well-known/lnurlp/btcmap-zaps";
+const TIMEOUT_MS = 5000;
+
+const CORS_HEADERS = { "Access-Control-Allow-Origin": "*" };
+
+export const GET: RequestHandler = async ({ fetch }) => {
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+	let res: Response;
+	try {
+		res = await fetch(UPSTREAM, { signal: controller.signal });
+	} catch {
+		return json(
+			{ status: "ERROR", reason: "Upstream unavailable" },
+			{ status: 502, headers: CORS_HEADERS },
+		);
+	} finally {
+		clearTimeout(timeout);
+	}
+
+	if (!res.ok) {
+		return json(
+			{ status: "ERROR", reason: "Upstream error" },
+			{ status: 502, headers: CORS_HEADERS },
+		);
+	}
+
+	let data: Record<string, unknown>;
+	try {
+		const parsed: unknown = await res.json();
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		) {
+			return json(
+				{ status: "ERROR", reason: "Invalid upstream response" },
+				{ status: 502, headers: CORS_HEADERS },
+			);
+		}
+		data = parsed as Record<string, unknown>;
+	} catch {
+		return json(
+			{ status: "ERROR", reason: "Invalid upstream response" },
+			{ status: 502, headers: CORS_HEADERS },
+		);
+	}
+
+	// Rewrite the text/identifier in metadata so wallets show zaps@btcmap.org
+	if (typeof data.metadata === "string") {
+		try {
+			const parsed: [string, string][] = JSON.parse(data.metadata);
+			data.metadata = JSON.stringify(
+				parsed.map(([type, value]) =>
+					type === "text/identifier"
+						? [type, "zaps@btcmap.org"]
+						: [type, value],
+				),
+			);
+		} catch {
+			// leave metadata as-is if parsing fails
+		}
+	}
+
+	return json(data, { headers: CORS_HEADERS });
+};


### PR DESCRIPTION
## Summary
- Add new `.well-known/lnurlp/zaps` SvelteKit server route to forward `zaps@btcmap.org` Lightning Address payments to `btcmap-zaps@rizful.com`
- Mirrors the existing `donations@btcmap.org` forwarding pattern upstream to Rizful
- Rewrites the `text/identifier` metadata so wallets display `zaps@btcmap.org`

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized LNURLp proxying for zaps and donations with a 5s timeout, permissive CORS, and upstream error handling.
  * Automatic metadata normalization that ensures wallet-displayed identifiers are set to the appropriate zaps/donations addresses.

* **Bug Fixes**
  * More consistent handling of upstream failures and malformed responses to reduce client errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/995)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->