### PR TITLE
fix(icons): add fallbacks for icons missing in ic:outline

### DIFF
--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -22,6 +22,13 @@ const materialExceptions: Record<string, string> = {
 	my_location: "material-symbols:my-location-rounded",
 	bookmark_filled: "ic:baseline-bookmark-added",
 	account_circle_filled: "ic:baseline-account-circle",
+	// Missing from ic:outline — fall back to material-symbols
+	potted_plant: "material-symbols:potted-plant-outline",
+	footprint: "material-symbols:footprint-outline",
+	water_pump: "material-symbols:water-pump-outline",
+	adult_content: "material-symbols:explicit-outline",
+	raven: "material-symbols:raven-outline",
+	surgical: "material-symbols:surgical-outline",
 };
 
 const faBrandIcons = ["x-twitter", "instagram", "facebook", "twitter"];


### PR DESCRIPTION
Six tag values resolved to nonexistent ic:outline-* icons, causing empty pins for ~30 places. Map them to material-symbols outline variants in the existing exceptions table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for six additional Material Design icons: potted plant, footprint, water pump, adult content, raven, and surgical.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/1004)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->