### PR TITLE
feat(lnurlp): add LN Address forwards for rockedf and rose

### DIFF
--- a/src/routes/.well-known/lnurlp/rockedf/+server.ts
+++ b/src/routes/.well-known/lnurlp/rockedf/+server.ts
@@ -1,0 +1,12 @@
+import { forwardLnurlp } from "$lib/lnurlpForwarder";
+
+import type { RequestHandler } from "./$types";
+
+const UPSTREAM = "https://coinos.io/.well-known/lnurlp/rockedf";
+
+export const GET: RequestHandler = ({ fetch }) =>
+	forwardLnurlp({
+		fetch,
+		upstream: UPSTREAM,
+		identifier: "rockedf@btcmap.org",
+	});

--- a/src/routes/.well-known/lnurlp/rose/+server.ts
+++ b/src/routes/.well-known/lnurlp/rose/+server.ts
@@ -1,0 +1,12 @@
+import { forwardLnurlp } from "$lib/lnurlpForwarder";
+
+import type { RequestHandler } from "./$types";
+
+const UPSTREAM = "https://coinos.io/.well-known/lnurlp/rose";
+
+export const GET: RequestHandler = ({ fetch }) =>
+	forwardLnurlp({
+		fetch,
+		upstream: UPSTREAM,
+		identifier: "rose@btcmap.org",
+	});


### PR DESCRIPTION
## Summary
- Add `rockedf@btcmap.org` LN Address forwarding to `rockedf@coinos.io`
- Add `rose@btcmap.org` LN Address forwarding to `rose@coinos.io`
- Reuse the existing shared LNURLp forwarder so metadata identifiers are rewritten to the public `btcmap.org` addresses

## Testing
- `pnpm run format:fix`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run test --run`

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lightning Network payment protocol support for two new accounts, enabling LNURL Pay functionality for improved payment processing and integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/1005)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->