### PR TITLE
refactor(wiki): replace gitea wiki urls with wiki.btcmap.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This website is a progressive web app, meaning you can install it on your mobile
 
 ## Embedding
 
-For information on how to embed the BTC Map web map onto your own website or application please reference our [Wiki](https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Embedding).
+For information on how to embed the BTC Map web map onto your own website or application please reference our [Wiki](https://wiki.btcmap.org/Embedding).
 
 ---
 

--- a/src/components/area/AreaStats.svelte
+++ b/src/components/area/AreaStats.svelte
@@ -401,7 +401,7 @@ onMount(async () => {
 
 <p class="text-center text-sm text-body md:text-left dark:text-white">
 	{$_(`areaStats.tagsInfo`)} <TextLink
-		link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance"
+		link="https://wiki.btcmap.org/Tagging-Merchants#tagging-guidance"
 		external>{$_(`areaStats.here`)}</TextLink
 	>.
 	<br />

--- a/src/components/layout/Header.svelte
+++ b/src/components/layout/Header.svelte
@@ -44,7 +44,7 @@ $: navLinks = [
 	{
 		id: "wiki",
 		title: $_("nav.wiki"),
-		url: "https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki",
+		url: "https://wiki.btcmap.org/",
 		icon: "wiki" as MobileNavIconName,
 	},
 	{

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -194,13 +194,13 @@ export const getIssueHelpLink = (issue_code: string) => {
 		issue_code === "out_of_date_soon" ||
 		issue_code === "not_verified"
 	) {
-		return "https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Verifying-Existing-Merchants";
+		return "https://wiki.btcmap.org/Verifying-Existing-Merchants";
 	}
 	if (issue_code.startsWith("invalid_tag_value")) {
-		return "https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance";
+		return "https://wiki.btcmap.org/Tagging-Merchants#tagging-guidance";
 	}
 	if (issue_code.startsWith("misspelled_tag_name")) {
-		return "https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance";
+		return "https://wiki.btcmap.org/Tagging-Merchants#tagging-guidance";
 	}
 	return undefined;
 };

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -134,7 +134,7 @@ $: latestTaggers = !!(supertaggers?.length && !elementsLoading);
 
 	<p class="text-center text-xl text-primary lg:text-left dark:text-white">
 		{$_('activityPage.cta')} <TextLink
-			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers-">{$_('activityPage.getTaggin')}</TextLink
+			link="https://wiki.btcmap.org/Tagging-Merchants#shadowy-supertaggers-">{$_('activityPage.getTaggin')}</TextLink
 		>
 	</p>
 

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -396,7 +396,7 @@ $: $theme !== undefined && mapLoaded === true && toggleTheme();
 
 	<p class="mt-10 text-center text-lg font-semibold text-primary md:text-xl dark:text-white">
 		{$_('addLocation.businessOwner')} <TextLink
-			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Merchant-Best-Practices"
+			link="https://wiki.btcmap.org/Merchant-Best-Practices"
 			external>{$_('addLocation.bestPractices')}</TextLink
 		> {$_('addLocation.guide')}
 	</p>
@@ -801,7 +801,7 @@ $: $theme !== undefined && mapLoaded === true && toggleTheme();
 					/>
 					<PrimaryButton
 						style="w-full py-3 rounded-xl"
-						link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers-"
+						link="https://wiki.btcmap.org/Tagging-Merchants#shadowy-supertaggers-"
 						external={true}
 					>
 						{$_('addLocation.supertaggerWikiButton')}

--- a/src/routes/api/gitea/issue/+server.ts
+++ b/src/routes/api/gitea/issue/+server.ts
@@ -133,7 +133,7 @@ function generateBody(
 	areasText: string,
 ): string {
 	const timestamp = new Date(Date.now()).toISOString();
-	const taggingInstructions = `If you are a new contributor please read our Tagging Instructions [here](https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants).`;
+	const taggingInstructions = `If you are a new contributor please read our Tagging Instructions [here](https://wiki.btcmap.org/Tagging-Merchants).`;
 
 	switch (type) {
 		case "add-location":

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -413,7 +413,7 @@ $: {
 
 	<p class="text-center text-sm text-body md:text-left dark:text-white">
 		{$_('dashboard.tagsNotePart1')} <TextLink
-			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance"
+			link="https://wiki.btcmap.org/Tagging-Merchants#tagging-guidance"
 			external>{$_('dashboard.tagsNoteLink')}</TextLink
 		>{$_('dashboard.tagsNotePart2')}
 	</p>

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -331,7 +331,7 @@ const handlePeriodChange = async (event: Event) => {
 
 		<PrimaryButton
 			style="w-[207px] mx-auto py-3 rounded-xl"
-			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers-"
+			link="https://wiki.btcmap.org/Tagging-Merchants#shadowy-supertaggers-"
 			external
 		>
 			{$_('leaderboard.joinButton')}

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -813,7 +813,7 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 
 	<p class="text-center text-sm text-body md:text-left dark:text-white">
 		*More information on bitcoin mapping tags can be found <a
-			href="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#tagging-guidance"
+			href="https://wiki.btcmap.org/Tagging-Merchants#tagging-guidance"
 			target="_blank"
 			rel="noreferrer"
 			class="text-link transition-colors hover:text-hover">here</a

--- a/src/routes/tagging-issues/+page.svelte
+++ b/src/routes/tagging-issues/+page.svelte
@@ -38,7 +38,7 @@ let issues: RpcIssue[] = data.rpcResult.requested_issues;
 
 	<p class="text-center text-xl text-primary lg:text-left dark:text-white">
 		{$_("taggingIssues.descriptionPart1")}<TextLink
-			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants">{$_("taggingIssues.linkText")}</TextLink
+			link="https://wiki.btcmap.org/Tagging-Merchants">{$_("taggingIssues.linkText")}</TextLink
 		>{$_("taggingIssues.descriptionPart2")}
 	</p>
 	<IssuesTable title={$_("taggingIssues.tableTitle")} {issues} loading={false} initialPageSize={50} />

--- a/src/routes/tickets/+page.svelte
+++ b/src/routes/tickets/+page.svelte
@@ -82,7 +82,7 @@ const isMaintenance = data.maintenance ?? false;
 
 	<p class="text-center text-xl text-primary lg:text-left dark:text-white">
 		{$_('maintain.taggingInstructionsIntro')} <TextLink
-			link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers">{$_('maintain.taggingInstructionsLink')}</TextLink
+			link="https://wiki.btcmap.org/Tagging-Merchants#shadowy-supertaggers">{$_('maintain.taggingInstructionsLink')}</TextLink
 		>.
 	</p>
 

--- a/src/routes/verify-location/+page.svelte
+++ b/src/routes/verify-location/+page.svelte
@@ -151,7 +151,7 @@ onMount(async () => {
 				external>{$_('verifyLocation.osmLinkText')}</TextLink
 			>{$_('verifyLocation.descriptionPart2')}
 			<TextLink
-				link="https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Tagging-Merchants#shadowy-supertaggers"
+				link="https://wiki.btcmap.org/Tagging-Merchants#shadowy-supertaggers"
 				external>{$_('verifyLocation.wikiLinkText')}</TextLink
 			>
 			{$_('verifyLocation.descriptionPart3')} <InfoTooltip


### PR DESCRIPTION
Replaces all BTC Map wiki base URLs from `https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/` to `https://wiki.btcmap.org/` across the codebase.

**Files changed:**
- `README.md`
- `src/components/area/AreaStats.svelte`
- `src/components/layout/Header.svelte`
- `src/lib/utils.ts`
- `src/routes/activity/+page.svelte`
- `src/routes/add-location/+page.svelte`
- `src/routes/api/gitea/issue/+server.ts`
- `src/routes/dashboard/+page.svelte`
- `src/routes/leaderboard/+page.svelte`
- `src/routes/merchant/[id]/+page.svelte`
- `src/routes/tagging-issues/+page.svelte`
- `src/routes/tickets/+page.svelte`
- `src/routes/verify-location/+page.svelte`

All pre-commit checks passed (format, type check, lint, tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated wiki documentation links throughout the application from the old Gitea-hosted wiki to the new `wiki.btcmap.org` domain, ensuring users are directed to current documentation for tagging guidance, merchant best practices, and help resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/1006)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->