### PR TITLE
feat(lnurlp): add comino@btcmap.org forward

### DIFF
--- a/src/routes/.well-known/lnurlp/comino/+server.ts
+++ b/src/routes/.well-known/lnurlp/comino/+server.ts
@@ -1,0 +1,12 @@
+import { forwardLnurlp } from "$lib/lnurlpForwarder";
+
+import type { RequestHandler } from "./$types";
+
+const UPSTREAM = "https://coinos.io/.well-known/lnurlp/comino";
+
+export const GET: RequestHandler = ({ fetch }) =>
+	forwardLnurlp({
+		fetch,
+		upstream: UPSTREAM,
+		identifier: "comino@btcmap.org",
+	});


### PR DESCRIPTION
## Summary
- Add `comino@btcmap.org` LN Address forwarding to `comino@coinos.io`
- Reuse the shared `forwardLnurlp` helper which rewrites the metadata identifier to the public `btcmap.org` address

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Lightning Network lnurlp payment protocol forwarding, enabling new payment capabilities through upstream integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->