### PR TITLE
fix(map): serve merchant OG image for ?merchant= URL param

### DIFF
--- a/src/lib/merchantDrawerHash.test.ts
+++ b/src/lib/merchantDrawerHash.test.ts
@@ -1,6 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock SvelteKit's browser module
 vi.mock("$app/environment", () => ({
 	browser: true,
 }));
@@ -9,16 +8,18 @@ import { parseMerchantHash, updateMerchantHash } from "./merchantDrawerHash";
 
 describe("parseMerchantHash", () => {
 	beforeEach(() => {
-		// Mock window.location.hash before each test
 		delete (window as unknown as { location: unknown }).location;
-		(window as unknown as { location: { hash: string } }).location = {
+		(
+			window as unknown as { location: { search: string; hash: string } }
+		).location = {
+			search: "",
 			hash: "",
 		};
 	});
 
-	describe("parsing merchant without map coordinates", () => {
-		it("should parse #merchant=123", () => {
-			window.location.hash = "#merchant=123";
+	describe("parsing merchant from query params", () => {
+		it("should parse ?merchant=123", () => {
+			window.location.search = "?merchant=123";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: 123,
@@ -27,8 +28,8 @@ describe("parseMerchantHash", () => {
 			});
 		});
 
-		it("should parse #merchant=123&view=boost", () => {
-			window.location.hash = "#merchant=123&view=boost";
+		it("should parse ?merchant=123&view=boost", () => {
+			window.location.search = "?merchant=123&view=boost";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: 123,
@@ -36,43 +37,33 @@ describe("parseMerchantHash", () => {
 				isOpen: true,
 			});
 		});
-	});
 
-	describe("parsing merchant with map coordinates", () => {
-		it("should parse #14/10.24279/-67.58397&merchant=24180", () => {
-			window.location.hash = "#14/10.24279/-67.58397&merchant=24180";
-			const result = parseMerchantHash();
-			expect(result).toEqual({
-				merchantId: 24180,
-				drawerView: "details",
-				isOpen: true,
-			});
-		});
-
-		it("should parse #14/10.24279/-67.58397&merchant=24180&view=boost", () => {
-			window.location.hash = "#14/10.24279/-67.58397&merchant=24180&view=boost";
-			const result = parseMerchantHash();
-			expect(result).toEqual({
-				merchantId: 24180,
-				drawerView: "boost",
-				isOpen: true,
-			});
-		});
-	});
-
-	describe("parsing empty or invalid hashes", () => {
-		it("should return null merchantId for empty hash", () => {
-			window.location.hash = "";
-			const result = parseMerchantHash();
-			expect(result).toEqual({
-				merchantId: null,
-				drawerView: "details",
-				isOpen: false,
-			});
-		});
-
-		it("should return null merchantId for hash without merchant param", () => {
+		it("should parse ?merchant=123 with map coordinates in hash", () => {
 			window.location.hash = "#14/10.24279/-67.58397";
+			window.location.search = "?merchant=24180";
+			const result = parseMerchantHash();
+			expect(result).toEqual({
+				merchantId: 24180,
+				drawerView: "details",
+				isOpen: true,
+			});
+		});
+
+		it("should parse ?merchant=123&view=boost with map coordinates in hash", () => {
+			window.location.hash = "#14/10.24279/-67.58397";
+			window.location.search = "?merchant=24180&view=boost";
+			const result = parseMerchantHash();
+			expect(result).toEqual({
+				merchantId: 24180,
+				drawerView: "boost",
+				isOpen: true,
+			});
+		});
+	});
+
+	describe("parsing empty or invalid query params", () => {
+		it("should return null merchantId for empty search", () => {
+			window.location.search = "";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: null,
@@ -81,8 +72,18 @@ describe("parseMerchantHash", () => {
 			});
 		});
 
-		it("should return null merchantId for #merchant=invalid", () => {
-			window.location.hash = "#merchant=invalid";
+		it("should return null merchantId for search without merchant param", () => {
+			window.location.search = "?foo=bar";
+			const result = parseMerchantHash();
+			expect(result).toEqual({
+				merchantId: null,
+				drawerView: "details",
+				isOpen: false,
+			});
+		});
+
+		it("should return null merchantId for ?merchant=invalid", () => {
+			window.location.search = "?merchant=invalid";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: null,
@@ -92,7 +93,7 @@ describe("parseMerchantHash", () => {
 		});
 
 		it("should return null merchantId for negative values", () => {
-			window.location.hash = "#merchant=-5";
+			window.location.search = "?merchant=-5";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: null,
@@ -102,7 +103,7 @@ describe("parseMerchantHash", () => {
 		});
 
 		it("should return null merchantId for zero", () => {
-			window.location.hash = "#merchant=0";
+			window.location.search = "?merchant=0";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: null,
@@ -112,7 +113,7 @@ describe("parseMerchantHash", () => {
 		});
 
 		it("should return null merchantId for decimal values", () => {
-			window.location.hash = "#merchant=123.45";
+			window.location.search = "?merchant=123.45";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: null,
@@ -124,7 +125,7 @@ describe("parseMerchantHash", () => {
 
 	describe("parsing with invalid view param", () => {
 		it('should default to "details" for invalid view param', () => {
-			window.location.hash = "#merchant=123&view=invalid";
+			window.location.search = "?merchant=123&view=invalid";
 			const result = parseMerchantHash();
 			expect(result).toEqual({
 				merchantId: 123,
@@ -137,66 +138,110 @@ describe("parseMerchantHash", () => {
 
 describe("updateMerchantHash", () => {
 	beforeEach(() => {
-		// Mock window.location
+		vi.stubGlobal("history", {
+			pushState: vi.fn(),
+		});
 		delete (window as unknown as { location: unknown }).location;
-		(window as unknown as { location: { hash: string } }).location = {
+		(
+			window as unknown as {
+				location: { search: string; hash: string; href: string };
+			}
+		).location = {
+			search: "",
 			hash: "",
+			href: "http://localhost/map",
 		};
 	});
 
-	describe("setting merchant hash", () => {
-		it("should set merchant hash without map coordinates", () => {
-			window.location.hash = "";
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	describe("setting merchant query params", () => {
+		it("should set merchant query params", () => {
 			updateMerchantHash(123, "details");
-			expect(window.location.hash).toBe("merchant=123");
-		});
-
-		it("should set merchant hash with boost view", () => {
-			window.location.hash = "";
-			updateMerchantHash(123, "boost");
-			expect(window.location.hash).toBe("merchant=123&view=boost");
-		});
-
-		it("should preserve map coordinates when setting merchant", () => {
-			window.location.hash = "#14/10.24279/-67.58397";
-			updateMerchantHash(24180, "details");
-			expect(window.location.hash).toBe("14/10.24279/-67.58397&merchant=24180");
-		});
-
-		it("should preserve map coordinates when setting merchant with boost view", () => {
-			window.location.hash = "#14/10.24279/-67.58397";
-			updateMerchantHash(24180, "boost");
-			expect(window.location.hash).toBe(
-				"14/10.24279/-67.58397&merchant=24180&view=boost",
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("merchant=123"),
 			);
 		});
 
-		it("should update existing merchant hash", () => {
-			window.location.hash = "#merchant=123";
-			updateMerchantHash(456, "details");
-			expect(window.location.hash).toBe("merchant=456");
+		it("should set merchant query params with boost view", () => {
+			updateMerchantHash(123, "boost");
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("merchant=123"),
+			);
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("view=boost"),
+			);
 		});
 
-		it("should update existing merchant hash with map coordinates", () => {
-			window.location.hash = "#14/10.24279/-67.58397&merchant=123";
-			updateMerchantHash(456, "boost");
-			expect(window.location.hash).toBe(
-				"14/10.24279/-67.58397&merchant=456&view=boost",
+		it("should preserve hash when setting merchant", () => {
+			window.location.hash = "#14/10.24279/-67.58397";
+			updateMerchantHash(24180, "details");
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("#14/10.24279/-67.58397"),
+			);
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("merchant=24180"),
+			);
+		});
+
+		it("should preserve hash when setting merchant with boost view", () => {
+			window.location.hash = "#14/10.24279/-67.58397";
+			updateMerchantHash(24180, "boost");
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("#14/10.24279/-67.58397"),
+			);
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("merchant=24180"),
+			);
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("view=boost"),
 			);
 		});
 	});
 
-	describe("removing merchant hash", () => {
-		it("should remove merchant hash when passed null", () => {
-			window.location.hash = "#merchant=123";
+	describe("removing merchant query params", () => {
+		it("should remove merchant query params when passed null", () => {
+			window.location.search = "?merchant=123";
 			updateMerchantHash(null, "details");
-			expect(window.location.hash).toBe("");
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.not.stringContaining("merchant"),
+			);
 		});
 
-		it("should preserve map coordinates when removing merchant", () => {
-			window.location.hash = "#14/10.24279/-67.58397&merchant=123";
+		it("should preserve hash when removing merchant", () => {
+			window.location.hash = "#14/10.24279/-67.58397";
+			window.location.search = "?merchant=123";
 			updateMerchantHash(null, "details");
-			expect(window.location.hash).toBe("14/10.24279/-67.58397");
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.stringContaining("#14/10.24279/-67.58397"),
+			);
+			expect(history.pushState).toHaveBeenCalledWith(
+				null,
+				"",
+				expect.not.stringContaining("merchant"),
+			);
 		});
 	});
 });

--- a/src/lib/merchantDrawerHash.ts
+++ b/src/lib/merchantDrawerHash.ts
@@ -8,6 +8,8 @@ export interface MerchantHashState {
 	isOpen: boolean;
 }
 
+export const MERCHANT_URL_CHANGE_EVENT = "merchant-url-change";
+
 export function parseMerchantHash(): MerchantHashState {
 	if (!browser) {
 		return { merchantId: null, drawerView: "details", isOpen: false };
@@ -63,4 +65,5 @@ export function updateMerchantHash(
 	}
 
 	history.pushState(null, "", url.toString());
+	window.dispatchEvent(new Event(MERCHANT_URL_CHANGE_EVENT));
 }

--- a/src/lib/merchantDrawerHash.ts
+++ b/src/lib/merchantDrawerHash.ts
@@ -13,27 +13,15 @@ export function parseMerchantHash(): MerchantHashState {
 		return { merchantId: null, drawerView: "details", isOpen: false };
 	}
 
-	const hash = window.location.hash.substring(1);
-	const ampIndex = hash.indexOf("&");
-
-	// Extract the merchant parameters
-	// Check if there's a map part (contains '/') before the ampersand
-	// If yes: params are after the '&' (e.g., "#14/10.24/-67.58&merchant=123")
-	// If no: entire hash is params (e.g., "#merchant=123" or "#merchant=123&view=boost")
-	let paramsString: string;
-	if (ampIndex !== -1 && hash.substring(0, ampIndex).includes("/")) {
-		// Map coordinates present, params are after ampersand
-		paramsString = hash.substring(ampIndex + 1);
-	} else {
-		// No map coordinates, entire hash is params
-		paramsString = hash;
+	const search = window.location.search;
+	if (!search) {
+		return { merchantId: null, drawerView: "details", isOpen: false };
 	}
 
-	const params = new URLSearchParams(paramsString);
+	const params = new URLSearchParams(search);
 	const merchantParam = params.get("merchant");
 	const viewParam = params.get("view");
 
-	// Validate merchant ID: must be a positive integer
 	let merchantId: number | null = null;
 	if (merchantParam) {
 		const parsedId = Number(merchantParam);
@@ -42,7 +30,6 @@ export function parseMerchantHash(): MerchantHashState {
 		}
 	}
 
-	// Validate view parameter against allowed values
 	const validViews: DrawerView[] = ["details", "boost"];
 	const drawerView: DrawerView =
 		viewParam && validViews.includes(viewParam as DrawerView)
@@ -60,35 +47,20 @@ export function updateMerchantHash(
 ) {
 	if (typeof window === "undefined") return;
 
-	const hash = window.location.hash.substring(1);
-	const ampIndex = hash.indexOf("&");
-
-	// Extract map coordinates (if present) - check if it contains '/'
-	let mapPart = "";
-	if (ampIndex !== -1) {
-		// Has ampersand - check if part before it is map coords
-		const beforeAmp = hash.substring(0, ampIndex);
-		if (beforeAmp.includes("/")) {
-			mapPart = beforeAmp;
-		}
-	} else if (hash.includes("/")) {
-		// No ampersand, but hash contains '/' - it's just map coords
-		mapPart = hash;
-	}
+	const url = new URL(window.location.href);
+	url.hash = window.location.hash;
 
 	if (merchantId) {
-		const params = new URLSearchParams();
-		params.set("merchant", String(merchantId));
+		url.searchParams.set("merchant", String(merchantId));
 		if (view !== "details") {
-			params.set("view", view);
-		}
-
-		if (mapPart) {
-			window.location.hash = `${mapPart}&${params.toString()}`;
+			url.searchParams.set("view", view);
 		} else {
-			window.location.hash = params.toString();
+			url.searchParams.delete("view");
 		}
 	} else {
-		window.location.hash = mapPart || "";
+		url.searchParams.delete("merchant");
+		url.searchParams.delete("view");
 	}
+
+	history.pushState(null, "", url.toString());
 }

--- a/src/routes/map/+page.server.ts
+++ b/src/routes/map/+page.server.ts
@@ -2,7 +2,7 @@ import type { GeoLocation } from "$lib/types";
 
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = async ({ request }) => {
+export const load: PageServerLoad = async ({ request, url }) => {
 	const geoHeader = request.headers.get("x-nf-geo");
 
 	const geo: GeoLocation = { lat: null, lng: null };
@@ -24,5 +24,19 @@ export const load: PageServerLoad = async ({ request }) => {
 		}
 	}
 
-	return { geo };
+	const merchantParam = url.searchParams.get("merchant");
+	let merchantOgImage: string | null = null;
+
+	if (merchantParam) {
+		const merchantId = Number(merchantParam);
+		if (
+			!Number.isNaN(merchantId) &&
+			merchantId > 0 &&
+			Number.isInteger(merchantId)
+		) {
+			merchantOgImage = `https://api.btcmap.org/og/element/${merchantId}`;
+		}
+	}
+
+	return { geo, merchantOgImage };
 };

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -67,7 +67,10 @@ import {
 	getVisiblePlaces,
 	getZoomBehavior,
 } from "$lib/map/viewport";
-import { parseMerchantHash } from "$lib/merchantDrawerHash";
+import {
+	MERCHANT_URL_CHANGE_EVENT,
+	parseMerchantHash,
+} from "$lib/merchantDrawerHash";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import type { MerchantListMode } from "$lib/merchantListStore";
 import { merchantList } from "$lib/merchantListStore";
@@ -1441,6 +1444,8 @@ const setupMapFinalization = (
 
 	// Watch for hash changes to clear marker selection when drawer closes
 	window.addEventListener("hashchange", handleHashChange);
+	window.addEventListener(MERCHANT_URL_CHANGE_EVENT, handleHashChange);
+	window.addEventListener("popstate", handleHashChange);
 
 	// Sync drawer state from URL hash on initial page load
 	merchantDrawer.syncFromHash();
@@ -1516,6 +1521,8 @@ onDestroy(async () => {
 	// Remove hash change listener
 	if (browser) {
 		window.removeEventListener("hashchange", handleHashChange);
+		window.removeEventListener(MERCHANT_URL_CHANGE_EVENT, handleHashChange);
+		window.removeEventListener("popstate", handleHashChange);
 	}
 
 	unsubscribeLocale?.();

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1442,12 +1442,12 @@ const setupMapFinalization = (
 		mapCenter = map.getCenter();
 	});
 
-	// Watch for hash changes to clear marker selection when drawer closes
+	// Watch for URL state changes (hashchange, merchant query param, back/forward) to keep drawer in sync
 	window.addEventListener("hashchange", handleHashChange);
 	window.addEventListener(MERCHANT_URL_CHANGE_EVENT, handleHashChange);
 	window.addEventListener("popstate", handleHashChange);
 
-	// Sync drawer state from URL hash on initial page load
+	// Sync drawer state from URL query params on initial page load
 	merchantDrawer.syncFromHash();
 
 	// If the URL had a merchant ID but no map coordinates, pan to the merchant

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1529,9 +1529,9 @@ onDestroy(async () => {
 
 <svelte:head>
 	<title>BTC Map</title>
-	<meta property="og:image" content="https://btcmap.org/images/og/map.png" />
+	<meta property="og:image" content={data.merchantOgImage ?? "https://btcmap.org/images/og/map.png"} />
 	<meta name="twitter:title" content="BTC Map" />
-	<meta name="twitter:image" content="https://btcmap.org/images/og/map.png" />
+	<meta name="twitter:image" content={data.merchantOgImage ?? "https://btcmap.org/images/og/map.png"} />
 </svelte:head>
 
 <div class="relative h-screen w-full">

--- a/tests/map-drawer.spec.ts
+++ b/tests/map-drawer.spec.ts
@@ -227,8 +227,8 @@ test.describe('Map Drawer', () => {
 		expect(trimmedCount).toMatch(/^\d+$/);
 	});
 
-	test('drawer opens from URL hash on initial page load (desktop)', async ({ page }) => {
-		// Navigate directly to map with merchant hash parameter
+	test('drawer opens from URL query param on initial page load (desktop)', async ({ page }) => {
+		// Navigate directly to map with merchant query parameter
 		await page.goto('/map?merchant=6556#15/53.55573/10.00825', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
@@ -236,7 +236,7 @@ test.describe('Map Drawer', () => {
 		const zoomInButton = page.getByRole('button', { name: 'Zoom in' });
 		await expect(zoomInButton).toBeVisible();
 
-		// Wait for markers to load before hash parameter can trigger drawer
+		// Wait for markers to load before query parameter can trigger drawer
 		await waitForMarkersToLoad(page);
 
 		// Wait for drawer to open automatically
@@ -263,11 +263,11 @@ test.describe('Map Drawer', () => {
 		expect(merchantHref).toContain('/merchant/6556');
 	});
 
-	test('drawer opens from URL hash on initial page load (mobile)', async ({ page }) => {
+	test('drawer opens from URL query param on initial page load (mobile)', async ({ page }) => {
 		// Set mobile viewport
 		await page.setViewportSize({ width: 375, height: 667 });
 
-		// Navigate directly to map with merchant hash parameter
+		// Navigate directly to map with merchant query parameter
 		await page.goto('/map?merchant=6556#15/53.55573/10.00825', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
@@ -275,7 +275,7 @@ test.describe('Map Drawer', () => {
 		const zoomInButton = page.getByRole('button', { name: 'Zoom in' });
 		await expect(zoomInButton).toBeVisible();
 
-		// Wait for markers to load before hash parameter can trigger drawer
+		// Wait for markers to load before query parameter can trigger drawer
 		await waitForMarkersToLoad(page);
 
 		// Wait for mobile drawer to open (appears at bottom)
@@ -298,7 +298,7 @@ test.describe('Map Drawer', () => {
 		await expect(drawerContent.first()).toBeVisible({ timeout: 10000 });
 	});
 
-	test('boost view opens from hash parameter', async ({ page }) => {
+	test('boost view opens from query parameter', async ({ page }) => {
 		// Navigate with boost view parameter
 		await page.goto('/map?merchant=6556&view=boost#15/53.55573/10.00825', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
@@ -307,7 +307,7 @@ test.describe('Map Drawer', () => {
 		const zoomInButton = page.getByRole('button', { name: 'Zoom in' });
 		await expect(zoomInButton).toBeVisible();
 
-		// Wait for markers to load before hash parameter can trigger drawer
+		// Wait for markers to load before query parameter can trigger drawer
 		await waitForMarkersToLoad(page);
 
 		// Wait for drawer to open
@@ -401,14 +401,14 @@ test.describe('Map Drawer', () => {
 		// Set mobile viewport
 		await page.setViewportSize({ width: 375, height: 667 });
 
-		// Navigate with merchant hash to open drawer directly
+		// Navigate with merchant query param to open drawer directly
 		await page.goto('/map?merchant=6556#15/53.55573/10.00825', { waitUntil: 'load' });
 
 		// Wait for map to load
 		const zoomInButton = page.getByRole('button', { name: 'Zoom in' });
 		await expect(zoomInButton).toBeVisible();
 
-		// Wait for markers to load before hash parameter can trigger drawer
+		// Wait for markers to load before query parameter can trigger drawer
 		await waitForMarkersToLoad(page);
 
 		// Wait for drawer to open

--- a/tests/map-drawer.spec.ts
+++ b/tests/map-drawer.spec.ts
@@ -229,7 +229,7 @@ test.describe('Map Drawer', () => {
 
 	test('drawer opens from URL hash on initial page load (desktop)', async ({ page }) => {
 		// Navigate directly to map with merchant hash parameter
-		await page.goto('/map#15/53.55573/10.00825&merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
 		// Wait for map to load
@@ -268,7 +268,7 @@ test.describe('Map Drawer', () => {
 		await page.setViewportSize({ width: 375, height: 667 });
 
 		// Navigate directly to map with merchant hash parameter
-		await page.goto('/map#15/53.55573/10.00825&merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
 		// Wait for map to load
@@ -300,7 +300,7 @@ test.describe('Map Drawer', () => {
 
 	test('boost view opens from hash parameter', async ({ page }) => {
 		// Navigate with boost view parameter
-		await page.goto('/map#15/53.55573/10.00825&merchant=6556&view=boost', { waitUntil: 'load' });
+		await page.goto('/map#15/53.55573/10.00825?merchant=6556&view=boost', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
 		// Wait for map to load
@@ -364,7 +364,7 @@ test.describe('Map Drawer', () => {
 		});
 
 		// Open merchant 6556 (has comments)
-		await page.goto('/map#15/53.55573/10.00825&merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
 		await waitForMarkersToLoad(page);
 
 		const drawer = page.locator('[role="dialog"]');
@@ -377,7 +377,7 @@ test.describe('Map Drawer', () => {
 
 		// Switch to merchant 1 (no comments)
 		await page.evaluate(() => {
-			window.location.hash = '#15/53.55573/10.00825&merchant=1';
+			window.location.hash = '#15/53.55573/10.00825?merchant=1';
 		});
 
 		// Wait for drawer to update — comments should be gone
@@ -385,7 +385,7 @@ test.describe('Map Drawer', () => {
 
 		// Switch back to merchant 6556
 		await page.evaluate(() => {
-			window.location.hash = '#15/53.55573/10.00825&merchant=6556';
+			window.location.hash = '#15/53.55573/10.00825?merchant=6556';
 		});
 
 		// Comments must re-appear (this is the bug scenario)
@@ -400,7 +400,7 @@ test.describe('Map Drawer', () => {
 		await page.setViewportSize({ width: 375, height: 667 });
 
 		// Navigate with merchant hash to open drawer directly
-		await page.goto('/map#15/53.55573/10.00825&merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
 
 		// Wait for map to load
 		const zoomInButton = page.getByRole('button', { name: 'Zoom in' });

--- a/tests/map-drawer.spec.ts
+++ b/tests/map-drawer.spec.ts
@@ -229,7 +229,7 @@ test.describe('Map Drawer', () => {
 
 	test('drawer opens from URL hash on initial page load (desktop)', async ({ page }) => {
 		// Navigate directly to map with merchant hash parameter
-		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map?merchant=6556#15/53.55573/10.00825', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
 		// Wait for map to load
@@ -268,7 +268,7 @@ test.describe('Map Drawer', () => {
 		await page.setViewportSize({ width: 375, height: 667 });
 
 		// Navigate directly to map with merchant hash parameter
-		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map?merchant=6556#15/53.55573/10.00825', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
 		// Wait for map to load
@@ -300,7 +300,7 @@ test.describe('Map Drawer', () => {
 
 	test('boost view opens from hash parameter', async ({ page }) => {
 		// Navigate with boost view parameter
-		await page.goto('/map#15/53.55573/10.00825?merchant=6556&view=boost', { waitUntil: 'load' });
+		await page.goto('/map?merchant=6556&view=boost#15/53.55573/10.00825', { waitUntil: 'load' });
 		await expect(page).toHaveTitle(/BTC Map/);
 
 		// Wait for map to load
@@ -364,7 +364,7 @@ test.describe('Map Drawer', () => {
 		});
 
 		// Open merchant 6556 (has comments)
-		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map?merchant=6556#15/53.55573/10.00825', { waitUntil: 'load' });
 		await waitForMarkersToLoad(page);
 
 		const drawer = page.locator('[role="dialog"]');
@@ -377,7 +377,8 @@ test.describe('Map Drawer', () => {
 
 		// Switch to merchant 1 (no comments)
 		await page.evaluate(() => {
-			window.location.hash = '#15/53.55573/10.00825?merchant=1';
+			history.pushState(null, '', '/map?merchant=1#15/53.55573/10.00825');
+			window.dispatchEvent(new Event('merchant-url-change'));
 		});
 
 		// Wait for drawer to update — comments should be gone
@@ -385,7 +386,8 @@ test.describe('Map Drawer', () => {
 
 		// Switch back to merchant 6556
 		await page.evaluate(() => {
-			window.location.hash = '#15/53.55573/10.00825?merchant=6556';
+			history.pushState(null, '', '/map?merchant=6556#15/53.55573/10.00825');
+			window.dispatchEvent(new Event('merchant-url-change'));
 		});
 
 		// Comments must re-appear (this is the bug scenario)
@@ -400,7 +402,7 @@ test.describe('Map Drawer', () => {
 		await page.setViewportSize({ width: 375, height: 667 });
 
 		// Navigate with merchant hash to open drawer directly
-		await page.goto('/map#15/53.55573/10.00825?merchant=6556', { waitUntil: 'load' });
+		await page.goto('/map?merchant=6556#15/53.55573/10.00825', { waitUntil: 'load' });
 
 		// Wait for map to load
 		const zoomInButton = page.getByRole('button', { name: 'Zoom in' });


### PR DESCRIPTION
Switches merchant URL handling from hash fragments to query params so social bots can see the merchant ID and receive the correct OG image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Merchant pages show merchant-specific preview images for social sharing when available.

* **Improvements**
  * Merchant drawer deep-links use query parameters (e.g., ?merchant=...) and preserve map position when sharing or navigating.
  * Back/forward and in-app navigation more reliably reflect drawer state; URL changes now trigger UI updates (including boost view).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/1019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->