### PR TITLE
refactor(tagging-issues): replace RPC call with REST endpoint

### DIFF
--- a/src/routes/tagging-issues/+page.server.ts
+++ b/src/routes/tagging-issues/+page.server.ts
@@ -4,37 +4,21 @@ import type { PageServerLoad } from "./$types";
 
 export const load: PageServerLoad = async ({ fetch }) => {
 	try {
-		const response = await fetch(`${API_BASE}/rpc`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
-				jsonrpc: "2.0",
-				id: 1,
-				method: "get_element_issues",
-				params: {
-					area_id: 662,
-					limit: 10_000,
-					offset: 0,
-				},
-			}),
-		});
+		const response = await fetch(
+			`${API_BASE}/v4/place-issues?area_id=662&limit=10000&offset=0`,
+		);
 
-		const data = await response.json();
-
-		if (data.error) {
-			const errorMessage = data.error.message || "RPC Error";
-			const errorDetails = data.error.data
-				? `: ${JSON.stringify(data.error.data)}`
-				: "";
+		if (!response.ok) {
 			return {
-				error: errorMessage + errorDetails,
+				error: `HTTP Error: ${response.status}`,
 				rpcResult: null,
 			};
 		}
+
+		const data = await response.json();
+
 		return {
-			rpcResult: data.result,
+			result: data,
 		};
 	} catch (err) {
 		return {

--- a/src/routes/tagging-issues/+page.svelte
+++ b/src/routes/tagging-issues/+page.svelte
@@ -7,7 +7,7 @@ import { theme } from "$lib/theme";
 import type { RpcIssue } from "$lib/types";
 
 export let data;
-let issues: RpcIssue[] = data.rpcResult.requested_issues;
+let issues: RpcIssue[] = data.result.requested_issues;
 </script>
 
 <svelte:head>


### PR DESCRIPTION
This PR is aimed to be as non invasive as possible, broader refactoring, such as renaming RpcIssue to something more appropriate will follow. 

This new REST endpoint is supposed to be an exact copy of the corresponding RPC endpoint:

https://github.com/teambtcmap/btcmap-api/blob/master/docs/rest/v4/place-issues.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how element issues are retrieved and processed, increasing reliability of issue loading.
* **Bug Fixes**
  * Enhanced error handling so failed loads surface clearer error states to the page.
* **User Impact**
  * No visual changes; issue lists and table rendering behave the same but load more reliably and fail more transparently when problems occur.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/1023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->