### PR TITLE
fix(map): restore 5 legacy basemaps #1030 

### DIFF
--- a/src/lib/map/basemaps.test.ts
+++ b/src/lib/map/basemaps.test.ts
@@ -1,0 +1,101 @@
+import type { StyleSpecification } from "maplibre-gl";
+import { describe, expect, it } from "vitest";
+
+import {
+	BASEMAPS,
+	buildRasterStyle,
+	defaultBasemap,
+	isBasemapId,
+	styleForBasemap,
+} from "./basemaps";
+
+describe("basemaps catalog", () => {
+	it("offers the five legacy basemaps in legacy order", () => {
+		expect(BASEMAPS.map((b) => b.id)).toEqual([
+			"liberty",
+			"ofm-dark",
+			"carto-positron",
+			"carto-dark-matter",
+			"osm",
+		]);
+	});
+
+	it("uses the legacy picker labels verbatim", () => {
+		expect(BASEMAPS.map((b) => b.label)).toEqual([
+			"OpenFreeMap Liberty",
+			"OpenFreeMap Dark",
+			"Carto Positron",
+			"Carto Dark Matter",
+			"OpenStreetMap",
+		]);
+	});
+});
+
+describe("isBasemapId", () => {
+	it("accepts every catalog id", () => {
+		for (const { id } of BASEMAPS) {
+			expect(isBasemapId(id)).toBe(true);
+		}
+	});
+
+	it("rejects unknown ids, including the retired migration-era ones", () => {
+		for (const id of ["openfreemap", "carto-light", "carto-dark", "", "OSM"]) {
+			expect(isBasemapId(id)).toBe(false);
+		}
+	});
+});
+
+describe("defaultBasemap", () => {
+	it("matches the legacy first-visit defaults (Liberty light, Carto Dark Matter dark)", () => {
+		expect(defaultBasemap("light")).toBe("liberty");
+		expect(defaultBasemap(undefined)).toBe("liberty");
+		expect(defaultBasemap("dark")).toBe("carto-dark-matter");
+	});
+});
+
+describe("styleForBasemap", () => {
+	it("returns the vector style URL for the four vector basemaps", () => {
+		expect(styleForBasemap("liberty")).toBe(
+			"https://tiles.openfreemap.org/styles/liberty",
+		);
+		expect(styleForBasemap("ofm-dark")).toBe(
+			"https://static.btcmap.org/map-styles/dark.json",
+		);
+		expect(styleForBasemap("carto-positron")).toBe(
+			"https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+		);
+		expect(styleForBasemap("carto-dark-matter")).toBe(
+			"https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+		);
+	});
+
+	it("returns an inline raster StyleSpecification for OSM", () => {
+		const style = styleForBasemap("osm");
+		expect(typeof style).not.toBe("string");
+		const spec = style as StyleSpecification;
+		expect(spec.version).toBe(8);
+		expect(spec.sources.osm).toBeDefined();
+		expect(spec.layers).toHaveLength(1);
+		expect(spec.layers[0].id).toBe("osm");
+	});
+});
+
+describe("buildRasterStyle", () => {
+	it("declares the OSM raster source with OSM attribution and maxzoom 19", () => {
+		const style = buildRasterStyle();
+		const src = style.sources.osm as {
+			type: string;
+			attribution?: string;
+			maxzoom?: number;
+		};
+		expect(src.type).toBe("raster");
+		expect(src.maxzoom).toBe(19);
+		expect(src.attribution).toContain("OpenStreetMap");
+	});
+
+	it("does not bake the supporter link into tile attribution (it is a customAttribution now)", () => {
+		const style = buildRasterStyle();
+		const src = style.sources.osm as { attribution?: string };
+		expect(src.attribution ?? "").not.toContain("Support BTC Map");
+	});
+});

--- a/src/lib/map/basemaps.ts
+++ b/src/lib/map/basemaps.ts
@@ -1,20 +1,64 @@
-// Raster basemap catalog for /map. All three sources/layers are added
-// to the style at init; switching is just a layer-visibility toggle, no
-// setStyle — which avoids the tile-compile cascade that broke the first
-// basemap-switcher attempt.
+// Basemap catalog for /map and /communities/map.
+//
+// Restores the five basemaps the legacy (Leaflet) maps offered, now driven
+// natively through MapLibre:
+//   • four VECTOR styles — OpenFreeMap Liberty, OpenFreeMap Dark (btcmap's
+//     tuned dark.json), Carto Positron, Carto Dark Matter. Each is a whole
+//     style document MapLibre fetches by URL.
+//   • one RASTER style — OpenStreetMap {z}/{x}/{y} tiles, declared inline.
+//
+// Each basemap is a FIXED style. The picker persists the choice (sticky), and
+// a theme toggle does NOT swap the basemap — only the first-visit default is
+// theme-aware (see defaultBasemap), matching the legacy defaults. Switching
+// basemaps always goes through map.setStyle({ transformStyle }) so the custom
+// pin/cluster/label (or community-polygon) layers ride along; raster↔raster
+// no longer applies since OSM is the only raster option.
 
-export type BasemapId = "osm" | "carto-light" | "carto-dark";
+import type { StyleSpecification } from "maplibre-gl";
+
+export type BasemapId =
+	| "liberty"
+	| "ofm-dark"
+	| "carto-positron"
+	| "carto-dark-matter"
+	| "osm";
 
 export const BASEMAPS: { id: BasemapId; label: string }[] = [
+	{ id: "liberty", label: "OpenFreeMap Liberty" },
+	{ id: "ofm-dark", label: "OpenFreeMap Dark" },
+	{ id: "carto-positron", label: "Carto Positron" },
+	{ id: "carto-dark-matter", label: "Carto Dark Matter" },
 	{ id: "osm", label: "OpenStreetMap" },
-	{ id: "carto-light", label: "Carto Light" },
-	{ id: "carto-dark", label: "Carto Dark" },
 ];
 
 export const BASEMAP_STORAGE_KEY = "btcmap-next-basemap";
 
+// The four vector style documents, fetched by MapLibre via URL. "ofm-dark" is
+// btcmap's tuned dark style (also used by the area/merchant/saved maps); the
+// Carto pair are Carto's free, key-less GL styles. Each carries its own data
+// attribution (OSM / OpenFreeMap / Carto) via its sources.
+const VECTOR_STYLE_URLS: Record<Exclude<BasemapId, "osm">, string> = {
+	liberty: "https://tiles.openfreemap.org/styles/liberty",
+	"ofm-dark": "https://static.btcmap.org/map-styles/dark.json",
+	"carto-positron":
+		"https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+	"carto-dark-matter":
+		"https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+};
+
 export const isBasemapId = (v: string): v is BasemapId =>
-	v === "osm" || v === "carto-light" || v === "carto-dark";
+	v === "liberty" ||
+	v === "ofm-dark" ||
+	v === "carto-positron" ||
+	v === "carto-dark-matter" ||
+	v === "osm";
+
+// First-visit default, matching the legacy maps: Liberty in light, Carto Dark
+// Matter in dark. Once the user picks from the basemap control that choice is
+// persisted (getStoredBasemap) and wins over this.
+export const defaultBasemap = (
+	theme: "light" | "dark" | undefined,
+): BasemapId => (theme === "dark" ? "carto-dark-matter" : "liberty");
 
 export const getStoredBasemap = (): BasemapId | null => {
 	if (typeof window === "undefined") return null;
@@ -26,3 +70,45 @@ export const getStoredBasemap = (): BasemapId | null => {
 	}
 	return null;
 };
+
+// "Support BTC Map" supporter link. Legacy /map injected this into the
+// attribution bar via DOM mutation regardless of the active basemap; here it
+// is passed as the AttributionControl's customAttribution so it shows on both
+// the vector and raster basemaps. The data-source credit (OpenStreetMap /
+// OpenFreeMap / Carto) is supplied by each style's own sources, so it is NOT
+// duplicated here.
+export const SUPPORT_ATTR =
+	'<a href="/supporters" title="Support BTC Map with sats">Support BTC Map</a>';
+
+const OSM_ATTR =
+	'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+// Inline raster style for the OpenStreetMap basemap — a single {z}/{x}/{y}
+// tile source. maxzoom 19 is OSM's native ceiling; MapLibre overzooms past it
+// up to the map's maxZoom, matching the legacy maxNativeZoom: 19 behaviour.
+export const buildRasterStyle = (): StyleSpecification => ({
+	version: 8,
+	// OpenFreeMap's public glyph endpoint (Cloudflare R2, no key) so the
+	// place-label layer's "Noto Sans Bold" font resolves on the raster
+	// basemap too.
+	glyphs: "https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf",
+	sources: {
+		osm: {
+			type: "raster",
+			tiles: [
+				"https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+				"https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+				"https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
+			],
+			tileSize: 256,
+			attribution: OSM_ATTR,
+			maxzoom: 19,
+		},
+	},
+	layers: [{ id: "osm", type: "raster", source: "osm" }],
+});
+
+// The style for a basemap selection: the vector style URL, or the inline
+// raster style for OSM.
+export const styleForBasemap = (id: BasemapId): StyleSpecification | string =>
+	id === "osm" ? buildRasterStyle() : VECTOR_STYLE_URLS[id];

--- a/src/lib/map/basemaps.ts
+++ b/src/lib/map/basemaps.ts
@@ -16,42 +16,49 @@
 
 import type { StyleSpecification } from "maplibre-gl";
 
-export type BasemapId =
-	| "liberty"
-	| "ofm-dark"
-	| "carto-positron"
-	| "carto-dark-matter"
-	| "osm";
+// Single source of truth for the basemap catalog. Order here drives the picker
+// order. `style` is the vector style URL MapLibre fetches; the raster OSM
+// basemap has no URL (style: null) — its style is built inline by
+// buildRasterStyle(). Everything else (the BasemapId type, the BASEMAPS picker
+// list, the id validator, styleForBasemap) derives from this, so adding or
+// removing a basemap is a one-line change that can't drift out of sync.
+// Carto's GL styles are free and key-less; each style carries its own data
+// attribution (OSM / OpenFreeMap / Carto) via its sources.
+const BASEMAP_DEFS = [
+	{
+		id: "liberty",
+		label: "OpenFreeMap Liberty",
+		style: "https://tiles.openfreemap.org/styles/liberty",
+	},
+	{
+		// btcmap's tuned dark style (also used by the area/merchant/saved maps).
+		id: "ofm-dark",
+		label: "OpenFreeMap Dark",
+		style: "https://static.btcmap.org/map-styles/dark.json",
+	},
+	{
+		id: "carto-positron",
+		label: "Carto Positron",
+		style: "https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
+	},
+	{
+		id: "carto-dark-matter",
+		label: "Carto Dark Matter",
+		style: "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
+	},
+	{ id: "osm", label: "OpenStreetMap", style: null },
+] as const;
 
-export const BASEMAPS: { id: BasemapId; label: string }[] = [
-	{ id: "liberty", label: "OpenFreeMap Liberty" },
-	{ id: "ofm-dark", label: "OpenFreeMap Dark" },
-	{ id: "carto-positron", label: "Carto Positron" },
-	{ id: "carto-dark-matter", label: "Carto Dark Matter" },
-	{ id: "osm", label: "OpenStreetMap" },
-];
+export type BasemapId = (typeof BASEMAP_DEFS)[number]["id"];
+
+export const BASEMAPS: { id: BasemapId; label: string }[] = BASEMAP_DEFS.map(
+	({ id, label }) => ({ id, label }),
+);
 
 export const BASEMAP_STORAGE_KEY = "btcmap-next-basemap";
 
-// The four vector style documents, fetched by MapLibre via URL. "ofm-dark" is
-// btcmap's tuned dark style (also used by the area/merchant/saved maps); the
-// Carto pair are Carto's free, key-less GL styles. Each carries its own data
-// attribution (OSM / OpenFreeMap / Carto) via its sources.
-const VECTOR_STYLE_URLS: Record<Exclude<BasemapId, "osm">, string> = {
-	liberty: "https://tiles.openfreemap.org/styles/liberty",
-	"ofm-dark": "https://static.btcmap.org/map-styles/dark.json",
-	"carto-positron":
-		"https://basemaps.cartocdn.com/gl/positron-gl-style/style.json",
-	"carto-dark-matter":
-		"https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json",
-};
-
 export const isBasemapId = (v: string): v is BasemapId =>
-	v === "liberty" ||
-	v === "ofm-dark" ||
-	v === "carto-positron" ||
-	v === "carto-dark-matter" ||
-	v === "osm";
+	BASEMAP_DEFS.some((b) => b.id === v);
 
 // First-visit default, matching the legacy maps: Liberty in light, Carto Dark
 // Matter in dark. Once the user picks from the basemap control that choice is
@@ -108,7 +115,7 @@ export const buildRasterStyle = (): StyleSpecification => ({
 	layers: [{ id: "osm", type: "raster", source: "osm" }],
 });
 
-// The style for a basemap selection: the vector style URL, or the inline
-// raster style for OSM.
+// The style for a basemap selection: the basemap's vector style URL, or the
+// inline raster style for the URL-less (OSM) basemap.
 export const styleForBasemap = (id: BasemapId): StyleSpecification | string =>
-	id === "osm" ? buildRasterStyle() : VECTOR_STYLE_URLS[id];
+	BASEMAP_DEFS.find((b) => b.id === id)?.style ?? buildRasterStyle();

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -15,7 +15,6 @@ import type {
 	GeoJSONSource,
 	MapLayerMouseEvent,
 	Map as MapLibreMap,
-	StyleSpecification,
 } from "maplibre-gl";
 import { onDestroy, onMount } from "svelte";
 import { get } from "svelte/store";
@@ -24,7 +23,13 @@ import MapLoadingMain from "$components/MapLoadingMain.svelte";
 import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import Socials from "$components/Socials.svelte";
 import { _ } from "$lib/i18n";
-import { BASEMAPS, type BasemapId, getStoredBasemap } from "$lib/map/basemaps";
+import {
+	BASEMAPS,
+	type BasemapId,
+	defaultBasemap,
+	getStoredBasemap,
+	styleForBasemap,
+} from "$lib/map/basemaps";
 import { parseHashCoords, writeHashCoords } from "$lib/map/mapHash";
 import { hasWebGL } from "$lib/map/webgl";
 import { areaError, areas, reportError, reports } from "$lib/store";
@@ -152,6 +157,27 @@ const computeBbox = (g: GeoJSON): [number, number, number, number] | null => {
 	visit(g);
 	if (!found) return null;
 	return [minX, minY, maxX, maxY];
+};
+
+// Swap the basemap while keeping the community polygon source + layers live.
+// transformStyle re-attaches them onto the incoming base style; the differ
+// leaves the identical custom layers in place and only swaps the basemap
+// layers below them.
+const applyBasemap = (id: BasemapId) => {
+	if (!map) return;
+	map.setStyle(styleForBasemap(id), {
+		transformStyle: (previous, next) => {
+			if (!previous) return next;
+			const sources = { ...next.sources };
+			if (previous.sources[SOURCE_ID]) {
+				sources[SOURCE_ID] = previous.sources[SOURCE_ID];
+			}
+			const carried = previous.layers.filter(
+				(l) => l.id === FILL_LAYER_ID || l.id === OUTLINE_LAYER_ID,
+			);
+			return { ...next, sources, layers: [...next.layers, ...carried] };
+		},
+	});
 };
 
 const addCommunitiesLayers = (m: MapLibreMap) => {
@@ -347,78 +373,13 @@ const initializeMap = async () => {
 	const maplibre = await import("maplibre-gl");
 	if (destroyed) return;
 
+	// Five basemaps (legacy parity). A stored picker choice wins; otherwise
+	// the first-visit default is theme-aware (Liberty light, Carto Dark
+	// Matter dark). Each basemap is a fixed, sticky style; switches go through
+	// applyBasemap → setStyle({ transformStyle }) so the polygons ride along.
 	const initialBasemap: BasemapId =
-		getStoredBasemap() ?? (get(theme) === "dark" ? "carto-dark" : "osm");
-
-	const OSM_ATTR =
-		'&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
-	const CARTO_ATTR = `${OSM_ATTR} &copy; <a href="https://carto.com/attributions">CARTO</a>`;
-
-	const style: StyleSpecification = {
-		version: 8,
-		glyphs: "https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf",
-		sources: {
-			osm: {
-				type: "raster",
-				tiles: [
-					"https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-					"https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-					"https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
-				],
-				tileSize: 256,
-				attribution: OSM_ATTR,
-				maxzoom: 19,
-			},
-			"carto-light": {
-				type: "raster",
-				tiles: [
-					"https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-					"https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-					"https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-					"https://d.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-				],
-				tileSize: 256,
-				attribution: CARTO_ATTR,
-				maxzoom: 19,
-			},
-			"carto-dark": {
-				type: "raster",
-				tiles: [
-					"https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-					"https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-					"https://c.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-					"https://d.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-				],
-				tileSize: 256,
-				attribution: CARTO_ATTR,
-				maxzoom: 19,
-			},
-		},
-		layers: [
-			{
-				id: "osm",
-				type: "raster",
-				source: "osm",
-				layout: { visibility: initialBasemap === "osm" ? "visible" : "none" },
-			},
-			{
-				id: "carto-light",
-				type: "raster",
-				source: "carto-light",
-				layout: {
-					visibility: initialBasemap === "carto-light" ? "visible" : "none",
-				},
-			},
-			{
-				id: "carto-dark",
-				type: "raster",
-				source: "carto-dark",
-				layout: {
-					visibility: initialBasemap === "carto-dark" ? "visible" : "none",
-				},
-			},
-		],
-	};
+		getStoredBasemap() ?? defaultBasemap(get(theme));
+	const style = styleForBasemap(initialBasemap);
 
 	const hashCoords = parseHashCoords();
 
@@ -456,7 +417,11 @@ const initializeMap = async () => {
 	map.addControl(new NavButtonsControl("communities"), "top-right");
 
 	map.addControl(
-		new BasemapsControl({ basemaps: BASEMAPS, initial: initialBasemap }),
+		new BasemapsControl({
+			basemaps: BASEMAPS,
+			initial: initialBasemap,
+			onSelect: applyBasemap,
+		}),
 		"top-right",
 	);
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -11,7 +11,6 @@ import type {
 	MapGeoJSONFeature,
 	MapLayerMouseEvent,
 	Map as MapLibreMap,
-	StyleSpecification,
 } from "maplibre-gl";
 import { onDestroy, onMount } from "svelte";
 import { get } from "svelte/store";
@@ -33,7 +32,14 @@ import {
 	NEARBY_RADIUS_MULTIPLIER,
 } from "$lib/constants";
 import { _, getDisplayLang, locale } from "$lib/i18n";
-import { BASEMAPS, type BasemapId, getStoredBasemap } from "$lib/map/basemaps";
+import {
+	BASEMAPS,
+	type BasemapId,
+	defaultBasemap,
+	getStoredBasemap,
+	SUPPORT_ATTR,
+	styleForBasemap,
+} from "$lib/map/basemaps";
 import {
 	type HashCoords,
 	parseHashCoords,
@@ -681,6 +687,76 @@ $: if (map && styleLoaded && $lastUpdatedPlaceId) {
 	lastUpdatedPlaceId.set(undefined);
 }
 
+// The custom sources + layers we add on top of whatever basemap is
+// active. applyBasemap() carries these across a setStyle() so the pins,
+// clusters, and labels survive a basemap/theme swap untouched (MapLibre's
+// style differ leaves byte-identical layers in place — only the basemap
+// layers below them get swapped).
+const CUSTOM_SOURCE_IDS = ["places", "places-boosted", "cluster-hull"];
+const CUSTOM_LAYER_IDS = [
+	"cluster-hull-fill",
+	"cluster-hull-outline",
+	"clusters-outer",
+	"clusters-inner",
+	"cluster-count",
+	"unclustered-point",
+	"boosted-point",
+	"comment-badge",
+	"comment-badge-count",
+	"saved-badge",
+	"place-label",
+	"boosted-comment-badge",
+	"boosted-comment-badge-count",
+	"boosted-saved-badge",
+	"boosted-place-label",
+	"clusters-hit",
+];
+
+// Switch the basemap without tearing down our pin/cluster/label layers.
+// setStyle's transformStyle hook re-attaches the custom sources + layers
+// onto the incoming base style; because they're identical to what's already
+// mounted, the differ keeps the layers (and the carried GeoJSON data) live —
+// only the basemap layers below them swap.
+//
+// Two things do NOT survive setStyle on their own and are re-established in
+// the style.load handler below:
+//   • the spiderfier's click/zoom handlers — unspiderfyAll() detaches them
+//     (map.off) and only applyTo() re-binds them, so we must applyTo again;
+//   • the addImage sprites (cluster-hit, badges) IF MapLibre ever falls back
+//     from the diff to a full rebuild (fresh imageManager). The loaders are
+//     hasImage-guarded, so re-running them is a cheap no-op on the normal path.
+// The handler is registered BEFORE setStyle on purpose: for the inline raster
+// (object) style, setStyle fires style.load SYNCHRONOUSLY during the call, so
+// a handler added afterwards would miss it.
+const applyBasemap = (id: BasemapId) => {
+	if (!map) return;
+	// Collapse any open spider before the restyle. This also detaches the
+	// spiderfy library's map handlers (which is why we re-applyTo below).
+	spiderfier?.unspiderfyAll();
+	map.once("style.load", () => {
+		if (!map) return;
+		applyLabelPalette(map, get(theme));
+		loadClusterHitSprite(map).catch(() => {});
+		loadCommentBadgeSprite(map);
+		loadSavedBadgeSprite(map).catch(() => {});
+		ensureSpritesForPlaces(map, get(places));
+		spiderfier?.applyTo("clusters-hit");
+	});
+	map.setStyle(styleForBasemap(id), {
+		transformStyle: (previous, next) => {
+			if (!previous) return next;
+			const sources = { ...next.sources };
+			for (const sid of CUSTOM_SOURCE_IDS) {
+				if (previous.sources[sid]) sources[sid] = previous.sources[sid];
+			}
+			const carried = previous.layers.filter((l) =>
+				CUSTOM_LAYER_IDS.includes(l.id),
+			);
+			return { ...next, sources, layers: [...next.layers, ...carried] };
+		},
+	});
+};
+
 onMount(async () => {
 	// WebGL absence (older Android WebViews, hardened browsers, disabled
 	// GPU) would leave the map blank if we tried to instantiate MapLibre.
@@ -694,91 +770,15 @@ onMount(async () => {
 	// flight; bail before instantiating against an unmounted container.
 	if (destroyed) return;
 
-	// All available basemaps are raster tile sources, declared upfront so
-	// the basemap picker only has to toggle layer visibility — no
-	// setStyle calls, which avoid the tile-compile cascade that broke
-	// the first attempt at this in Phase 4.
+	// Five basemaps (legacy parity): four vector styles + the OSM raster
+	// style. A stored picker choice wins; otherwise the first-visit default
+	// is theme-aware (Liberty in light, Carto Dark Matter in dark). Each
+	// basemap is a FIXED style — the choice is sticky and a theme toggle does
+	// not swap it. Switching goes through applyBasemap() → setStyle({
+	// transformStyle }) so the custom pin/cluster/label layers ride along.
 	const initialBasemap: BasemapId =
-		getStoredBasemap() ?? (get(theme) === "dark" ? "carto-dark" : "osm");
-
-	// Append the "Support BTC Map" link to every basemap's attribution
-	// string. Legacy /map injected this via DOM mutation; doing it
-	// inline in the style spec means MapLibre's default
-	// AttributionControl picks it up automatically without us touching
-	// the DOM after init.
-	const SUPPORT_ATTR =
-		'&copy; <a href="/supporters" title="Support BTC Map with sats">Support BTC Map</a>';
-	const OSM_ATTR = `&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors ${SUPPORT_ATTR}`;
-	const CARTO_ATTR = `${OSM_ATTR} &copy; <a href="https://carto.com/attributions">CARTO</a>`;
-
-	const style: StyleSpecification = {
-		version: 8,
-		// OpenFreeMap's public glyph endpoint (Cloudflare R2, no key, production-OK).
-		// MapLibre's demotiles.maplibre.org is explicitly a demo server with no SLA —
-		// see https://github.com/maplibre/demotiles (README: "web, helloworld and CI tests").
-		glyphs: "https://tiles.openfreemap.org/fonts/{fontstack}/{range}.pbf",
-		sources: {
-			osm: {
-				type: "raster",
-				tiles: [
-					"https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-					"https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
-					"https://c.tile.openstreetmap.org/{z}/{x}/{y}.png",
-				],
-				tileSize: 256,
-				attribution: OSM_ATTR,
-				maxzoom: 19,
-			},
-			"carto-light": {
-				type: "raster",
-				tiles: [
-					"https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-					"https://b.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-					"https://c.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-					"https://d.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png",
-				],
-				tileSize: 256,
-				attribution: CARTO_ATTR,
-				maxzoom: 19,
-			},
-			"carto-dark": {
-				type: "raster",
-				tiles: [
-					"https://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-					"https://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-					"https://c.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-					"https://d.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
-				],
-				tileSize: 256,
-				attribution: CARTO_ATTR,
-				maxzoom: 19,
-			},
-		},
-		layers: [
-			{
-				id: "osm",
-				type: "raster",
-				source: "osm",
-				layout: { visibility: initialBasemap === "osm" ? "visible" : "none" },
-			},
-			{
-				id: "carto-light",
-				type: "raster",
-				source: "carto-light",
-				layout: {
-					visibility: initialBasemap === "carto-light" ? "visible" : "none",
-				},
-			},
-			{
-				id: "carto-dark",
-				type: "raster",
-				source: "carto-dark",
-				layout: {
-					visibility: initialBasemap === "carto-dark" ? "visible" : "none",
-				},
-			},
-		],
-	};
+		getStoredBasemap() ?? defaultBasemap(get(theme));
+	const style = styleForBasemap(initialBasemap);
 
 	// Viewport resolution order: hash → ?lat&long query → cached last
 	// view → IP-geo → defaults. Hash is what /map writes back on every
@@ -834,8 +834,13 @@ onMount(async () => {
 
 	map = new maplibre.Map({
 		container: mapContainer,
-		// Minimal inline raster style — OSM tiles. Vector basemaps come in Phase 4.
+		// Resolved basemap style — a vector style URL, or the inline OSM raster
+		// style. Defaults to the theme-aware basemap unless the user picked one.
 		style,
+		// Show the "Support BTC Map" supporter link on every basemap (legacy
+		// /map guaranteed it regardless of basemap). Data-source credit
+		// (OSM / OpenFreeMap / Carto) comes from each style's own sources.
+		attributionControl: { customAttribution: SUPPORT_ATTR },
 		center: initialCenter,
 		zoom: initialZoom,
 		bearing: hashCoords?.bearing ?? 0,
@@ -908,10 +913,14 @@ onMount(async () => {
 
 	// Basemap picker — layers-icon button that expands on hover/click,
 	// matching the L.control.layers shape prod uses. Owns its own
-	// localStorage persistence. The three basemap layers were declared in
-	// the initial style spec above; this control only toggles visibility.
+	// localStorage persistence; the actual swap is delegated to
+	// applyBasemap so the custom pin/cluster/label layers survive it.
 	map.addControl(
-		new BasemapsControl({ basemaps: BASEMAPS, initial: initialBasemap }),
+		new BasemapsControl({
+			basemaps: BASEMAPS,
+			initial: initialBasemap,
+			onSelect: applyBasemap,
+		}),
 		"top-right",
 	);
 
@@ -1602,7 +1611,9 @@ onMount(async () => {
 
 // Theme toggle → re-color the place-label layer in place. setPaintProperty
 // is cheap and avoids rebuilding the source. Guarded by styleLoaded so we
-// don't fire before the layer exists.
+// don't fire before the layer exists. The basemap itself is NOT swapped on a
+// theme change — each basemap is a fixed style and the choice is sticky (the
+// first-visit default is theme-aware, but after that the user's pick stands).
 $: if (map && styleLoaded && $theme && $theme !== lastAppliedLabelTheme) {
 	lastAppliedLabelTheme = $theme;
 	applyLabelPalette(map, $theme);

--- a/src/routes/map/controls/BasemapsControl.ts
+++ b/src/routes/map/controls/BasemapsControl.ts
@@ -20,16 +20,19 @@ type BasemapEntry = { id: BasemapId; label: string };
 type Options = {
 	basemaps: BasemapEntry[];
 	initial: BasemapId;
+	// Apply the chosen basemap. The page owns the actual swap because it
+	// has to carry the custom pin/cluster/label layers across the
+	// setStyle (vector basemaps aren't a toggle-able layer — they're a
+	// whole style). This control only handles the UI + persistence.
+	onSelect: (id: BasemapId) => void;
 };
 
 // Layer-picker control with the same shape as Leaflet's L.control.layers
 // that prod /map uses: a single icon button that expands into a radio
-// list of basemap labels. The three basemap layers are declared in the
-// initial style spec; this control only toggles their `visibility` and
-// persists the active selection so it survives reloads.
+// list of basemap labels. Selecting one delegates to the page's
+// onSelect (which does the setStyle swap) and persists the choice.
 export class BasemapsControl implements IControl {
 	#options: Options;
-	#map: MapLibreMap | undefined;
 	#container: HTMLDivElement | undefined;
 	#button: HTMLAnchorElement | undefined;
 	#popup: HTMLDivElement | undefined;
@@ -46,9 +49,7 @@ export class BasemapsControl implements IControl {
 		return "top-right";
 	}
 
-	onAdd(map: MapLibreMap): HTMLElement {
-		this.#map = map;
-
+	onAdd(_map: MapLibreMap): HTMLElement {
 		const container = document.createElement("div");
 		container.className =
 			"maplibregl-ctrl maplibregl-ctrl-group maplibre-next-basemaps";
@@ -109,7 +110,6 @@ export class BasemapsControl implements IControl {
 		this.#container = undefined;
 		this.#button = undefined;
 		this.#popup = undefined;
-		this.#map = undefined;
 	}
 
 	#renderPopup(): void {
@@ -145,18 +145,9 @@ export class BasemapsControl implements IControl {
 	}
 
 	#select(id: BasemapId): void {
-		if (!this.#map) return;
 		if (id === this.#current) {
 			this.#close();
 			return;
-		}
-		// Toggle visibility on the pre-declared raster layers.
-		for (const bm of this.#options.basemaps) {
-			this.#map.setLayoutProperty(
-				bm.id,
-				"visibility",
-				bm.id === id ? "visible" : "none",
-			);
 		}
 		this.#current = id;
 		try {
@@ -164,6 +155,7 @@ export class BasemapsControl implements IControl {
 		} catch {
 			// localStorage unavailable; skip persistence
 		}
+		this.#options.onSelect(id);
 		trackEvent("layer_change", { layer: id });
 		this.#close();
 	}


### PR DESCRIPTION
Fixes: #1030

and fix basemap-switch regressions

Restore the five basemaps the legacy maps offered on /map and /communities/map: OpenFreeMap Liberty, OpenFreeMap Dark, Carto Positron, Carto Dark Matter (all vector) and OpenStreetMap (raster). Each is a fixed, sticky style with a theme-aware first-visit default (Liberty in light, Carto Dark Matter in dark), matching legacy defaults.

Fix regressions introduced when the picker moved to setStyle:

- Re-attach the spiderfy click/zoom handlers after every basemap swap. unspiderfyAll() detaches them (map.off) and only applyTo() re-binds them, so after the first switch clicking a cluster did nothing — no zoom-in, no spider expansion. applyBasemap now re-runs applyTo on the new style.
- Register the style.load handler BEFORE setStyle so it also fires for the synchronous raster (object-style) swap, where it re-applies the label palette, re-attaches spiderfy, and re-runs the hasImage-guarded sprite loaders (so cluster/badge sprites survive a diff-failure rebuild).
- Restore the "Support BTC Map" attribution link, lost on the default vector basemap, via the AttributionControl customAttribution on /map so it shows on every basemap; drop it from the raster source string.
- Drop the theme->setStyle coupling: basemaps are fixed/sticky now, so a theme toggle only recolors the place labels and never swaps the basemap.
- Remove stale comments, a dead StyleSpecification import, and the unused currentBasemap/lastBasemapTheme state.

Add unit tests for the basemaps catalog/helpers. Verified in-browser: vector<->raster swaps preserve all 16 custom layers + 3 sources + sprites, cluster-click works after each swap, and attribution shows OSM credit plus the supporter link on every basemap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded basemap catalog to five options (including Liberty, OFM Dark, Carto Positron, Carto Dark Matter, and OSM)
  * Theme-aware default basemap selection for first visits (light/dark)
  * Basemap switching now preserves map overlays, custom layers, and attributions; raster OSM styling and custom attribution included
  * Basemap picker persists choice and delegates application for smoother switching

* **Tests**
  * Added test suite validating basemap catalog, defaults, styles, and attribution handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/teambtcmap/btcmap.org/pull/1031?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->