### PR TITLE
refactor(map): extract shared computeBbox into $lib/map #1034

### DIFF
--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -12,6 +12,7 @@ import AreaMerchantDrawer from "$components/area/AreaMerchantDrawer.svelte";
 import MapLoadingEmbed from "$components/MapLoadingEmbed.svelte";
 import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import { CLUSTERING_DISABLED_ZOOM } from "$lib/constants";
+import { computeBbox } from "$lib/map/bbox";
 import {
 	ensureSprite,
 	installPlaceholderHandler,
@@ -79,26 +80,6 @@ const buildFeatureCollection = (
 		},
 	})),
 });
-
-const computeBboxFromPlaces = (
-	list: SavedPlace[],
-): [number, number, number, number] | null => {
-	let minX = Number.POSITIVE_INFINITY;
-	let minY = Number.POSITIVE_INFINITY;
-	let maxX = Number.NEGATIVE_INFINITY;
-	let maxY = Number.NEGATIVE_INFINITY;
-	let found = false;
-	for (const p of list) {
-		if (typeof p.lat !== "number" || typeof p.lon !== "number") continue;
-		if (p.lon < minX) minX = p.lon;
-		if (p.lat < minY) minY = p.lat;
-		if (p.lon > maxX) maxX = p.lon;
-		if (p.lat > maxY) maxY = p.lat;
-		found = true;
-	}
-	if (!found) return null;
-	return [minX, minY, maxX, maxY];
-};
 
 const addPlacesLayers = (m: MapLibreMap) => {
 	if (!m.getSource("places")) {
@@ -198,7 +179,9 @@ const initializeMapContents = (m: MapLibreMap) => {
 };
 
 const fitToPlaces = (m: MapLibreMap) => {
-	const bbox = computeBboxFromPlaces(places);
+	// computeBbox walks the same Point FeatureCollection we feed the source,
+	// so an empty/invalid list yields null and we fall back to the world view.
+	const bbox = computeBbox(buildFeatureCollection(places));
 	if (bbox) {
 		m.fitBounds(
 			[

--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
 import "maplibre-gl/dist/maplibre-gl.css";
 
-import type {
-	Feature,
-	FeatureCollection,
-	GeoJSON,
-	Geometry,
-	Position,
-} from "geojson";
+import type { GeoJSON } from "geojson";
 import type {
 	GeoJSONSource,
 	MapLayerMouseEvent,
@@ -23,6 +17,7 @@ import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import ShowTags from "$components/ShowTags.svelte";
 import TaggingIssues from "$components/TaggingIssues.svelte";
 import { CLUSTERING_DISABLED_ZOOM, GradeTable } from "$lib/constants";
+import { computeBbox } from "$lib/map/bbox";
 import {
 	ensureSpritesForPlaces,
 	installPlaceholderHandler,
@@ -142,55 +137,6 @@ const buildFeatureCollection = (list: Place[]): PlaceFeatureCollection => ({
 			},
 		})),
 });
-
-// Walk every coordinate in any GeoJSON object and reduce to [minX, minY, maxX, maxY].
-// Inlined instead of pulling in @turf/bbox — the project doesn't ship it.
-const computeBbox = (g: GeoJSON): [number, number, number, number] | null => {
-	let minX = Number.POSITIVE_INFINITY;
-	let minY = Number.POSITIVE_INFINITY;
-	let maxX = Number.NEGATIVE_INFINITY;
-	let maxY = Number.NEGATIVE_INFINITY;
-	let found = false;
-	const visitPosition = (pos: Position) => {
-		const [x, y] = pos;
-		if (typeof x !== "number" || typeof y !== "number") return;
-		if (x < minX) minX = x;
-		if (y < minY) minY = y;
-		if (x > maxX) maxX = x;
-		if (y > maxY) maxY = y;
-		found = true;
-	};
-	const visitCoords = (coords: unknown) => {
-		if (!Array.isArray(coords)) return;
-		if (coords.length > 0 && typeof coords[0] === "number") {
-			visitPosition(coords as Position);
-			return;
-		}
-		for (const c of coords) visitCoords(c);
-	};
-	const visitGeometry = (geom: Geometry) => {
-		if (geom.type === "GeometryCollection") {
-			for (const sub of geom.geometries) visitGeometry(sub);
-		} else {
-			visitCoords((geom as { coordinates: unknown }).coordinates);
-		}
-	};
-	const visit = (input: GeoJSON) => {
-		if (input.type === "FeatureCollection") {
-			for (const f of (input as FeatureCollection).features) {
-				if (f.geometry) visitGeometry(f.geometry);
-			}
-		} else if (input.type === "Feature") {
-			const f = input as Feature;
-			if (f.geometry) visitGeometry(f.geometry);
-		} else {
-			visitGeometry(input as Geometry);
-		}
-	};
-	visit(g);
-	if (!found) return null;
-	return [minX, minY, maxX, maxY];
-};
 
 // Register the area polygon source + outline layer. Re-runs on every style
 // reload so a theme swap doesn't strip the overlay. When the source already

--- a/src/lib/map/bbox.test.ts
+++ b/src/lib/map/bbox.test.ts
@@ -1,0 +1,169 @@
+import type {
+	Feature,
+	FeatureCollection,
+	GeoJSON,
+	Geometry,
+	GeometryCollection,
+} from "geojson";
+import { describe, expect, it } from "vitest";
+
+import { computeBbox } from "./bbox";
+
+describe("computeBbox", () => {
+	it("returns a zero-area box for a single Point", () => {
+		const point: GeoJSON = { type: "Point", coordinates: [10, 20] };
+		expect(computeBbox(point)).toEqual([10, 20, 10, 20]);
+	});
+
+	it("walks a Polygon ring", () => {
+		const polygon: GeoJSON = {
+			type: "Polygon",
+			coordinates: [
+				[
+					[0, 0],
+					[4, 0],
+					[4, 3],
+					[0, 3],
+					[0, 0],
+				],
+			],
+		};
+		expect(computeBbox(polygon)).toEqual([0, 0, 4, 3]);
+	});
+
+	it("walks a MultiPolygon (nested coordinate arrays)", () => {
+		const multi: GeoJSON = {
+			type: "MultiPolygon",
+			coordinates: [
+				[
+					[
+						[0, 0],
+						[1, 0],
+						[1, 1],
+						[0, 0],
+					],
+				],
+				[
+					[
+						[5, 5],
+						[6, 5],
+						[6, 7],
+						[5, 5],
+					],
+				],
+			],
+		};
+		expect(computeBbox(multi)).toEqual([0, 0, 6, 7]);
+	});
+
+	it("walks a FeatureCollection of mixed geometries", () => {
+		const fc: FeatureCollection = {
+			type: "FeatureCollection",
+			features: [
+				{
+					type: "Feature",
+					properties: {},
+					geometry: { type: "Point", coordinates: [-3, -2] },
+				},
+				{
+					type: "Feature",
+					properties: {},
+					geometry: {
+						type: "LineString",
+						coordinates: [
+							[1, 1],
+							[8, 9],
+						],
+					},
+				},
+			],
+		};
+		expect(computeBbox(fc)).toEqual([-3, -2, 8, 9]);
+	});
+
+	it("recurses into a GeometryCollection", () => {
+		const gc: GeometryCollection = {
+			type: "GeometryCollection",
+			geometries: [
+				{ type: "Point", coordinates: [2, 2] },
+				{
+					type: "Polygon",
+					coordinates: [
+						[
+							[-5, -5],
+							[10, -5],
+							[10, 4],
+							[-5, -5],
+						],
+					],
+				},
+			],
+		};
+		expect(computeBbox(gc)).toEqual([-5, -5, 10, 4]);
+	});
+
+	it("spans the antimeridian as raw min/max (no normalization)", () => {
+		// Two points straddling +/-180: the walker reports the literal extent.
+		const fc: FeatureCollection = {
+			type: "FeatureCollection",
+			features: [
+				{
+					type: "Feature",
+					properties: {},
+					geometry: { type: "Point", coordinates: [179, 10] },
+				},
+				{
+					type: "Feature",
+					properties: {},
+					geometry: { type: "Point", coordinates: [-179, 12] },
+				},
+			],
+		};
+		expect(computeBbox(fc)).toEqual([-179, 10, 179, 12]);
+	});
+
+	it("returns null for an empty FeatureCollection", () => {
+		const empty: FeatureCollection = {
+			type: "FeatureCollection",
+			features: [],
+		};
+		expect(computeBbox(empty)).toBeNull();
+	});
+
+	it("returns null when a Feature has null geometry", () => {
+		const feature: Feature<Geometry | null> = {
+			type: "Feature",
+			properties: {},
+			geometry: null,
+		};
+		expect(computeBbox(feature as GeoJSON)).toBeNull();
+	});
+
+	it("ignores NaN coordinates and returns null when all are NaN", () => {
+		const point: GeoJSON = {
+			type: "Point",
+			coordinates: [Number.NaN, Number.NaN],
+		};
+		expect(computeBbox(point)).toBeNull();
+	});
+
+	it("skips a NaN point but keeps valid ones in a FeatureCollection", () => {
+		const fc: FeatureCollection = {
+			type: "FeatureCollection",
+			features: [
+				{
+					type: "Feature",
+					properties: {},
+					geometry: { type: "Point", coordinates: [Number.NaN, 5] },
+				},
+				{
+					type: "Feature",
+					properties: {},
+					geometry: { type: "Point", coordinates: [3, 4] },
+				},
+			],
+		};
+		// The NaN x rejects the whole position; only [3, 4] contributes.
+		expect(computeBbox(fc)).toEqual([3, 4, 3, 4]);
+	});
+});

--- a/src/lib/map/bbox.test.ts
+++ b/src/lib/map/bbox.test.ts
@@ -147,6 +147,38 @@ describe("computeBbox", () => {
 		expect(computeBbox(point)).toBeNull();
 	});
 
+	it("rejects a non-finite (Infinity) coordinate as a whole position", () => {
+		const fc: FeatureCollection = {
+			type: "FeatureCollection",
+			features: [
+				{
+					type: "Feature",
+					properties: {},
+					geometry: {
+						type: "Point",
+						coordinates: [Number.POSITIVE_INFINITY, 0],
+					},
+				},
+				{
+					type: "Feature",
+					properties: {},
+					geometry: { type: "Point", coordinates: [5, 6] },
+				},
+			],
+		};
+		// The Infinity x rejects that whole position; only [5, 6] contributes,
+		// so the bbox never carries a non-finite value into fitBounds.
+		expect(computeBbox(fc)).toEqual([5, 6, 5, 6]);
+	});
+
+	it("returns null when every coordinate is non-finite", () => {
+		const point: GeoJSON = {
+			type: "Point",
+			coordinates: [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY],
+		};
+		expect(computeBbox(point)).toBeNull();
+	});
+
 	it("skips a NaN point but keeps valid ones in a FeatureCollection", () => {
 		const fc: FeatureCollection = {
 			type: "FeatureCollection",

--- a/src/lib/map/bbox.ts
+++ b/src/lib/map/bbox.ts
@@ -1,0 +1,79 @@
+// Compute the bounding box of any GeoJSON object as [minX, minY, maxX, maxY]
+// i.e. [west, south, east, north] — the order MapLibre's fitBounds expects via
+// [[bbox[0], bbox[1]], [bbox[2], bbox[3]]].
+//
+// Inlined recursive walker instead of pulling in @turf/bbox — the project does
+// not ship that dependency. Lifted from AreaMap / communities/map (which held
+// byte-identical copies) and the point-list variant in MultiPlaceMap, which now
+// funnels its place points through this generic walker by building a
+// FeatureCollection first.
+//
+// Returns null when no finite coordinate is found (empty input, or geometry
+// whose positions are all non-numeric / NaN), so callers can branch to a
+// fallback camera (see MultiPlaceMap.fitToPlaces) or skip the fit (see
+// AreaMap.fitToArea). NaN coordinates are rejected as a whole position —
+// typeof NaN === "number" passes the original type guard, so an all-NaN input
+// would otherwise return degenerate infinite bounds instead of null.
+
+import type {
+	Feature,
+	FeatureCollection,
+	GeoJSON,
+	Geometry,
+	Position,
+} from "geojson";
+
+export type Bbox = [number, number, number, number];
+
+export const computeBbox = (g: GeoJSON): Bbox | null => {
+	let minX = Number.POSITIVE_INFINITY;
+	let minY = Number.POSITIVE_INFINITY;
+	let maxX = Number.NEGATIVE_INFINITY;
+	let maxY = Number.NEGATIVE_INFINITY;
+	let found = false;
+
+	const visitPosition = (pos: Position) => {
+		const [x, y] = pos;
+		if (typeof x !== "number" || typeof y !== "number") return;
+		if (Number.isNaN(x) || Number.isNaN(y)) return;
+		if (x < minX) minX = x;
+		if (y < minY) minY = y;
+		if (x > maxX) maxX = x;
+		if (y > maxY) maxY = y;
+		found = true;
+	};
+
+	const visitCoords = (coords: unknown) => {
+		if (!Array.isArray(coords)) return;
+		if (coords.length > 0 && typeof coords[0] === "number") {
+			visitPosition(coords as Position);
+			return;
+		}
+		for (const c of coords) visitCoords(c);
+	};
+
+	const visitGeometry = (geom: Geometry) => {
+		if (geom.type === "GeometryCollection") {
+			for (const sub of geom.geometries) visitGeometry(sub);
+		} else {
+			visitCoords((geom as { coordinates: unknown }).coordinates);
+		}
+	};
+
+	const visit = (input: GeoJSON) => {
+		if (input.type === "FeatureCollection") {
+			for (const f of (input as FeatureCollection).features) {
+				if (f.geometry) visitGeometry(f.geometry);
+			}
+		} else if (input.type === "Feature") {
+			const f = input as Feature;
+			if (f.geometry) visitGeometry(f.geometry);
+		} else {
+			visitGeometry(input as Geometry);
+		}
+	};
+
+	visit(g);
+	if (!found) return null;
+	return [minX, minY, maxX, maxY];
+};

--- a/src/lib/map/bbox.ts
+++ b/src/lib/map/bbox.ts
@@ -9,11 +9,12 @@
 // FeatureCollection first.
 //
 // Returns null when no finite coordinate is found (empty input, or geometry
-// whose positions are all non-numeric / NaN), so callers can branch to a
-// fallback camera (see MultiPlaceMap.fitToPlaces) or skip the fit (see
-// AreaMap.fitToArea). NaN coordinates are rejected as a whole position —
-// typeof NaN === "number" passes the original type guard, so an all-NaN input
-// would otherwise return degenerate infinite bounds instead of null.
+// whose positions are all non-numeric / non-finite), so callers can branch to
+// a fallback camera (see MultiPlaceMap.fitToPlaces) or skip the fit (see
+// AreaMap.fitToArea). NaN and ±Infinity are rejected as a whole position —
+// typeof NaN === "number" passes the original type guard, so without the
+// finiteness check a non-finite coordinate would survive into a degenerate
+// bbox and on into map.fitBounds instead of yielding null.
 
 import type {
 	Feature,
@@ -35,7 +36,7 @@ export const computeBbox = (g: GeoJSON): Bbox | null => {
 	const visitPosition = (pos: Position) => {
 		const [x, y] = pos;
 		if (typeof x !== "number" || typeof y !== "number") return;
-		if (Number.isNaN(x) || Number.isNaN(y)) return;
+		if (!Number.isFinite(x) || !Number.isFinite(y)) return;
 		if (x < minX) minX = x;
 		if (y < minY) minY = y;
 		if (x > maxX) maxX = x;

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -4,13 +4,7 @@ import "./communities-map.css";
 
 import rewind from "@mapbox/geojson-rewind";
 import { geoArea } from "d3-geo";
-import type {
-	Feature,
-	FeatureCollection,
-	GeoJSON,
-	Geometry,
-	Position,
-} from "geojson";
+import type { Feature, FeatureCollection, Geometry } from "geojson";
 import type {
 	GeoJSONSource,
 	MapLayerMouseEvent,
@@ -30,6 +24,7 @@ import {
 	getStoredBasemap,
 	styleForBasemap,
 } from "$lib/map/basemaps";
+import { computeBbox } from "$lib/map/bbox";
 import { parseHashCoords, writeHashCoords } from "$lib/map/mapHash";
 import { hasWebGL } from "$lib/map/webgl";
 import { areaError, areas, reportError, reports } from "$lib/store";
@@ -107,56 +102,6 @@ const buildFeatureCollection = (
 		}
 	}
 	return { type: "FeatureCollection", features };
-};
-
-// Inlined to avoid pulling @turf/bbox into the bundle just for this. Shares
-// the same shape as AreaMap's bbox walker; lift to $lib if a third consumer
-// appears.
-const computeBbox = (g: GeoJSON): [number, number, number, number] | null => {
-	let minX = Number.POSITIVE_INFINITY;
-	let minY = Number.POSITIVE_INFINITY;
-	let maxX = Number.NEGATIVE_INFINITY;
-	let maxY = Number.NEGATIVE_INFINITY;
-	let found = false;
-	const visitPosition = (pos: Position) => {
-		const [x, y] = pos;
-		if (typeof x !== "number" || typeof y !== "number") return;
-		if (x < minX) minX = x;
-		if (y < minY) minY = y;
-		if (x > maxX) maxX = x;
-		if (y > maxY) maxY = y;
-		found = true;
-	};
-	const visitCoords = (coords: unknown) => {
-		if (!Array.isArray(coords)) return;
-		if (coords.length > 0 && typeof coords[0] === "number") {
-			visitPosition(coords as Position);
-			return;
-		}
-		for (const c of coords) visitCoords(c);
-	};
-	const visitGeometry = (geom: Geometry) => {
-		if (geom.type === "GeometryCollection") {
-			for (const sub of geom.geometries) visitGeometry(sub);
-		} else {
-			visitCoords((geom as { coordinates: unknown }).coordinates);
-		}
-	};
-	const visit = (input: GeoJSON) => {
-		if (input.type === "FeatureCollection") {
-			for (const f of (input as FeatureCollection).features) {
-				if (f.geometry) visitGeometry(f.geometry);
-			}
-		} else if (input.type === "Feature") {
-			const f = input as Feature;
-			if (f.geometry) visitGeometry(f.geometry);
-		} else {
-			visitGeometry(input as Geometry);
-		}
-	};
-	visit(g);
-	if (!found) return null;
-	return [minX, minY, maxX, maxY];
 };
 
 // Swap the basemap while keeping the community polygon source + layers live.


### PR DESCRIPTION
Fixes: #1034

Lift the byte-identical GeoJSON bbox walker out of AreaMap and communities/map into $lib/map/bbox.ts, and route MultiPlaceMap's point-list fit through it. Also harden the walker with a NaN-coordinate guard so an all-invalid input returns null (clean camera fallback) instead of degenerate infinite bounds.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated bounding-box calculation into a shared map utility used by multiple map views, improving consistency and fallback behavior for empty or invalid place lists.

* **Tests**
  * Added comprehensive tests for bounding-box computation across geometry types, antimeridian cases, and various invalid/non-finite coordinate scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->