### PR TITLE
fix(merchant): tip lightning scheme #966

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -11,6 +11,7 @@ import {
 	isValidLatitude,
 	isValidLongitude,
 	sanitizeUrl,
+	stripLightningScheme,
 } from "./utils";
 
 describe("sanitizeUrl", () => {
@@ -679,5 +680,29 @@ describe("areaIconSrc", () => {
 		expect(areaIconSrc(null)).toBe("/images/bitcoin.svg");
 		expect(areaIconSrc(undefined)).toBe("/images/bitcoin.svg");
 		expect(areaIconSrc("")).toBe("/images/bitcoin.svg");
+	});
+});
+
+describe("stripLightningScheme", () => {
+	it("removes a leading lightning: scheme", () => {
+		expect(stripLightningScheme("lightning:alice@getalby.com")).toBe(
+			"alice@getalby.com",
+		);
+	});
+
+	it("leaves a bare address untouched", () => {
+		expect(stripLightningScheme("alice@getalby.com")).toBe("alice@getalby.com");
+	});
+
+	it("strips the scheme case-insensitively", () => {
+		expect(stripLightningScheme("LIGHTNING:alice@getalby.com")).toBe(
+			"alice@getalby.com",
+		);
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(stripLightningScheme("  lightning:alice@getalby.com  ")).toBe(
+			"alice@getalby.com",
+		);
 	});
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -9,6 +9,7 @@ import {
 	formatDistance,
 	getCommunitiesAtCoordinates,
 	isValidLatitude,
+	isValidLightningTip,
 	isValidLongitude,
 	sanitizeUrl,
 	stripLightningScheme,
@@ -704,5 +705,37 @@ describe("stripLightningScheme", () => {
 		expect(stripLightningScheme("  lightning:alice@getalby.com  ")).toBe(
 			"alice@getalby.com",
 		);
+	});
+});
+
+describe("isValidLightningTip", () => {
+	it("accepts a well-formed lightning address", () => {
+		expect(isValidLightningTip("alice@getalby.com")).toBe(true);
+	});
+
+	it("accepts an address that still carries the lightning: scheme", () => {
+		expect(isValidLightningTip("lightning:alice@getalby.com")).toBe(true);
+	});
+
+	it("rejects undefined/empty input", () => {
+		expect(isValidLightningTip(undefined)).toBe(false);
+		expect(isValidLightningTip("")).toBe(false);
+	});
+
+	it("rejects an undefined username leaked from missing data", () => {
+		expect(isValidLightningTip("undefined@zbd.gg")).toBe(false);
+		expect(isValidLightningTip("lightning:undefined@zbd.gg")).toBe(false);
+	});
+
+	it("rejects a null username", () => {
+		expect(isValidLightningTip("null@zbd.gg")).toBe(false);
+	});
+
+	it("rejects an address with no domain dot", () => {
+		expect(isValidLightningTip("alice@localhost")).toBe(false);
+	});
+
+	it("rejects an address containing whitespace", () => {
+		expect(isValidLightningTip("alice @getalby.com")).toBe(false);
 	});
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -706,6 +706,12 @@ describe("stripLightningScheme", () => {
 			"alice@getalby.com",
 		);
 	});
+
+	it("strips whitespace following the scheme", () => {
+		expect(stripLightningScheme("lightning: alice@getalby.com")).toBe(
+			"alice@getalby.com",
+		);
+	});
 });
 
 describe("isValidLightningTip", () => {
@@ -715,6 +721,10 @@ describe("isValidLightningTip", () => {
 
 	it("accepts an address that still carries the lightning: scheme", () => {
 		expect(isValidLightningTip("lightning:alice@getalby.com")).toBe(true);
+	});
+
+	it("accepts an address with whitespace after the scheme", () => {
+		expect(isValidLightningTip("lightning: alice@getalby.com")).toBe(true);
 	});
 
 	it("rejects undefined/empty input", () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -367,6 +367,18 @@ export const formatOpeningHours = (str: string): string => {
 export const stripLightningScheme = (value: string): string =>
 	value.trim().replace(/^lightning:/i, "");
 
+// A lightning address is `localpart@domain.tld`. Guard against malformed
+// values that leak from missing upstream data — most notably
+// "undefined@zbd.gg", where a missing username serialised to the literal
+// string "undefined" — so a dead Tip button is never rendered.
+export const isValidLightningTip = (value: string | undefined): boolean => {
+	if (!value) return false;
+	const address = stripLightningScheme(value);
+	if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(address)) return false;
+	const localPart = address.split("@")[0].toLowerCase();
+	return localPart !== "undefined" && localPart !== "null";
+};
+
 // Escapes HTML special characters to prevent XSS in text content
 // Use this for plain text inserted into innerHTML contexts (e.g., Leaflet tooltips)
 export function escapeHtml(text: string): string {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -360,6 +360,13 @@ export const formatOpeningHours = (str: string): string => {
 		.join("");
 };
 
+// Tip values from the v4 activity API arrive with the `lightning:` URI scheme
+// already attached (e.g. "lightning:alice@getalby.com"). Tip.svelte prepends
+// its own `lightning:`, so strip the incoming scheme first to avoid a doubled
+// `lightning:lightning:` href that no wallet can resolve.
+export const stripLightningScheme = (value: string): string =>
+	value.trim().replace(/^lightning:/i, "");
+
 // Escapes HTML special characters to prevent XSS in text content
 // Use this for plain text inserted into innerHTML contexts (e.g., Leaflet tooltips)
 export function escapeHtml(text: string): string {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -363,9 +363,10 @@ export const formatOpeningHours = (str: string): string => {
 // Tip values from the v4 activity API arrive with the `lightning:` URI scheme
 // already attached (e.g. "lightning:alice@getalby.com"). Tip.svelte prepends
 // its own `lightning:`, so strip the incoming scheme first to avoid a doubled
-// `lightning:lightning:` href that no wallet can resolve.
+// `lightning:lightning:` href that no wallet can resolve. Also consume any
+// whitespace after the scheme so the normalized address is never space-padded.
 export const stripLightningScheme = (value: string): string =>
-	value.trim().replace(/^lightning:/i, "");
+	value.trim().replace(/^lightning:\s*/i, "");
 
 // A lightning address is `localpart@domain.tld`. Guard against malformed
 // values that leak from missing upstream data — most notably

--- a/src/routes/merchant/[id]/components/MerchantEvent.svelte
+++ b/src/routes/merchant/[id]/components/MerchantEvent.svelte
@@ -3,6 +3,7 @@ import Time from "svelte-time";
 
 import Tip from "$components/Tip.svelte";
 import type { EventType, User } from "$lib/types";
+import { stripLightningScheme } from "$lib/utils";
 
 import { resolve } from "$app/paths";
 
@@ -11,6 +12,10 @@ export let user_id: number | undefined;
 export let user_name: string | undefined;
 export let user_tip: string | undefined;
 export let time: string;
+
+// The API ships user_tip with its own `lightning:` scheme; strip it so
+// Tip.svelte (which re-adds the scheme) can't emit `lightning:lightning:`.
+$: tipDestination = user_tip ? stripLightningScheme(user_tip) : undefined;
 </script>
 
 <div class="py-3 text-left text-base">
@@ -33,7 +38,7 @@ export let time: string;
 
 			<!-- time ago -->
 			<span
-				class="block font-semibold text-taggerTime lg:inline dark:text-white/70 {user_tip
+				class="block font-semibold text-taggerTime lg:inline dark:text-white/70 {tipDestination
 					? 'lg:mr-5'
 					: ''}"
 			>
@@ -42,8 +47,8 @@ export let time: string;
 		</div>
 
 		<!-- lightning tip button -->
-		{#if user_tip}
-			<Tip destination={user_tip} class="block lg:inline" />
+		{#if tipDestination}
+			<Tip destination={tipDestination} class="block lg:inline" />
 		{/if}
 	</div>
 </div>

--- a/src/routes/merchant/[id]/components/MerchantEvent.svelte
+++ b/src/routes/merchant/[id]/components/MerchantEvent.svelte
@@ -3,7 +3,7 @@ import Time from "svelte-time";
 
 import Tip from "$components/Tip.svelte";
 import type { EventType, User } from "$lib/types";
-import { stripLightningScheme } from "$lib/utils";
+import { isValidLightningTip, stripLightningScheme } from "$lib/utils";
 
 import { resolve } from "$app/paths";
 
@@ -15,7 +15,12 @@ export let time: string;
 
 // The API ships user_tip with its own `lightning:` scheme; strip it so
 // Tip.svelte (which re-adds the scheme) can't emit `lightning:lightning:`.
-$: tipDestination = user_tip ? stripLightningScheme(user_tip) : undefined;
+// Skip malformed addresses (e.g. "undefined@zbd.gg") so the Tip button is
+// hidden rather than rendering a dead link.
+$: tipDestination =
+	user_tip && isValidLightningTip(user_tip)
+		? stripLightningScheme(user_tip)
+		: undefined;
 </script>
 
 <div class="py-3 text-left text-base">


### PR DESCRIPTION
  ## Summary

  Fixes two tip-link bugs on the merchant detail Activity tab (`MerchantEvent` →
  `Tip.svelte`), found reviewing #966.

  - **Doubled scheme:** the API returns `user_tip` as `lightning:alice@getalby.com`, and
  `Tip.svelte` re-prepends `lightning:` → `lightning:lightning:…`, a dead link. Now stripped
  first, matching every other Tip call site.
  - **Malformed addresses:** a bad `user_tip` (e.g. `undefined@zbd.gg`) rendered as a live
  link. Now validated; the button is hidden when the address doesn't parse.

  ## Changes

  - `stripLightningScheme` + `isValidLightningTip` helpers in `$lib/utils`, applied in
  `MerchantEvent`
  - 11 new unit tests

  Scoped to the merchant detail page only. Verified: `format`, `check`, `lint` clean; 368
  tests pass.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lightning address normalization and validation to accept valid addresses (with or without a scheme) and trim stray whitespace.

* **Bug Fixes**
  * Prevented malformed tip addresses from rendering as broken or clickable links and adjusted layout to hide invalid tips.

* **Tests**
  * Added unit tests covering scheme stripping, whitespace handling, valid/invalid addresses and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->