### PR TITLE
fix(layout): reclaim mobile width by replacing the w-10/12 main gutter

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -144,7 +144,7 @@ export let data;
 	{#if !['/', '/map', '/communities/map', '/communities', '/countries'].includes(data.pathname)}
 		<div class="bg-teal dark:bg-dark">
 			<Header />
-			<main class="mx-auto w-10/12 xl:w-[1200px]">
+			<main class="mx-auto w-full px-4 xl:w-[1200px] xl:px-0">
 				<LoadingIndicator visible={layoutSyncVisible} status={layoutLoadingStatus} progress={$placesLoadingProgress} />
 				<slot />
 				<Footer />

--- a/src/routes/license/+page.svelte
+++ b/src/routes/license/+page.svelte
@@ -11,7 +11,7 @@ import { _ } from "$lib/i18n";
 	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
-<div class="mt-10 mb-20 space-y-5 text-body dark:text-white">
+<div class="mx-auto mt-10 mb-20 max-w-4xl space-y-5 text-body dark:text-white">
 	<p class="text-center font-semibold text-primary dark:text-white">
 		BTC Map - Easily find places to spend sats anywhere on the planet.
 		<br />

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -136,7 +136,7 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 	</div>
 {/if}
 
-<div class="mx-auto my-10 max-w-5xl px-4 text-left md:my-16">
+<div class="mx-auto my-10 max-w-5xl text-left md:my-16">
 	<div
 		class="space-y-4 lg:grid lg:grid-cols-[minmax(0,360px)_minmax(0,1fr)] lg:items-start lg:gap-8 lg:space-y-0"
 	>

--- a/src/routes/privacy-policy/+page.svelte
+++ b/src/routes/privacy-policy/+page.svelte
@@ -12,7 +12,7 @@ const linkClass = "text-link transition-colors hover:text-hover";
 	<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 </svelte:head>
 
-<div class="mt-10 mb-20 space-y-10">
+<div class="mx-auto mt-10 mb-20 max-w-3xl space-y-10">
 	<div class="space-y-5 text-xl text-body dark:text-white">
 		<h1 class="text-4xl !leading-tight font-semibold text-primary md:text-5xl dark:text-white">
 			{$_("privacyPolicy.title")}


### PR DESCRIPTION
The global `<main>` used `w-10/12` — a fixed 83.33% width at every breakpoint below xl — so phones lost ~8% per side regardless of screen size, and the content sat narrower than the (full-width) mobile header. Switch to the header's own frame: full width with a 16px gutter on mobile, the centered 1200px column at xl+.

- +layout.svelte: w-10/12 xl:w-[1200px] -> w-full px-4 xl:w-[1200px] xl:px-0
- merchant detail: drop the now-redundant page-level px-4 (the layout supplies the 16px gutter; keeping both double-padded to ~32px on mobile)
- license / privacy-policy: cap long prose with max-w so it doesn't stretch on tablet/laptop widths now that the column is full width

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout design across multiple pages
  * Enhanced content centering and spacing on the license and privacy policy pages
  * Adjusted page width constraints and padding for better visual presentation on different screen sizes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->