### PR TITLE
fix(merchant): make tab count badges circular #966

### DIFF
--- a/src/routes/merchant/[id]/components/MerchantTabs.svelte
+++ b/src/routes/merchant/[id]/components/MerchantTabs.svelte
@@ -73,7 +73,7 @@ const onKeydown = (event: KeyboardEvent, index: number) => {
 				{t.label}
 				{#if t.count}
 					<span
-						class="rounded-full px-1.5 py-0.5 text-[10px] font-bold {tab === t.key
+						class="inline-flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1 text-[10px] leading-none font-bold {tab === t.key
 							? 'bg-link text-white'
 							: 'bg-gray-200 text-body dark:bg-white/10 dark:text-white/60'}"
 					>


### PR DESCRIPTION


The count badge was a plain inline span, so its height came from the tab button's inherited line-height (~24px) while a single digit is ~18px wide — rounded-full then rendered a vertical stadium. Make it a centered inline-flex box with equal height/min-width and leading-none: single digits are an 18px circle, multi-digit counts grow horizontally into a pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile tab badge styling with a fixed-size layout for improved visual consistency. Badge appearance remains functionally identical with consistent color scheme for selected and unselected states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->