### PR TITLE
fix(merchant): make map deep link select the merchant #966

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -140,34 +140,64 @@
 		animation: wiggle 2s ease-in-out infinite;
 	}
 
-	/* Selected marker highlight */
-	.selected-marker {
-		filter: drop-shadow(0 0 4px #00b7d2) drop-shadow(0 0 8px #00b7d2) !important;
-		animation: pulse-glow 2s ease-in-out infinite;
+	/* Selected-merchant locator pulse — the DOM overlay marker dropped on the
+	   selected pin's geo point (design C). --bm-pulse-color is set per
+	   selection to match the pin (teal / bitcoin orange). */
+	.bm-selected-pulse {
+		position: relative;
+		width: 0;
+		height: 0;
 	}
 
-	.selected-marker-boosted {
-		filter: drop-shadow(0 0 4px #f7931a) drop-shadow(0 0 8px #f7931a) !important;
-		animation: pulse-glow-boosted 2s ease-in-out infinite;
+	.bm-pulse-ring,
+	.bm-pulse-dot {
+		position: absolute;
+		left: 0;
+		top: 0;
+		transform: translate(-50%, -50%);
+		border-radius: 50%;
 	}
 
-	@keyframes pulse-glow {
-		0%,
+	.bm-pulse-ring {
+		border: 3px solid var(--bm-pulse-color, #0e95af);
+		opacity: 0;
+		animation: bm-pulse 1.8s ease-out infinite;
+	}
+
+	.bm-pulse-ring--delay {
+		animation-delay: 0.9s;
+	}
+
+	.bm-pulse-dot {
+		width: 8px;
+		height: 8px;
+		background: var(--bm-pulse-color, #0e95af);
+		box-shadow: 0 0 0 2px #fff;
+	}
+
+	@keyframes bm-pulse {
+		0% {
+			width: 18px;
+			height: 18px;
+			opacity: 0.55;
+		}
 		100% {
-			filter: drop-shadow(0 0 4px #00b7d2) drop-shadow(0 0 8px #00b7d2);
-		}
-		50% {
-			filter: drop-shadow(0 0 6px #00b7d2) drop-shadow(0 0 12px #00b7d2);
+			width: 70px;
+			height: 70px;
+			opacity: 0;
 		}
 	}
 
-	@keyframes pulse-glow-boosted {
-		0%,
-		100% {
-			filter: drop-shadow(0 0 4px #f7931a) drop-shadow(0 0 8px #f7931a);
+	@media (prefers-reduced-motion: reduce) {
+		.bm-pulse-ring {
+			animation: none;
+			opacity: 0.4;
+			width: 44px;
+			height: 44px;
 		}
-		50% {
-			filter: drop-shadow(0 0 6px #f7931a) drop-shadow(0 0 12px #f7931a);
+
+		.bm-pulse-ring--delay {
+			display: none;
 		}
 	}
 }

--- a/src/app.css
+++ b/src/app.css
@@ -142,7 +142,9 @@
 
 	/* Selected-merchant locator pulse — the DOM overlay marker dropped on the
 	   selected pin's geo point (design C). --bm-pulse-color is set per
-	   selection to match the pin (teal / bitcoin orange). */
+	   selection (in +page.svelte) to PIN_FILL_REGULAR / PIN_FILL_BOOSTED so it
+	   matches the pin; the #0e95af fallback below just mirrors PIN_FILL_REGULAR
+	   as a last resort and is never used in practice. */
 	.bm-selected-pulse {
 		position: relative;
 		width: 0;

--- a/src/lib/map/mapHash.ts
+++ b/src/lib/map/mapHash.ts
@@ -1,9 +1,15 @@
-// URL hash viewport sync for /map.
+// URL viewport sync for /map.
 //
-// Format: `#zoom/lat/lng&merchant=123&view=…`. We extend it
-// with optional `/bearing/pitch` segments after lng, written only when
-// non-zero. Drawer params after `&` are preserved untouched so a shared
-// URL combining a viewport + an open drawer round-trips.
+// The hash holds ONLY the viewport: `#zoom/lat/lng`, optionally extended with
+// `/bearing/pitch` segments (written only when non-zero). The merchant drawer
+// params (`merchant`, `view`) live in the QUERY STRING instead — see
+// $lib/merchantDrawerHash — so the server-side OG-image loader can read them
+// (the hash fragment is never sent to the server). Build the canonical
+// merchant deep link with buildMerchantMapHref().
+//
+// Any legacy `&`-suffixed hash params (the pre-#1019 `#z/lat/lng&merchant=…`
+// scheme) are still preserved untouched below for backward compatibility, but
+// nothing in the app reads merchant/view from the hash anymore.
 
 export type HashCoords = {
 	zoom: number;

--- a/src/lib/merchantDrawerHash.test.ts
+++ b/src/lib/merchantDrawerHash.test.ts
@@ -4,7 +4,12 @@ vi.mock("$app/environment", () => ({
 	browser: true,
 }));
 
-import { parseMerchantHash, updateMerchantHash } from "./merchantDrawerHash";
+import { parseHashCoords } from "./map/mapHash";
+import {
+	buildMerchantMapHref,
+	parseMerchantHash,
+	updateMerchantHash,
+} from "./merchantDrawerHash";
 
 describe("parseMerchantHash", () => {
 	beforeEach(() => {
@@ -242,6 +247,44 @@ describe("updateMerchantHash", () => {
 				"",
 				expect.not.stringContaining("merchant"),
 			);
+		});
+	});
+});
+
+describe("buildMerchantMapHref deep-link round-trip", () => {
+	const setLocationFromHref = (href: string) => {
+		const url = new URL(href, "http://localhost");
+		delete (window as unknown as { location: unknown }).location;
+		(
+			window as unknown as { location: { search: string; hash: string } }
+		).location = { search: url.search, hash: url.hash };
+	};
+
+	it("produces a link parseMerchantHash and parseHashCoords can both read", () => {
+		setLocationFromHref(buildMerchantMapHref(1128, 32.6489863, -16.9101835));
+		expect(parseMerchantHash().merchantId).toBe(1128);
+		expect(parseHashCoords()).toMatchObject({
+			zoom: 18,
+			lat: 32.6489863,
+			lng: -16.9101835,
+		});
+	});
+
+	it("keeps the merchant in the query string, not the hash", () => {
+		expect(buildMerchantMapHref(1128, 1, 2)).toBe("/map?merchant=1128#18/1/2");
+	});
+
+	it("regression: the pre-#1019 hash format leaves the merchant unreadable", () => {
+		// `#z/lat/lng&merchant=…` leaves the query string empty, so
+		// parseMerchantHash returns null — the exact reason the old
+		// "View on main map" link selected nothing.
+		setLocationFromHref("/map#18/32.6489863/-16.9101835&merchant=1128");
+		expect(parseMerchantHash().merchantId).toBeNull();
+		// The viewport still parses, which is why the map opened at the right
+		// place but with no marker selected or drawer open.
+		expect(parseHashCoords()).toMatchObject({
+			lat: 32.6489863,
+			lng: -16.9101835,
 		});
 	});
 });

--- a/src/lib/merchantDrawerHash.ts
+++ b/src/lib/merchantDrawerHash.ts
@@ -81,5 +81,8 @@ export function buildMerchantMapHref(
 	lng: number,
 	zoom = 18,
 ): string {
-	return `/map?merchant=${merchantId}#${zoom}/${lat}/${lng}`;
+	// Encode the id so a non-numeric/crafted id can never split into extra
+	// query params or break the URL. Place ids are numeric today (so this
+	// encodes to itself), making it purely defensive.
+	return `/map?merchant=${encodeURIComponent(String(merchantId))}#${zoom}/${lat}/${lng}`;
 }

--- a/src/lib/merchantDrawerHash.ts
+++ b/src/lib/merchantDrawerHash.ts
@@ -67,3 +67,19 @@ export function updateMerchantHash(
 	history.pushState(null, "", url.toString());
 	window.dispatchEvent(new Event(MERCHANT_URL_CHANGE_EVENT));
 }
+
+// Canonical /map deep link to a single merchant. The merchant id goes in the
+// query string (read by parseMerchantHash above and by the server-side
+// OG-image loader in map/+page.server.ts), while the viewport goes in the hash
+// (read by parseHashCoords in $lib/map/mapHash). Both readers must agree with
+// this format — the round-trip is covered in merchantDrawerHash.test.ts. Do
+// NOT move the merchant into the hash: the fragment is never sent to the
+// server, and parseMerchantHash only reads window.location.search.
+export function buildMerchantMapHref(
+	merchantId: number | string,
+	lat: number,
+	lng: number,
+	zoom = 18,
+): string {
+	return `/map?merchant=${merchantId}#${zoom}/${lat}/${lng}`;
+}

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -52,6 +52,8 @@ import {
 	ensureSpritesForPlaces,
 	installPlaceholderHandler,
 	loadSvgImage,
+	PIN_FILL_BOOSTED,
+	PIN_FILL_REGULAR,
 } from "$lib/map/maplibreSprites";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
 import {
@@ -257,20 +259,29 @@ const syncSelectionPulse = (selectedId: number | null) => {
 		pulsePinId = null;
 		return;
 	}
-	if (pulsePinId === selectedId && pulseMarker) return; // already placed
 	const place = get(placesById).get(selectedId);
 	if (!place) return; // not loaded yet
+	const isNewSelection = pulsePinId !== selectedId;
 	if (!pulseMarker) {
 		pulseMarker = new maplibreNs.Marker({
 			element: buildPulseElement(),
 			anchor: "center",
 		});
 	}
-	const color = isBoosted(place) ? "#F7931A" : "#0E95AF";
+	// Keep colour + position in sync with the place even when the selection is
+	// unchanged: boosting from the drawer recolours the pin (teal → orange) and
+	// fires the $places reactive, and the pulse must follow. setProperty,
+	// setLngLat and addTo are idempotent on an already-added marker, so this
+	// stays cheap on every $places tick. Colours come from the same source of
+	// truth as the GL pin sprite so the two can't desync.
+	const color = isBoosted(place) ? PIN_FILL_BOOSTED : PIN_FILL_REGULAR;
 	pulseMarker.getElement().style.setProperty("--bm-pulse-color", color);
 	pulseMarker.setLngLat([place.lon, place.lat]).addTo(map);
 	pulsePinId = selectedId;
-	updatePulseVisibility();
+	// Reconcile cluster-based visibility only on a real selection change;
+	// moveend/idle handle it thereafter (avoids a querySourceFeatures per
+	// $places tick).
+	if (isNewSelection) updatePulseVisibility();
 };
 
 // Reactive zoom level for the panel — drives the "zoom in" prompt and the
@@ -1623,7 +1634,6 @@ onMount(async () => {
 			currentLat = c.lat;
 			currentLon = c.lng;
 			debouncedUpdateMerchantList();
-			updatePulseVisibility();
 		});
 
 		// Tile-loading indicator — debounced to avoid flicker on quick pans.

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -6,7 +6,6 @@ import convex from "@turf/convex";
 import { featureCollection, point } from "@turf/helpers";
 import type { Feature, FeatureCollection, Point, Polygon } from "geojson";
 import type {
-	ExpressionSpecification,
 	FilterSpecification,
 	GeoJSONSource,
 	LngLatBounds,
@@ -195,9 +194,6 @@ const panToPlace = (lat: number, lon: number) => {
 let maplibreNs: typeof import("maplibre-gl") | null = null;
 let pulseMarker: Marker | null = null;
 let pulsePinId: number | null = null; // merchant the pulse overlay is on
-let liftedPinId: number | null | undefined; // merchant the size-lift is applied to
-const PIN_LAYER_IDS = ["unclustered-point", "boosted-point"];
-const SELECTED_PIN_SCALE = 1.3;
 
 const buildPulseElement = (): HTMLDivElement => {
 	const el = document.createElement("div");
@@ -208,23 +204,6 @@ const buildPulseElement = (): HTMLDivElement => {
 		'<span class="bm-pulse-ring bm-pulse-ring--delay"></span>' +
 		'<span class="bm-pulse-dot"></span>';
 	return el;
-};
-
-// Lift the selected pin above its neighbours via icon-size. Applied once per
-// selection change (icon-size is a layout property) to avoid relayout churn.
-const setSelectedPinLift = (selectedId: number | null) => {
-	if (!map) return;
-	const sizeExpr: ExpressionSpecification = [
-		"case",
-		["==", ["get", "id"], selectedId ?? -1],
-		SELECTED_PIN_SCALE,
-		1,
-	];
-	for (const layerId of PIN_LAYER_IDS) {
-		if (map.getLayer(layerId)) {
-			map.setLayoutProperty(layerId, "icon-size", sizeExpr);
-		}
-	}
 };
 
 // Hide the pulse when the selected merchant has been rolled into a cluster at
@@ -806,13 +785,6 @@ $: if (map && styleLoaded && $places) {
 $: if (map && styleLoaded && $lastUpdatedPlaceId) {
 	syncPlacesToSource($places);
 	lastUpdatedPlaceId.set(undefined);
-}
-
-// Lift the selected pin on selection change (guarded so the icon-size relayout
-// runs only when the selected merchant actually changes).
-$: if (map && styleLoaded && $merchantDrawer.merchantId !== liftedPinId) {
-	liftedPinId = $merchantDrawer.merchantId;
-	setSelectedPinLift(liftedPinId);
 }
 
 // Position the locator pulse. Depends on $places too so a deep-linked merchant

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -7,6 +7,7 @@ import { featureCollection, point } from "@turf/helpers";
 import type { Feature, FeatureCollection, Point, Polygon } from "geojson";
 import type {
 	ExpressionSpecification,
+	FilterSpecification,
 	GeoJSONSource,
 	LngLatBounds,
 	MapGeoJSONFeature,
@@ -172,9 +173,15 @@ let latestHullClusterId: number | null = null;
 let deepLinkPanUnsub: (() => void) | null = null;
 let deepLinkPanTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Zoom level that reveals a single selected merchant: just past
+// CLUSTERING_DISABLED_ZOOM (17) so it declusters into its own pin (with the
+// selection pulse on top) rather than being absorbed into a cluster. The
+// DEFAULT_MAP_ZOOM (15) the deep-link pan used to land on still clusters.
+const REVEAL_ZOOM = 17.5;
+
 const panToPlace = (lat: number, lon: number) => {
 	if (!map) return;
-	map.easeTo({ center: [lon, lat], zoom: DEFAULT_MAP_ZOOM, duration: 300 });
+	map.easeTo({ center: [lon, lat], zoom: REVEAL_ZOOM, duration: 300 });
 };
 
 // Selected-merchant highlight (design "C — centered pulsing locator"): the GL
@@ -218,6 +225,27 @@ const setSelectedPinLift = (selectedId: number | null) => {
 	}
 };
 
+// Hide the pulse when the selected merchant has been rolled into a cluster at
+// the current zoom (there's no individual pin to sit on, so the pulse would
+// float orphaned); show it again once the pin renders individually. The
+// regular `places` source clusters; the boosted source never does. We query
+// the live source state rather than a zoom threshold — whether a point
+// clusters depends on its neighbours, not just the zoom level.
+const updatePulseVisibility = () => {
+	if (!map || !pulseMarker || pulsePinId === null) return;
+	const place = get(placesById).get(pulsePinId);
+	let visible = true;
+	if (place && !isBoosted(place)) {
+		const filter: FilterSpecification = [
+			"all",
+			["!", ["has", "point_count"]],
+			["==", ["get", "id"], pulsePinId],
+		];
+		visible = map.querySourceFeatures("places", { filter }).length > 0;
+	}
+	pulseMarker.getElement().style.display = visible ? "" : "none";
+};
+
 // Show / move / hide the locator pulse for the selected merchant. Needs the
 // place's coordinates, so it no-ops until the place is in $placesById — a
 // deep-linked merchant gets its pulse once places sync in (the reactive below
@@ -242,6 +270,7 @@ const syncSelectionPulse = (selectedId: number | null) => {
 	pulseMarker.getElement().style.setProperty("--bm-pulse-color", color);
 	pulseMarker.setLngLat([place.lon, place.lat]).addTo(map);
 	pulsePinId = selectedId;
+	updatePulseVisibility();
 };
 
 // Reactive zoom level for the panel — drives the "zoom in" prompt and the
@@ -396,7 +425,19 @@ const debouncedUpdateMerchantList = debounce(
 
 const panToNearbyMerchant = (place: Place) => {
 	if (!map) return;
-	map.easeTo({ center: [place.lon, place.lat], duration: 300 });
+	// Below the clustering threshold the picked merchant may be absorbed into a
+	// cluster, leaving the selection pulse floating with no pin under it. Zoom
+	// past the threshold to reveal its individual pin (same intent as
+	// zoomToSearchResult); once we're already zoomed in, just pan.
+	if (map.getZoom() < CLUSTERING_DISABLED_ZOOM) {
+		map.easeTo({
+			center: [place.lon, place.lat],
+			zoom: REVEAL_ZOOM,
+			duration: 400,
+		});
+	} else {
+		map.easeTo({ center: [place.lon, place.lat], duration: 300 });
+	}
 };
 
 const zoomToSearchResult = (place: Place) => {
@@ -1582,6 +1623,7 @@ onMount(async () => {
 			currentLat = c.lat;
 			currentLon = c.lng;
 			debouncedUpdateMerchantList();
+			updatePulseVisibility();
 		});
 
 		// Tile-loading indicator — debounced to avoid flicker on quick pans.
@@ -1606,6 +1648,9 @@ onMount(async () => {
 			}
 			tilesLoading = false;
 			mapTilesLoaded = true;
+			// Clustering is settled on idle — reconcile the pulse with whether the
+			// selected pin is currently rendered individually or inside a cluster.
+			updatePulseVisibility();
 		});
 
 		// Persist viewport in the URL hash. Preserves any merchant=… params
@@ -1652,11 +1697,14 @@ onMount(async () => {
 		window.addEventListener(MERCHANT_URL_CHANGE_EVENT, handleHashChange);
 		window.addEventListener("popstate", handleHashChange);
 
-		// Deep link: URL had a merchant= param but the hash carried no
-		// viewport coords. Pan the camera to the merchant once it's in the
-		// places store. If places are still loading, subscribe and wait —
-		// 10s safety unsubscribe so we never leak.
-		if (!hashCoords) {
+		// Deep link: the URL selected a merchant. Reveal it as an individual
+		// pin — pan/zoom to it once it's in the places store — when the URL
+		// carried no viewport, OR carried one whose zoom is below the clustering
+		// threshold (where the pin would be absorbed into a cluster, leaving the
+		// selection pulse floating with nothing under it). A hash zoom at/above
+		// the threshold is honoured as-is. If places are still loading,
+		// subscribe and wait — 10s safety unsubscribe so we never leak.
+		if (!hashCoords || hashCoords.zoom < CLUSTERING_DISABLED_ZOOM) {
 			const { merchantId, isOpen } = parseMerchantHash();
 			if (isOpen && merchantId) {
 				const place = get(placesById).get(merchantId);

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -6,11 +6,13 @@ import convex from "@turf/convex";
 import { featureCollection, point } from "@turf/helpers";
 import type { Feature, FeatureCollection, Point, Polygon } from "geojson";
 import type {
+	ExpressionSpecification,
 	GeoJSONSource,
 	LngLatBounds,
 	MapGeoJSONFeature,
 	MapLayerMouseEvent,
 	Map as MapLibreMap,
+	Marker,
 } from "maplibre-gl";
 import { onDestroy, onMount } from "svelte";
 import { get } from "svelte/store";
@@ -173,6 +175,73 @@ let deepLinkPanTimer: ReturnType<typeof setTimeout> | null = null;
 const panToPlace = (lat: number, lon: number) => {
 	if (!map) return;
 	map.easeTo({ center: [lon, lat], zoom: DEFAULT_MAP_ZOOM, duration: 300 });
+};
+
+// Selected-merchant highlight (design "C — centered pulsing locator"): the GL
+// pin scales up, and a single DOM overlay marker — a pulsing ring + a center
+// dot in the pin's own hue — sits on the selected pin's geo point. The pulse
+// is pure CSS (composited, honors prefers-reduced-motion), so the GL pin layer
+// stays untouched and fast. `maplibre` is imported dynamically in onMount, so
+// we stash the namespace here to construct the Marker reactively.
+let maplibreNs: typeof import("maplibre-gl") | null = null;
+let pulseMarker: Marker | null = null;
+let pulsePinId: number | null = null; // merchant the pulse overlay is on
+let liftedPinId: number | null | undefined; // merchant the size-lift is applied to
+const PIN_LAYER_IDS = ["unclustered-point", "boosted-point"];
+const SELECTED_PIN_SCALE = 1.3;
+
+const buildPulseElement = (): HTMLDivElement => {
+	const el = document.createElement("div");
+	el.className = "bm-selected-pulse";
+	el.style.pointerEvents = "none";
+	el.innerHTML =
+		'<span class="bm-pulse-ring"></span>' +
+		'<span class="bm-pulse-ring bm-pulse-ring--delay"></span>' +
+		'<span class="bm-pulse-dot"></span>';
+	return el;
+};
+
+// Lift the selected pin above its neighbours via icon-size. Applied once per
+// selection change (icon-size is a layout property) to avoid relayout churn.
+const setSelectedPinLift = (selectedId: number | null) => {
+	if (!map) return;
+	const sizeExpr: ExpressionSpecification = [
+		"case",
+		["==", ["get", "id"], selectedId ?? -1],
+		SELECTED_PIN_SCALE,
+		1,
+	];
+	for (const layerId of PIN_LAYER_IDS) {
+		if (map.getLayer(layerId)) {
+			map.setLayoutProperty(layerId, "icon-size", sizeExpr);
+		}
+	}
+};
+
+// Show / move / hide the locator pulse for the selected merchant. Needs the
+// place's coordinates, so it no-ops until the place is in $placesById — a
+// deep-linked merchant gets its pulse once places sync in (the reactive below
+// re-runs on $places).
+const syncSelectionPulse = (selectedId: number | null) => {
+	if (!map || !maplibreNs) return;
+	if (selectedId === null) {
+		pulseMarker?.remove();
+		pulsePinId = null;
+		return;
+	}
+	if (pulsePinId === selectedId && pulseMarker) return; // already placed
+	const place = get(placesById).get(selectedId);
+	if (!place) return; // not loaded yet
+	if (!pulseMarker) {
+		pulseMarker = new maplibreNs.Marker({
+			element: buildPulseElement(),
+			anchor: "center",
+		});
+	}
+	const color = isBoosted(place) ? "#F7931A" : "#0E95AF";
+	pulseMarker.getElement().style.setProperty("--bm-pulse-color", color);
+	pulseMarker.setLngLat([place.lon, place.lat]).addTo(map);
+	pulsePinId = selectedId;
 };
 
 // Reactive zoom level for the panel — drives the "zoom in" prompt and the
@@ -687,6 +756,21 @@ $: if (map && styleLoaded && $lastUpdatedPlaceId) {
 	lastUpdatedPlaceId.set(undefined);
 }
 
+// Lift the selected pin on selection change (guarded so the icon-size relayout
+// runs only when the selected merchant actually changes).
+$: if (map && styleLoaded && $merchantDrawer.merchantId !== liftedPinId) {
+	liftedPinId = $merchantDrawer.merchantId;
+	setSelectedPinLift(liftedPinId);
+}
+
+// Position the locator pulse. Depends on $places too so a deep-linked merchant
+// gets its pulse once the place data syncs in; syncSelectionPulse no-ops when
+// the target is unchanged or not yet loaded.
+$: if (map && styleLoaded) {
+	void $places;
+	syncSelectionPulse($merchantDrawer.merchantId);
+}
+
 // The custom sources + layers we add on top of whatever basemap is
 // active. applyBasemap() carries these across a setStyle() so the pins,
 // clusters, and labels survive a basemap/theme swap untouched (MapLibre's
@@ -769,6 +853,8 @@ onMount(async () => {
 	// User may have navigated away while the dynamic import was in
 	// flight; bail before instantiating against an unmounted container.
 	if (destroyed) return;
+	// Stash the namespace so the selection-pulse helpers can build a Marker.
+	maplibreNs = maplibre;
 
 	// Five basemaps (legacy parity): four vector styles + the OSM raster
 	// style. A stored picker choice wins; otherwise the first-visit default
@@ -1634,6 +1720,8 @@ onDestroy(() => {
 	if (deepLinkPanTimer) clearTimeout(deepLinkPanTimer);
 	deepLinkPanUnsub?.();
 	deepLinkPanUnsub = null;
+	pulseMarker?.remove();
+	pulseMarker = null;
 	if (tilesLoadingTimer) clearTimeout(tilesLoadingTimer);
 	if (tilesLoadingFallback) clearTimeout(tilesLoadingFallback);
 	spiderfier?.unspiderfyAll();

--- a/src/routes/merchant/[id]/components/MerchantHero.svelte
+++ b/src/routes/merchant/[id]/components/MerchantHero.svelte
@@ -2,6 +2,7 @@
 import Icon from "$components/Icon.svelte";
 import SaveButton from "$components/SaveButton.svelte";
 import { _ } from "$lib/i18n";
+import { buildMerchantMapHref } from "$lib/merchantDrawerHash";
 
 import MerchantStaticMap from "./MerchantStaticMap.svelte";
 
@@ -44,7 +45,7 @@ export let deleted = false;
 		{/if}
 
 		<a
-			href={`/map#18/${lat}/${long}&merchant=${id}`}
+			href={buildMerchantMapHref(id, lat, long)}
 			class="absolute top-3 right-3 z-10 inline-flex items-center gap-1 rounded-lg border border-gray-300 bg-white/90 px-2.5 py-1.5 text-xs font-semibold text-primary shadow-sm backdrop-blur transition-colors hover:text-link dark:border-white/20 dark:bg-black/40 dark:text-white"
 		>
 			{$_('info.viewOnMainMap')}


### PR DESCRIPTION

<img width="245" height="236" alt="image" src="https://github.com/user-attachments/assets/17c66df5-92e0-4740-8e50-cca74323c916" />

Started as a fix for the merchant page's "View on main map" deep link, then grew to cover
  the selected-pin highlight and clustering.

  - **Deep link (#966):** the link put the merchant in the URL hash, but the map reads it
  from the query string (since #1019), so nothing got selected. Extracted
  `buildMerchantMapHref()` as the canonical `/map?merchant=…#zoom/lat/lng` link (used by
  `MerchantHero`), refreshed the stale `mapHash.ts` comment, and url-encoded the id.
  - **Selected-pin highlight (#1003):** restored the lost selection cue as a "pulsing
  locator" — a CSS-animated ring + dot in the pin's hue; honors `prefers-reduced-motion`.
  Removed the orphaned Leaflet-era glow CSS.
  - **Clustering (#1003):** selecting a merchant zooms past the cluster threshold to reveal
  its pin, and the pulse hides when the pin is rolled into a cluster (returning when it
  declusters).

  Tests: deep-link round-trip + a regression test for the legacy hash format.

  <!-- This is an auto-generated comment: release notes by coderabbit.ai -->
  ## Summary by CodeRabbit

  * **New Features**
    * Standardized merchant deep-links: merchant ID now in the query string and viewport in
  the URL hash; merchant card “View on main map” uses the canonical link.
    * New selected-merchant visual: a CSS-driven pulsing overlay; map now zooms in to reveal
  an individual pin when deep-linking/selecting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Canonical merchant deep-links: viewport encoded in the URL hash; merchant ID moved to the query string. Merchant card “View on main map” uses this canonical link.
  * Improved selected-merchant visuals: CSS-driven pulsing overlay and behavior that zooms to reveal individual pins when needed.

* **Tests**
  * Added deep-link round-trip tests and a regression test for legacy hash formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->