### PR TITLE
fix(mobile): prevent iOS Safari zoom from clipping merchant drawer 

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -41,7 +41,7 @@
 		<meta name="twitter:site" content="@btcmap" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="msapplication-TileColor" content="#0B9072" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="manifest" href="/btcmap.webmanifest" />
 		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/src/components/SearchInput.svelte
+++ b/src/components/SearchInput.svelte
@@ -30,7 +30,7 @@ export function focus() {
 		type="search"
 		{placeholder}
 		aria-label={ariaLabel}
-		class="w-full border-0 bg-transparent py-3 pr-10 pl-10 text-sm text-primary outline-none placeholder:text-gray-400 dark:text-white dark:placeholder:text-white/50 [&::-webkit-search-cancel-button]:hidden
+		class="w-full border-0 bg-transparent py-3 pr-10 pl-10 text-base text-primary outline-none placeholder:text-gray-400 md:text-sm dark:text-white dark:placeholder:text-white/50 [&::-webkit-search-cancel-button]:hidden
 			{rounded ? 'rounded-lg' : ''}"
 	/>
 	<div class="absolute top-1/2 right-3 -translate-y-1/2">

--- a/src/components/SearchInput.svelte
+++ b/src/components/SearchInput.svelte
@@ -30,7 +30,7 @@ export function focus() {
 		type="search"
 		{placeholder}
 		aria-label={ariaLabel}
-		class="w-full border-0 bg-transparent py-3 pr-10 pl-10 text-base text-primary outline-none placeholder:text-gray-400 md:text-sm dark:text-white dark:placeholder:text-white/50 [&::-webkit-search-cancel-button]:hidden
+		class="w-full border-0 bg-transparent py-3 pr-10 pl-10 text-base text-primary outline-none placeholder:text-gray-400 dark:text-white dark:placeholder:text-white/50 [&::-webkit-search-cancel-button]:hidden
 			{rounded ? 'rounded-lg' : ''}"
 	/>
 	<div class="absolute top-1/2 right-3 -translate-y-1/2">


### PR DESCRIPTION
Fixes: #1049

##  Problem

  On iOS Safari only, the mobile merchant drawer appears clipped on the right edge after using the map search — long opening hours, the last action button, the boost card, and comments all
  get cut off (see reporter screenshots). Chrome DevTools mobile emulation and Android render it fine.

###  Root cause

  Not a flexbox/long-text problem — it's iOS Safari's auto-zoom on input focus:

  1. The search input (SearchInput.svelte) used text-sm (14px). iOS Safari zooms the page in whenever a text input smaller than 16px is focused.
  2. The viewport meta (app.html) was width=device-width with no initial-scale=1, so iOS never resets the zoom afterward.

  So: tap search → iOS zooms in → tap a result → the drawer opens while still zoomed → the visual viewport is now narrower than the 390px layout, pushing the right edge of all full-width
  content off-screen. Short left-aligned content (name, address, phone) stays visible, which matches the screenshots exactly.

  Chrome and Android don't apply the focus-zoom heuristic, which is why it only reproduced on iOS.

 ## Fix

  - SearchInput.svelte: text-sm → text-base md:text-sm — 16px on mobile (stops the zoom), 14px preserved on desktop. Covers both map search entry points (floating bar + panel) since they
  share this component.
  - app.html: viewport → width=device-width, initial-scale=1 for a predictable initial scale.

  Used the accessibility-safe approach (16px inputs) rather than maximum-scale=1 / user-scalable=no, which would disable pinch-zoom.

  ## Verification

  - Reproduced and diagnosed with a Playwright WebKit vs Chromium harness: the drawer's CSS lays out perfectly at 320/360/375/390px in both engines (hours-span min-content is only 43px and
  wraps fine) — confirming the layout was never the issue.
  - After the fix, a fresh WebKit run confirms the search input is 16px on mobile (no zoom) and 14px on desktop; viewport meta includes initial-scale=1.
  - pnpm run check, lint, format:fix clean; 370/370 unit tests pass.

  ## Notes

  - Three other inputs share the same latent issue (LeaderboardSearch, IssuesTable, auth BackupCredentials); left out of scope here — can follow up if wanted.
  - Worth a final sanity check on a real iPhone, though the mechanism and conditions are definitive.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved viewport configuration for more consistent initial page scaling across devices, reducing unexpected zooming on load.
  * Adjusted search input text sizing to use a slightly larger default font and switch to a smaller size on medium screens, enhancing readability and responsive layout balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->