### PR TITLE
fix(meta): reword social description tagline

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "btcmap",
 	"version": "1.0.0",
 	"private": true,
-	"description": "Easily find places to spend sats anywhere on the planet.",
+	"description": "Find places to spend sats wherever you are.",
 	"repository": "https://github.com/teambtcmap/btcmap.org",
 	"author": "secondl1ght <secondl1ght@protonmail.com>",
 	"license": "AGPL-3.0",

--- a/src/app.html
+++ b/src/app.html
@@ -41,6 +41,8 @@
 		<meta property="og:site_name" content="BTC Map" />
 		<meta name="twitter:site" content="@btcmap" />
 		<meta name="twitter:card" content="summary_large_image" />
+		<meta property="og:image:alt" content="BTC Map - Find places to spend sats wherever you are." />
+		<meta name="twitter:image:alt" content="BTC Map - Find places to spend sats wherever you are." />
 		<meta name="msapplication-TileColor" content="#0B9072" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="manifest" href="/btcmap.webmanifest" />

--- a/src/app.html
+++ b/src/app.html
@@ -41,8 +41,6 @@
 		<meta property="og:site_name" content="BTC Map" />
 		<meta name="twitter:site" content="@btcmap" />
 		<meta name="twitter:card" content="summary_large_image" />
-		<meta property="og:image:alt" content="BTC Map - Find places to spend sats wherever you are." />
-		<meta name="twitter:image:alt" content="BTC Map - Find places to spend sats wherever you are." />
 		<meta name="msapplication-TileColor" content="#0B9072" />
 		<meta name="viewport" content="width=device-width" />
 		<link rel="manifest" href="/btcmap.webmanifest" />

--- a/src/app.html
+++ b/src/app.html
@@ -38,6 +38,7 @@
 		<meta name="keywords" content="bitcoin, open source, map" />
 		<meta name="author" content="BTC Map" />
 		<meta property="og:type" content="website" />
+		<meta property="og:site_name" content="BTC Map" />
 		<meta name="twitter:site" content="@btcmap" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="msapplication-TileColor" content="#0B9072" />

--- a/src/error.html
+++ b/src/error.html
@@ -15,10 +15,10 @@
 		<meta name="keywords" content="bitcoin, open source, map" />
 		<meta name="author" content="BTC Map" />
 		<meta property="og:type" content="website" />
-		<meta name="description" content="Easily find places to spend sats anywhere on the planet." />
+		<meta name="description" content="Find places to spend sats wherever you are." />
 		<meta
 			name="twitter:description"
-			content="Easily find places to spend sats anywhere on the planet."
+			content="Find places to spend sats wherever you are."
 		/>
 		<meta name="twitter:site" content="@btcmap" />
 		<meta name="twitter:card" content="summary_large_image" />

--- a/src/error.html
+++ b/src/error.html
@@ -16,6 +16,7 @@
 		<meta name="author" content="BTC Map" />
 		<meta property="og:type" content="website" />
 		<meta name="description" content="Find places to spend sats wherever you are." />
+		<meta property="og:description" content="Find places to spend sats wherever you are." />
 		<meta
 			name="twitter:description"
 			content="Find places to spend sats wherever you are."

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -111,11 +111,11 @@ export let data;
 	{#if !data.pathname.startsWith('/community/') && !data.pathname.startsWith('/country/')}
 		<meta
 			name="description"
-			content="Easily find places to spend sats anywhere on the planet."
+			content="Find places to spend sats wherever you are."
 		/>
 		<meta
 			name="twitter:description"
-			content="Easily find places to spend sats anywhere on the planet."
+			content="Find places to spend sats wherever you are."
 		/>
 	{/if}
 	{#if ['/map', '/communities/map'].includes(data.pathname)}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -117,6 +117,10 @@ export let data;
 			name="twitter:description"
 			content="Find places to spend sats wherever you are."
 		/>
+		<meta
+			property="og:description"
+			content="Find places to spend sats wherever you are."
+		/>
 	{/if}
 	{#if ['/map', '/communities/map'].includes(data.pathname)}
 		<!-- Fullscreen map routes have no scrollbar; skip the reserved gutter so the map fills the viewport -->

--- a/src/routes/license/+page.svelte
+++ b/src/routes/license/+page.svelte
@@ -13,7 +13,7 @@ import { _ } from "$lib/i18n";
 
 <div class="mx-auto mt-10 mb-20 max-w-4xl space-y-5 text-body dark:text-white">
 	<p class="text-center font-semibold text-primary dark:text-white">
-		BTC Map - Easily find places to spend sats anywhere on the planet.
+		BTC Map - Find places to spend sats wherever you are.
 		<br />
 		Copyright &#169; 2022-{new Date().getFullYear()} BTC Map
 		<br />

--- a/static/btcmap.webmanifest
+++ b/static/btcmap.webmanifest
@@ -1,7 +1,7 @@
 {
 	"name": "BTC Map",
 	"short_name": "BTC Map",
-	"description": "Easily find places to spend sats anywhere on the planet.",
+	"description": "Find places to spend sats wherever you are.",
 	"scope": "/",
 	"start_url": "/map",
 	"display": "standalone",

--- a/static/offline.html
+++ b/static/offline.html
@@ -16,6 +16,7 @@
 		<meta name="author" content="BTC Map" />
 		<meta property="og:type" content="website" />
 		<meta name="description" content="Find places to spend sats wherever you are." />
+		<meta property="og:description" content="Find places to spend sats wherever you are." />
 		<meta
 			property="twitter:description"
 			content="Find places to spend sats wherever you are."

--- a/static/offline.html
+++ b/static/offline.html
@@ -18,11 +18,11 @@
 		<meta name="description" content="Find places to spend sats wherever you are." />
 		<meta property="og:description" content="Find places to spend sats wherever you are." />
 		<meta
-			property="twitter:description"
+			name="twitter:description"
 			content="Find places to spend sats wherever you are."
 		/>
-		<meta property="twitter:site" content="@btcmap" />
-		<meta property="twitter:card" content="summary_large_image" />
+		<meta name="twitter:site" content="@btcmap" />
+		<meta name="twitter:card" content="summary_large_image" />
 		<meta charset="utf-8" />
 		<meta name="msapplication-TileColor" content="#0B9072" />
 		<meta name="viewport" content="width=device-width" />
@@ -3774,8 +3774,8 @@ Constrain images and videos to the parent width and preserve their intrinsic asp
 		<!-- HEAD_svelte-12p4y40_END -->
 		<!-- HEAD_svelte-1gr44ch_START -->
 		<meta property="og:image" content="https://btcmap.org/images/og/home.png" />
-		<meta property="twitter:title" content="BTC Map" />
-		<meta property="twitter:image" content="https://btcmap.org/images/og/home.png" />
+		<meta name="twitter:title" content="BTC Map" />
+		<meta name="twitter:image" content="https://btcmap.org/images/og/home.png" />
 		<!-- HEAD_svelte-1gr44ch_END -->
 	</head>
 	<body class="bg-teal dark:bg-dark">

--- a/static/offline.html
+++ b/static/offline.html
@@ -15,10 +15,10 @@
 		<meta name="keywords" content="bitcoin, open source, map" />
 		<meta name="author" content="BTC Map" />
 		<meta property="og:type" content="website" />
-		<meta name="description" content="Easily find places to spend sats anywhere on the planet." />
+		<meta name="description" content="Find places to spend sats wherever you are." />
 		<meta
 			property="twitter:description"
-			content="Easily find places to spend sats anywhere on the planet."
+			content="Find places to spend sats wherever you are."
 		/>
 		<meta property="twitter:site" content="@btcmap" />
 		<meta property="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
Change the meta/social description from "Easily find places to spend sats anywhere on the planet." to "Find places to spend sats wherever you are." across the global layout head, the static error fallback page, and the license page footer copy.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the site tagline to "Find places to spend sats wherever you are" across pages, offline/error screens, manifest, and license/info content for consistent messaging.
  * Improved social preview metadata (Open Graph and Twitter tags), including adding site name and aligning descriptions for better link previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->