### PR TITLE
fix(map): improve nearby button reveal the list UX

### DIFF
--- a/src/routes/map/components/MapSearchBar.svelte
+++ b/src/routes/map/components/MapSearchBar.svelte
@@ -133,11 +133,12 @@ function handleClear() {
 				role="radio"
 				aria-checked={mode === 'nearby'}
 				on:click={() => handleModeSwitch('nearby')}
-				class="rounded-full px-4 py-2.5 text-sm font-medium shadow-sm transition-colors md:px-3 md:py-1.5 md:text-xs
+				class="inline-flex items-center gap-1.5 rounded-full px-4 py-2.5 text-sm font-medium shadow-sm transition-colors md:px-3 md:py-1.5 md:text-xs
 					{mode === 'nearby'
 					? 'bg-link text-white'
 					: 'bg-white text-gray-600 hover:bg-gray-50 dark:bg-dark dark:text-white/70 dark:hover:bg-gray-700'}"
 			>
+				<Icon type="fa" icon="list" w="14" h="14" />
 				{$_('search.nearby')}{#if isLoadingCount}<span class="opacity-60">
 						...</span
 					>{:else if formattedCount}

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -261,11 +261,6 @@ $: if (browser && isOpen !== undefined) {
 	}
 }
 
-// Focus search input when panel opens (always, since we now have unified search)
-$: if (browser && isOpen && searchInputComponent) {
-	tick().then(() => searchInputComponent?.focus());
-}
-
 function handleItemClick(place: Place) {
 	trackEvent("merchant_list_item_click", { mode });
 	merchantDrawer.open(place.id, "details");
@@ -415,11 +410,12 @@ onDestroy(() => {
 					role="radio"
 					on:click={() => handleModeSwitch('nearby')}
 					aria-checked={mode === 'nearby'}
-					class="flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors
+					class="flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors
 						{mode === 'nearby'
 						? 'bg-white text-primary shadow-sm dark:bg-white/10 dark:text-white'
 						: 'text-body hover:text-primary dark:text-white/70 dark:hover:text-white'}"
 				>
+					<Icon type="fa" icon="list" w="14" h="14" />
 					{$_('search.nearby')}{#if isLoadingList}<span class="opacity-60">
 							...</span
 						>{:else}{formatNearbyCount(totalCount)}{/if}


### PR DESCRIPTION
...and stop mobile keyboard covering it

Add a list icon to the Nearby pill (floating bar + panel header) so it reads as a list trigger rather than a plain mode toggle, improving discoverability.

Only autofocus the panel search input on desktop (>= md breakpoint); on mobile the keyboard no longer pops up and covers the merchant list the moment it opens.


<img width="417" height="714" alt="image" src="https://github.com/user-attachments/assets/128f3304-bd13-4a12-8a04-fcf9516271ff" />
<img width="393" height="703" alt="image" src="https://github.com/user-attachments/assets/e44709e2-feb2-4a7d-9b62-6bb794349436" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Focus behavior adjusted so the search input only auto-focuses on larger (desktop) screens.

* **Style**
  * Added list icons to Nearby/navigation controls.
  * Updated Nearby toggle/button layout and spacing for improved alignment and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->