### PR TITLE
feat(map): nearby list earlier

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,8 +41,8 @@ export const MAP_FIT_BOUNDS_PADDING = 50;
 
 // MERCHANT LIST ZOOM BEHAVIOR:
 // ┌─────────────────────────────────────────────────────────────────────────┐
-// │ Zoom < 11  │ No data shown - "zoom in" message                          │
-// │ Zoom 11-14 │ API search with 1.5x radius, max 99 results                │
+// │ Zoom < 10  │ No data shown - "zoom in" message                          │
+// │ Zoom 10-14 │ API search (1.5x radius): nearest 99; "zoom in" if >750     │
 // │ Zoom 15+   │ Use loaded markers with 1.5x bounds, names visible, enrich when open      │
 // └─────────────────────────────────────────────────────────────────────────┘
 // All zoom levels use 1.5x radius multiplier for consistent "nearby" count.
@@ -61,20 +61,26 @@ export const BOOSTED_CLUSTERING_MAX_ZOOM = 5;
 // Fetches enriched Place data (icons, addresses) only when panel is open
 export const MERCHANT_LIST_MIN_ZOOM = 15;
 
-// Zoom 11-14: "Low density" mode - use API search with result limit
-// If results exceed MERCHANT_LIST_MAX_ITEMS, we hide the list and show "zoom in"
-export const MERCHANT_LIST_LOW_ZOOM = 11;
+// Zoom 10-14: "Low density" mode - use API search.
+// Shows the nearest MERCHANT_LIST_MAX_ITEMS; only blanks to "zoom in" when
+// matches exceed MERCHANT_LIST_FETCH_CEILING (a payload guard).
+export const MERCHANT_LIST_LOW_ZOOM = 10;
 
 // Max merchants to display in list and count shown on button
 // When count exceeds this, button shows ">99" and list shows 99 items
 export const MERCHANT_LIST_MAX_ITEMS = 99;
+
+// Payload guard for the low-zoom API search: if more than this many places
+// match, skip rendering and show "zoom in" instead of downloading them all.
+// Distinct from MERCHANT_LIST_MAX_ITEMS (the display/slice cap) and far higher,
+// so dense areas show the nearest 99 rather than blanking.
+export const MERCHANT_LIST_FETCH_CEILING = 750;
 
 // Radius multiplier for "nearby" search (extends beyond viewport for context)
 // Used consistently across all zoom levels for predictable count behavior
 export const NEARBY_RADIUS_MULTIPLIER = 1.5;
 
 // Map viewport marker loading
-export const MAX_LOADED_MARKERS = 200;
 export const VIEWPORT_BATCH_SIZE = 25;
 export const VIEWPORT_BUFFER_PERCENT = 0.2;
 export const MAP_DEBOUNCE_DELAY = 300;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -70,10 +70,12 @@ export const MERCHANT_LIST_LOW_ZOOM = 10;
 // When count exceeds this, button shows ">99" and list shows 99 items
 export const MERCHANT_LIST_MAX_ITEMS = 99;
 
-// Payload guard for the low-zoom API search: if more than this many places
-// match, skip rendering and show "zoom in" instead of downloading them all.
-// Distinct from MERCHANT_LIST_MAX_ITEMS (the display/slice cap) and far higher,
-// so dense areas show the nearest 99 rather than blanking.
+// Relevance/render guard for the low-zoom API search: above this many matches
+// we blank the list and show "zoom in" rather than render an unhelpfully dense
+// set. Applied client-side AFTER the full response is fetched, so it does not
+// reduce the download — a server-side distance-sorted limit would be needed for
+// that. Distinct from MERCHANT_LIST_MAX_ITEMS (the display/slice cap) and far
+// higher, so dense areas show the nearest 99 rather than blanking.
 export const MERCHANT_LIST_FETCH_CEILING = 750;
 
 // Radius multiplier for "nearby" search (extends beyond viewport for context)

--- a/src/lib/map/viewport.test.ts
+++ b/src/lib/map/viewport.test.ts
@@ -15,15 +15,15 @@ const stubBounds = (
 	}) as unknown as LngLatBounds;
 
 describe("getZoomBehavior", () => {
-	it('returns "none" for zoom levels below 11', () => {
+	it('returns "none" for zoom levels below 10', () => {
 		expect(getZoomBehavior(1)).toBe("none");
 		expect(getZoomBehavior(5)).toBe("none");
-		expect(getZoomBehavior(10)).toBe("none");
+		expect(getZoomBehavior(9)).toBe("none");
 	});
 
-	it('returns "api-with-limit" for zoom levels 11-14', () => {
+	it('returns "api-with-limit" for zoom levels 10-14', () => {
+		expect(getZoomBehavior(10)).toBe("api-with-limit");
 		expect(getZoomBehavior(11)).toBe("api-with-limit");
-		expect(getZoomBehavior(12)).toBe("api-with-limit");
 		expect(getZoomBehavior(14)).toBe("api-with-limit");
 	});
 

--- a/src/lib/map/viewport.ts
+++ b/src/lib/map/viewport.ts
@@ -8,8 +8,8 @@ export type ZoomBehavior = "none" | "api-with-limit" | "local-markers";
 // See constants.ts for zoom behavior documentation
 export function getZoomBehavior(zoom: number): ZoomBehavior {
 	if (zoom >= MERCHANT_LIST_MIN_ZOOM) return "local-markers"; // Zoom 15+
-	if (zoom >= MERCHANT_LIST_LOW_ZOOM) return "api-with-limit"; // Zoom 11-14
-	return "none"; // Below zoom 11
+	if (zoom >= MERCHANT_LIST_LOW_ZOOM) return "api-with-limit"; // Zoom 10-14
+	return "none"; // Below zoom 10
 }
 
 // MapLibre-shaped haversine for the enrichment fetch radius. No 10%

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -2,6 +2,7 @@ import { get } from "svelte/store";
 import type { Mock } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { MERCHANT_LIST_FETCH_CEILING } from "$lib/constants";
 import type { Place } from "$lib/types";
 
 // Mock the centralized axios instance
@@ -358,6 +359,37 @@ describe("merchantListStore", () => {
 
 			expect(state.merchants).toEqual([]);
 			expect(state.totalCount).toBe(60);
+		});
+
+		it("shows nearest items when matches are under the fetch ceiling", async () => {
+			const mockPlaces = Array.from({ length: 150 }, (_, i) =>
+				createMockPlace({ id: i }),
+			);
+			(api.get as Mock).mockResolvedValueOnce({ data: mockPlaces });
+
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10, {
+				hideIfExceeds: MERCHANT_LIST_FETCH_CEILING,
+			});
+			const state = get(merchantList);
+
+			expect(state.merchants.length).toBe(99); // MERCHANT_LIST_MAX_ITEMS
+			expect(state.totalCount).toBe(150);
+		});
+
+		it("blanks the list when matches exceed the fetch ceiling", async () => {
+			const mockPlaces = Array.from(
+				{ length: MERCHANT_LIST_FETCH_CEILING + 1 },
+				(_, i) => createMockPlace({ id: i }),
+			);
+			(api.get as Mock).mockResolvedValueOnce({ data: mockPlaces });
+
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10, {
+				hideIfExceeds: MERCHANT_LIST_FETCH_CEILING,
+			});
+			const state = get(merchantList);
+
+			expect(state.merchants).toEqual([]);
+			expect(state.totalCount).toBe(MERCHANT_LIST_FETCH_CEILING + 1);
 		});
 
 		it("should store totalCount even when hiding results", async () => {

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -209,7 +209,7 @@ function createMerchantListStore() {
 		},
 
 		// Fetch merchants from API and replace the current list
-		// Used at high zoom (17+) and low zoom (11-14) where we can't rely on loaded markers
+		// Used at high zoom (17+) and low zoom (10-14) where we can't rely on loaded markers
 		// hideIfExceeds: if API returns more than this, clear the list (shows "zoom in" message)
 		async fetchAndReplaceList(
 			center: { lat: number; lon: number },
@@ -292,7 +292,7 @@ function createMerchantListStore() {
 		},
 
 		// Fetch only IDs to get count (minimal payload for button badge)
-		// Used at zoom 11-14 when panel is closed - avoids fetching full data unnecessarily
+		// Used at zoom 10-14 when panel is closed - avoids fetching full data unnecessarily
 		async fetchCountOnly(
 			center: { lat: number; lon: number },
 			radiusKm: number,

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -29,7 +29,7 @@ import {
 	DEFAULT_MAP_ZOOM,
 	LABEL_VISIBLE_ZOOM,
 	MAP_DEBOUNCE_DELAY,
-	MERCHANT_LIST_MAX_ITEMS,
+	MERCHANT_LIST_FETCH_CEILING,
 	MERCHANT_LIST_MIN_ZOOM,
 	NEARBY_RADIUS_MULTIPLIER,
 } from "$lib/constants";
@@ -394,7 +394,7 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 			break;
 		}
 		case "api-with-limit": {
-			// Zoom 11-14: API search; count-only when panel is closed.
+			// Zoom 10-14: API search; count-only when panel is closed.
 			const radiusKm =
 				calculateRadiusKmFromLngLatBounds(bounds) * NEARBY_RADIUS_MULTIPLIER;
 			if (!listOpen || !allowHeavyFetch) {
@@ -406,7 +406,7 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 				merchantList.fetchAndReplaceList(
 					{ lat: center.lat, lon: center.lng },
 					radiusKm,
-					{ hideIfExceeds: MERCHANT_LIST_MAX_ITEMS },
+					{ hideIfExceeds: MERCHANT_LIST_FETCH_CEILING },
 				);
 			}
 			break;

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -12,11 +12,7 @@ import {
 	type CategoryKey,
 	placeMatchesCategory,
 } from "$lib/categoryMapping";
-import {
-	BREAKPOINTS,
-	MERCHANT_LIST_LOW_ZOOM,
-	MERCHANT_LIST_MIN_ZOOM,
-} from "$lib/constants";
+import { BREAKPOINTS, MERCHANT_LIST_LOW_ZOOM } from "$lib/constants";
 import { _ } from "$lib/i18n";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import type { MerchantListMode } from "$lib/merchantListStore";
@@ -240,12 +236,15 @@ function getCategoryButtonClass(
 	return "cursor-not-allowed bg-gray-100 text-gray-400 dark:bg-white/5 dark:text-white/30";
 }
 
-// Show "zoom in" message when:
-// 1. Below zoom 11 (always - no data fetched at this level)
-// 2. Between zoom 11-14 with no merchants (too many results in dense area)
+// Show "zoom in" prompt when:
+// 1. Below the list floor (no data fetched at this zoom)
+// 2. Results were blanked because the area is too dense (>fetch ceiling):
+//    an empty list but a non-zero total count
+// A genuinely empty area (totalCount === 0) falls through to the
+// "No merchants visible in current view" body state instead.
 $: showZoomInMessage =
 	currentZoom < MERCHANT_LIST_LOW_ZOOM ||
-	(currentZoom < MERCHANT_LIST_MIN_ZOOM && merchants.length === 0);
+	(merchants.length === 0 && totalCount > 0);
 $: isTruncated = totalCount > merchants.length;
 
 // Body scroll lock on mobile when panel is open

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -578,8 +578,9 @@ onDestroy(() => {
 						{/each}
 					</ul>
 				{/if}
-			{:else if showZoomInMessage}
-				<!-- Nearby mode: clickable zoom in prompt -->
+			{:else if showZoomInMessage && !isLoadingList}
+				<!-- Nearby mode: clickable zoom in prompt (loading spinner takes
+				     precedence so a stale count-only state can't flash this) -->
 				<button
 					type="button"
 					on:click={handleZoomToNearbyLevel}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented a search result density limit of 750 matches: when exceeded, the merchant list is hidden with a prompt to zoom in for more focused search results.
  * Extended merchant search availability across zoom levels 10-14.
  * Improved "zoom in" messaging to appear when search results exceed the density threshold, providing clearer guidance for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->