### PR TITLE
fix(layout): reserve safe-area bottom clearance so footer  

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -42,7 +42,7 @@
 		<meta name="twitter:site" content="@btcmap" />
 		<meta name="twitter:card" content="summary_large_image" />
 		<meta name="msapplication-TileColor" content="#0B9072" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<link rel="manifest" href="/btcmap.webmanifest" />
 		<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/src/components/Boost.svelte
+++ b/src/components/Boost.svelte
@@ -33,7 +33,7 @@ const handleBoostComplete = () => {
 	<OutClick on:outclick={handleOutClick}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
-			class="center-fixed z-[2000] max-h-[90vh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:w-[430px] dark:border-white/95 dark:bg-dark"
+			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:w-[430px] dark:border-white/95 dark:bg-dark"
 		>
 			<CloseButton on:click={closeModal} />
 

--- a/src/components/Modal.svelte
+++ b/src/components/Modal.svelte
@@ -66,7 +66,7 @@ export function setTrigger(el: HTMLElement) {
 		role="dialog"
 		aria-modal="true"
 		aria-labelledby={titleId}
-		class="fixed inset-x-4 bottom-4 z-[2000] flex max-h-[85dvh] flex-col overflow-hidden rounded-2xl border border-gray-300 bg-white px-5 py-5 shadow-2xl dark:border-white/95 dark:bg-dark sm:inset-auto sm:top-1/2 sm:left-1/2 sm:h-auto sm:w-80 sm:max-h-[90vh] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-xl sm:px-6 sm:py-6"
+		class="fixed inset-x-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-[2000] flex max-h-[85dvh] flex-col overflow-hidden rounded-2xl border border-gray-300 bg-white px-5 py-5 shadow-2xl dark:border-white/95 dark:bg-dark sm:inset-auto sm:top-1/2 sm:left-1/2 sm:h-auto sm:w-80 sm:max-h-[90dvh] sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-xl sm:px-6 sm:py-6"
 	>
 		<div class="mb-4 flex items-center justify-between">
 			<h2 id={titleId} class="text-lg font-semibold text-primary dark:text-white">

--- a/src/components/ShowTags.svelte
+++ b/src/components/ShowTags.svelte
@@ -12,7 +12,7 @@ const closeModal = () => ($showTags = undefined);
 	<OutClick excludeQuerySelectorAll="#show-tags" on:outclick={closeModal}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
-			class="center-fixed z-[2000] max-h-[90vh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:h-[400px] md:w-[430px] dark:border-white/95 dark:bg-dark"
+			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:h-[400px] md:w-[430px] dark:border-white/95 dark:bg-dark"
 		>
 			<CloseButton on:click={closeModal} />
 

--- a/src/components/TaggingIssues.svelte
+++ b/src/components/TaggingIssues.svelte
@@ -17,7 +17,7 @@ const closeModal = () => ($taggingIssues = undefined);
 	<OutClick excludeQuerySelectorAll="#tagging-issues" on:outclick={closeModal}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
-			class="center-fixed z-[2000] max-h-[90vh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:h-[400px] md:w-[430px] dark:border-white/95 dark:bg-dark"
+			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:h-[400px] md:w-[430px] dark:border-white/95 dark:bg-dark"
 		>
 			<CloseButton on:click={closeModal} />
 

--- a/src/components/layout/Footer.svelte
+++ b/src/components/layout/Footer.svelte
@@ -35,7 +35,7 @@ const rightLinks = [
 ];
 </script>
 
-<footer class="mx-auto w-full max-w-6xl items-center justify-between space-y-5 pb-5 xl:flex xl:items-start xl:space-y-0">
+<footer class="mx-auto w-full max-w-6xl items-center justify-between space-y-5 pb-[max(3rem,env(safe-area-inset-bottom))] xl:flex xl:items-start xl:space-y-0">
 	<div class="flex flex-wrap justify-center gap-5 xl:block xl:space-x-5">
 		<SocialLink url={$socials.matrix} social="matrix" />
 		<SocialLink url={$socials.github} social="github" />

--- a/src/components/layout/Header.svelte
+++ b/src/components/layout/Header.svelte
@@ -227,7 +227,7 @@ afterNavigate(() => {
 	<nav
 		class="hide-scroll absolute top-[122.45px] z-30 {showMobileMenu
 			? 'left-0'
-			: 'left-[-100%]'} h-[calc(100dvh-122.45px)] w-full space-y-2 overflow-y-auto border-t border-[#BDD2D4] bg-teal p-8 transition-all ease-in-out dark:bg-dark"
+			: 'left-[-100%]'} h-[calc(100dvh-122.45px)] w-full space-y-2 overflow-y-auto border-t border-[#BDD2D4] bg-teal px-8 pt-8 pb-[max(3rem,env(safe-area-inset-bottom))] transition-all ease-in-out dark:bg-dark"
 	>
 		{#each navLinks as link (link.id)}
 			<!-- dropdown menu -->

--- a/src/routes/merchant/[id]/components/CommentAdd.svelte
+++ b/src/routes/merchant/[id]/components/CommentAdd.svelte
@@ -94,7 +94,7 @@ const handleStatusCheckError = (error: unknown) => {
 	<OutClick excludeQuerySelectorAll="#boost-button" on:outclick={handleOutClick}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
-			class="center-fixed z-[2000] max-h-[90vh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:w-[430px] dark:border-white/95 dark:bg-dark"
+			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:w-[430px] dark:border-white/95 dark:bg-dark"
 		>
 			<CloseButton
 				position="flex justify-end"


### PR DESCRIPTION
...clears OS taskbar

On devices where the OS taskbar overlays the browser viewport (e.g. Windows tablets), the footer's "Analytics" link was hidden behind the taskbar because the footer only reserved pb-5 (20px) of bottom clearance.

- app.html: add viewport-fit=cover so env(safe-area-inset-*) populates
- Footer: pb-5 -> pb-[max(3rem,env(safe-area-inset-bottom))] (fixed floor clears the taskbar even where Windows reports a 0 safe-area inset; max() avoids double-padding on notched phones)
- Header mobile menu: add matching bottom clearance so the last nav item is reachable
- Modal: bottom-4 -> bottom-[max(1rem,env(safe-area-inset-bottom))], and migrate sm:max-h-[90vh] -> 90dvh
- ShowTags / Boost / TaggingIssues / CommentAdd: max-h-[90vh] -> 90dvh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile device layout support, including better handling of notched displays and safe areas
  * Enhanced modal and viewport height responsiveness on mobile browsers with dynamic UI elements
  * Adjusted spacing on footer and navigation menus for optimized mobile device display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->