### PR TITLE
fix(map): clear desktop drawer & list panel from bottom OS taskbar

### DIFF
--- a/src/routes/map/components/MerchantDrawerDesktop.svelte
+++ b/src/routes/map/components/MerchantDrawerDesktop.svelte
@@ -113,7 +113,7 @@ export function openDrawer(id: number) {
 	<div
 		bind:this={drawerElement}
 		in:fly={{ x: -MERCHANT_DRAWER_WIDTH, duration: 300 }}
-		class="absolute top-3 z-[1002] max-h-[calc(100%-1.5rem)] w-full overflow-y-auto rounded-lg bg-white shadow-lg transition-[left] duration-200 dark:bg-dark"
+		class="absolute top-3 z-[1002] max-h-[calc(100%-0.75rem-max(3rem,env(safe-area-inset-bottom)))] w-full overflow-y-auto rounded-lg bg-white shadow-lg transition-[left] duration-200 dark:bg-dark"
 		style="left: {drawerLeft}px; max-width: {MERCHANT_DRAWER_WIDTH}px"
 		role="dialog"
 		aria-label={$_("mapDrawer.merchantDetails")}

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -340,7 +340,7 @@ onDestroy(() => {
 {#if isOpen}
 	<section
 		bind:this={panelElement}
-		class="pb-safe absolute inset-0 z-[1001] flex flex-col overflow-hidden bg-white md:absolute md:inset-auto md:top-3 md:bottom-4 md:left-3 md:w-80 md:rounded-lg md:pb-0 md:shadow-lg dark:bg-dark dark:shadow-black/30"
+		class="pb-safe absolute inset-0 z-[1001] flex flex-col overflow-hidden bg-white md:absolute md:inset-auto md:top-3 md:bottom-[max(3rem,env(safe-area-inset-bottom))] md:left-3 md:w-80 md:rounded-lg md:pb-0 md:shadow-lg dark:bg-dark dark:shadow-black/30"
 		role="complementary"
 		aria-label={$_('aria.merchantList')}
 	>


### PR DESCRIPTION
The desktop merchant drawer and list panel anchored their bottom edge only ~12-16px above the viewport bottom, so on a Windows tablet in PC Mode the OS taskbar covered the bottom of the drawer and the "See full profile" link was never reachable.

Reserve max(3rem, env(safe-area-inset-bottom)) of bottom clearance on both: env() handles notched phones, and the 3rem floor clears the taskbar on Windows, which reports a 0 safe-area inset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safe-area handling in the merchant drawer and list panel to ensure proper layout positioning on devices with notches or home indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->