### PR TITLE
fix(merchant): preserve line breaks in comments #662

### DIFF
--- a/src/routes/merchant/[id]/components/MerchantComment.svelte
+++ b/src/routes/merchant/[id]/components/MerchantComment.svelte
@@ -35,7 +35,7 @@ export let compact = false;
 	>
 		<div class:space-y-2={!compact} class:space-y-1={compact} class:lg:space-y-0={!compact}>
 			<span
-				class="text-primary dark:text-white"
+				class="whitespace-pre-line text-primary dark:text-white"
 				class:lg:mr-5={!compact}
 			>
 				{text}


### PR DESCRIPTION
Fixes: https://github.com/teambtcmap/btcmap.org/issues/662

Change made:
Render merchant comment text with white-space: pre-line so line breaks entered in the comment textarea are preserved when displayed, instead of being collapsed by the browser's default HTML whitespace rules.

Before:
<img width="900" height="638" alt="before662" src="https://github.com/user-attachments/assets/ee06729b-8932-4cee-a43e-b9fc5b6b7314" />

After:
<img width="900" height="851" alt="after662" src="https://github.com/user-attachments/assets/d56120f1-0df2-4e3d-8c60-bb71b3cb0a00" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved comment text display to properly preserve line breaks and whitespace formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->