### PR TITLE
fix(activity): use BTC Map IDs instead of OSM IDs on Tagging Activity page #492

### DIFF
--- a/src/components/LatestTagger.svelte
+++ b/src/components/LatestTagger.svelte
@@ -12,6 +12,7 @@ export let user: User | undefined = undefined;
 export let time: string;
 export let latest: boolean;
 export let merchantId: string;
+export let placeId: number | undefined = undefined;
 
 $: deleteLink = merchantId.split(":");
 
@@ -53,7 +54,7 @@ $: username = profile?.display_name;
 				<a
 					href={action === 'delete'
 						? `https://www.openstreetmap.org/${deleteLink[0]}/${deleteLink[1]}`
-						: `/merchant/${merchantId}`}
+						: `/merchant/${placeId ?? merchantId}`}
 					target={action === 'delete' ? '_blank' : null}
 					rel={action === 'delete' ? 'noreferrer' : null}
 					class="break-all text-link transition-colors hover:text-hover"

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -340,6 +340,7 @@ export enum TipType {
 export interface ActivityEvent extends Event {
 	location: string;
 	merchantId: string;
+	placeId?: number;
 	tagger?: User;
 }
 

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -54,7 +54,7 @@ const fetchMerchantData = async (
 			`${API_BASE}/v4/places/${encodeURIComponent(elementId)}?fields=id,name&include_deleted=true`,
 		);
 		if (!response.ok) throw new Error("API call failed");
-		const data: Place = await response.json();
+		const data: Pick<Place, "id" | "name"> = await response.json();
 		return { name: data.name || formatElementID(elementId), placeId: data.id };
 	} catch {
 		return { name: formatElementID(elementId) };
@@ -90,19 +90,7 @@ const supertaggerSync = async (
 			};
 		});
 
-		try {
-			supertaggers = await Promise.all(supertaggerPromises);
-		} catch (error) {
-			console.error("Error fetching merchant data:", error);
-			// Fallback: create entries with element IDs only
-			supertaggers = recentEvents.map((event) => ({
-				...event,
-				location: formatElementID(event.element_id),
-				merchantId: event.element_id,
-				placeId: undefined,
-				tagger: findUser(event),
-			}));
-		}
+		supertaggers = await Promise.all(supertaggerPromises);
 
 		elementsLoading = false;
 	}

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -51,7 +51,7 @@ const fetchMerchantData = async (
 ): Promise<{ name: string; placeId?: number }> => {
 	try {
 		const response = await fetch(
-			`${API_BASE}/v4/places/${encodeURIComponent(elementId)}?fields=id,name`,
+			`${API_BASE}/v4/places/${encodeURIComponent(elementId)}?fields=id,name&include_deleted=true`,
 		);
 		if (!response.ok) throw new Error("API call failed");
 		const data = await response.json();
@@ -93,7 +93,7 @@ const supertaggerSync = async (
 		try {
 			supertaggers = await Promise.all(supertaggerPromises);
 		} catch (error) {
-			console.error("Error fetching merchant names:", error);
+			console.error("Error fetching merchant data:", error);
 			// Fallback: create entries with element IDs only
 			supertaggers = recentEvents.map((event) => ({
 				...event,

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -20,7 +20,7 @@ import { batchSync } from "$lib/sync/batchSync";
 import { eventsSync } from "$lib/sync/events";
 import { usersSync } from "$lib/sync/users";
 import { theme } from "$lib/theme";
-import type { ActivityEvent, Event, User } from "$lib/types";
+import type { ActivityEvent, Event, Place, User } from "$lib/types";
 import { errToast, formatElementID } from "$lib/utils";
 
 onMount(() => {
@@ -54,7 +54,7 @@ const fetchMerchantData = async (
 			`${API_BASE}/v4/places/${encodeURIComponent(elementId)}?fields=id,name&include_deleted=true`,
 		);
 		if (!response.ok) throw new Error("API call failed");
-		const data = await response.json();
+		const data: Place = await response.json();
 		return { name: data.name || formatElementID(elementId), placeId: data.id };
 	} catch {
 		return { name: formatElementID(elementId) };

--- a/src/routes/activity/+page.svelte
+++ b/src/routes/activity/+page.svelte
@@ -46,14 +46,18 @@ const findUser = (tagger: Event) => {
 	}
 };
 
-const fetchMerchantName = async (elementId: string): Promise<string> => {
+const fetchMerchantData = async (
+	elementId: string,
+): Promise<{ name: string; placeId?: number }> => {
 	try {
-		const response = await fetch(`${API_BASE}/v2/elements/${elementId}`);
+		const response = await fetch(
+			`${API_BASE}/v4/places/${encodeURIComponent(elementId)}?fields=id,name`,
+		);
 		if (!response.ok) throw new Error("API call failed");
 		const data = await response.json();
-		return data.osm_json?.tags?.name || formatElementID(elementId);
+		return { name: data.name || formatElementID(elementId), placeId: data.id };
 	} catch {
-		return formatElementID(elementId);
+		return { name: formatElementID(elementId) };
 	}
 };
 
@@ -70,15 +74,18 @@ const supertaggerSync = async (
 		elementsLoading = true;
 		supertaggers = [];
 
-		// Fetch merchant names concurrently
+		// Fetch merchant names and BTC Map IDs concurrently
 		const supertaggerPromises = recentEvents.map(async (event) => {
-			const location = await fetchMerchantName(event.element_id);
+			const { name: location, placeId } = await fetchMerchantData(
+				event.element_id,
+			);
 			const tagger = findUser(event);
 
 			return {
 				...event,
 				location,
 				merchantId: event.element_id,
+				placeId,
 				tagger,
 			};
 		});
@@ -92,6 +99,7 @@ const supertaggerSync = async (
 				...event,
 				location: formatElementID(event.element_id),
 				merchantId: event.element_id,
+				placeId: undefined,
 				tagger: findUser(event),
 			}));
 		}
@@ -156,6 +164,7 @@ $: latestTaggers = !!(supertaggers?.length && !elementsLoading);
 							time={tagger['created_at']}
 							latest={tagger === supertaggers[0] ? true : false}
 							merchantId={tagger.merchantId}
+							placeId={tagger.placeId}
 						/>
 					{/each}
 				{:else}


### PR DESCRIPTION
### Fixes: https://github.com/teambtcmap/btcmap.org/issues/492

**Summary**
The Tagging Activity page (/activity) was linking to merchants using OSM element IDs (e.g. /merchant/node:12345678) instead of BTC Map numeric IDs (e.g. /merchant/42)
Replaced fetchMerchantName (called v2/elements) with fetchMerchantData (calls v4/places) to retrieve both the place name and BTC Map numeric ID in one request
Threaded placeId through ActivityEvent and LatestTagger.svelte so non-delete links use the canonical BTC Map ID; delete links continue pointing to OpenStreetMap

**Notes**
This was not a hard crash — the merchant page accepts both formats via isValidPlaceId, so OSM-style links worked but were semantically incorrect
Delete events intentionally still link to OpenStreetMap (the place no longer exists in BTC Map at that point)
Aligns the Tagging Activity page with the pattern already used by ActivityCard.svelte on Area/Community feeds

**Test plan**
 Navigate to /activity — non-delete entries should link to /merchant/<numeric-id>
 Click a delete entry — should open openstreetmap.org/node/<id> in a new tab
 pnpm run check passes
 pnpm run lint passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
* Activity events now include an optional place identifier to support more precise place-aware location linking.
* Activity pages now enrich the “latest supertaggers” with merchant name and optional place identifier, and pass it through to the latest tagger display.

**Bug Fixes**
* Improved resilience of place lookups: when merchant place data can’t be retrieved, the location name remains available while the place identifier is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->