### PR TITLE
fix(map): guard nearby status-row zoom-in link while list loads #1066

### DIFF
--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -464,7 +464,9 @@ onDestroy(() => {
 						{:else}
 							{searchResults.length} result{searchResults.length !== 1 ? 's' : ''}
 						{/if}
-					{:else if showZoomInMessage}
+					{:else if showZoomInMessage && !isLoadingList}
+						<!-- Loading spinner takes precedence so a stale count-only state
+						     can't flash this link (mirrors the body branch below) -->
 						<button
 							on:click={handleZoomToNearbyLevel}
 							class="text-link underline-offset-2 hover:underline dark:text-white"


### PR DESCRIPTION
Fixes: #1066

PR #1058 added a `!isLoadingList` guard so the nearby "zoom in" prompt can't flash during an in-flight fetch, but it only patched the body branch. The status-row link was left unguarded, so during the brief loading window the body shows the spinner while the status row simultaneously shows a contradictory clickable "zoom in" link. Mirror the guard on the status-row branch so the spinner takes precedence in both regions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the "zoom in" message could briefly appear while loading the merchant list, ensuring the loading indicator takes priority.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->