### PR TITLE
feat: switch from deprecated anon rpc to public rest api for fetching issues

### DIFF
--- a/src/routes/community/[area]/[section]/+page.server.ts
+++ b/src/routes/community/[area]/[section]/+page.server.ts
@@ -45,22 +45,13 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 		// }));
 		const tickets = "maintenance";
 
-		const issuesResponse = await fetch(`${API_BASE}/rpc`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
-				jsonrpc: "2.0",
-				id: 1,
-				method: "get_element_issues",
-				params: {
-					area_id: fetchedArea.id,
-					limit: 10_000,
-					offset: 0,
-				},
-			}),
-		});
+		const issuesResponse = await fetch(
+			`${API_BASE}/v4/place-issues?area_id=${fetchedArea.id}&limit=10000&offset=0`,
+		);
+
+		if (!issuesResponse.ok) {
+			throw error(502, "Upstream API error");
+		}
 
 		const issues = await issuesResponse.json();
 
@@ -69,7 +60,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			numericId: fetchedArea.id,
 			name: fetchedArea.tags.name,
 			tickets: tickets,
-			issues: issues.result.requested_issues,
+			issues: issues.requested_issues,
 			verifiedDate: fetchedArea.tags["verified:date"],
 			description: fetchedArea.tags.description,
 			iconSquare: fetchedArea.tags["icon:square"],

--- a/src/routes/country/[area]/[section]/+page.server.ts
+++ b/src/routes/country/[area]/[section]/+page.server.ts
@@ -47,22 +47,13 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 		// }));
 		const tickets = "maintenance";
 
-		const issuesResponse = await fetch(`${API_BASE}/rpc`, {
-			method: "POST",
-			headers: {
-				"Content-Type": "application/json",
-			},
-			body: JSON.stringify({
-				jsonrpc: "2.0",
-				id: 1,
-				method: "get_element_issues",
-				params: {
-					area_id: fetchedArea.id,
-					limit: 10_000,
-					offset: 0,
-				},
-			}),
-		});
+		const issuesResponse = await fetch(
+			`${API_BASE}/v4/place-issues?area_id=${fetchedArea.id}&limit=10000&offset=0`,
+		);
+
+		if (!issuesResponse.ok) {
+			throw error(502, "Upstream API error");
+		}
 
 		const issues = await issuesResponse.json();
 
@@ -71,7 +62,7 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			numericId: fetchedArea.id,
 			name: fetchedArea.tags.name,
 			tickets: tickets,
-			issues: issues.result.requested_issues,
+			issues: issues.requested_issues,
 			description: fetchedArea.tags.description,
 		};
 	} catch (err) {


### PR DESCRIPTION
RPC will soon stop accepting anon calls, so migrating to public REST API is necessary. There are no changes to payload so it should work as before with no additional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend data-fetching for community and country issue pages to use an optimized API endpoint, improving data retrieval efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->