### PR TITLE
refactor(types): drop stale RPC naming after REST migration #1023

### DIFF
--- a/src/components/IssuesTable.svelte
+++ b/src/components/IssuesTable.svelte
@@ -24,11 +24,11 @@ import { _, locale } from "svelte-i18n";
 import Icon from "$components/Icon.svelte";
 import IssueCell from "$components/IssueCell.svelte";
 import { theme } from "$lib/theme";
-import type { RpcIssue } from "$lib/types";
+import type { PlaceIssue } from "$lib/types";
 import { debounce, getIssueHelpLink, getIssueIcon, isEven } from "$lib/utils";
 
 export let title: string;
-export let issues: RpcIssue[];
+export let issues: PlaceIssue[];
 export let loading: boolean;
 export let initialPageSize = 10;
 

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -47,7 +47,7 @@ import type {
 	AreaPageProps,
 	AreaTags,
 	Place,
-	RpcIssue,
+	PlaceIssue,
 	Tagger,
 } from "$lib/types.js";
 import { TipType } from "$lib/types.js";
@@ -367,7 +367,7 @@ let lightning: { destination: string; type: TipType } | undefined;
 
 let taggers: Tagger[] = [];
 
-let issues: RpcIssue[] = [];
+let issues: PlaceIssue[] = [];
 </script>
 
 <main class="my-10 space-y-16 text-center md:my-20">

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -119,7 +119,7 @@ function createSessionStore() {
 			if (stored) set(stored);
 		},
 
-		// Create a throwaway account via the existing RPC endpoints. Returns
+		// Create a throwaway account via the existing REST endpoints. Returns
 		// the new session on success. Stores everything in localStorage so the
 		// user stays "logged in" across reloads.
 		//

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,7 +152,7 @@ export type MerchantPageData = {
 	osmEditUrl: string;
 };
 
-export type RpcIssue = {
+export type PlaceIssue = {
 	element_osm_type: string;
 	element_osm_id: number;
 	element_name: string;
@@ -182,17 +182,6 @@ export type IssueIcon =
 	| "fa-hourglass-end"
 	| "fa-list-check"
 	| "fa-hourglass-half";
-
-export type RpcGetMostActiveUsersItem = {
-	id: number;
-	name: string;
-	image_url: string;
-	tip_address: string;
-	edits: number;
-	created: number;
-	updated: number;
-	deleted: number;
-};
 
 export type OSMTags = { [key: string]: any };
 
@@ -401,7 +390,7 @@ export type AreaPageProps = {
 	numericId: number;
 	name: string;
 	tickets: Tickets;
-	issues: RpcIssue[];
+	issues: PlaceIssue[];
 	verifiedDate?: string;
 	description?: string;
 	iconSquare?: string;

--- a/src/routes/leaderboard/+page.server.ts
+++ b/src/routes/leaderboard/+page.server.ts
@@ -62,7 +62,7 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 		if (!response.ok) {
 			return {
 				error: `API Error: ${response.status}`,
-				rpcResult: null,
+				result: null,
 				period: resolvedPeriod,
 				periodOptions: PERIOD_OPTIONS,
 			};
@@ -71,14 +71,14 @@ export const load: PageServerLoad = async ({ url, fetch }) => {
 		const data = await response.json();
 
 		return {
-			rpcResult: { users: data },
+			result: { users: data },
 			period: resolvedPeriod,
 			periodOptions: PERIOD_OPTIONS,
 		};
 	} catch (err) {
 		return {
 			error: err instanceof Error ? err.message : "Failed to load leaderboard",
-			rpcResult: null,
+			result: null,
 			period: resolvedPeriod,
 			periodOptions: PERIOD_OPTIONS,
 		};

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -141,8 +141,8 @@ const normalizeUsers = (users: TopEditorItem[]): TaggerRow[] => {
 };
 
 $: {
-	if (Array.isArray(data?.rpcResult?.users)) {
-		const normalizedUsers = normalizeUsers(data.rpcResult.users);
+	if (Array.isArray(data?.result?.users)) {
+		const normalizedUsers = normalizeUsers(data.result.users);
 		leaderboardRows = normalizedUsers;
 		totalTaggers = normalizedUsers.length;
 		loading = false;

--- a/src/routes/tagging-issues/+page.server.ts
+++ b/src/routes/tagging-issues/+page.server.ts
@@ -11,7 +11,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		if (!response.ok) {
 			return {
 				error: `HTTP Error: ${response.status}`,
-				rpcResult: null,
+				result: null,
 			};
 		}
 
@@ -24,7 +24,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 		return {
 			error:
 				err instanceof Error ? err.message : "Failed to load element issues",
-			rpcResult: null,
+			result: null,
 		};
 	}
 };

--- a/src/routes/tagging-issues/+page.svelte
+++ b/src/routes/tagging-issues/+page.svelte
@@ -4,10 +4,10 @@ import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import TextLink from "$components/TextLink.svelte";
 import { _ } from "$lib/i18n";
 import { theme } from "$lib/theme";
-import type { RpcIssue } from "$lib/types";
+import type { PlaceIssue } from "$lib/types";
 
 export let data;
-let issues: RpcIssue[] = data.result.requested_issues;
+let issues: PlaceIssue[] = data.result?.requested_issues ?? [];
 </script>
 
 <svelte:head>


### PR DESCRIPTION
The tagging-issues and leaderboard routes now use REST endpoints (/v4/place-issues, /v4/top-editors) but kept RPC-era naming:

- rename RpcIssue type to PlaceIssue (now sourced from /v4/place-issues)
- remove dead RpcGetMostActiveUsersItem type (unused)
- rename rpcResult fields to result in tagging-issues & leaderboard
- guard tagging-issues svelte against missing result on error paths (server error branches return result: null; was read unguarded)
- fix stale "RPC endpoints" comment in session signUp (uses /v4/users)

Genuine /rpc JSON-RPC calls in community/country sections are left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized internal type naming conventions and data structure field names across the application for improved consistency.
  * Removed an unused type definition.
  * Updated documentation to reflect current implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->