### PR TITLE
fix(map): restore the boosted-locations filter (?boosts=true)

### DIFF
--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -109,7 +109,8 @@ const isMobileLayout = browser && window.innerWidth < BREAKPOINTS.md;
 // via a full page reload, so it's constant for the session; it narrows both the
 // map markers and the nearby list to currently-boosted places.
 const boostsOnly =
-	browser && new URLSearchParams(window.location.search).has("boosts");
+	browser &&
+	new URLSearchParams(window.location.search).get("boosts") === "true";
 
 type PlaceFeature = {
 	type: "Feature";
@@ -369,7 +370,10 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 
 	const bounds = map.getBounds();
 	const center = map.getCenter();
-	const behavior = getZoomBehavior(currentZoom);
+	// Boosted-only: the bulk $places feed already holds the tiny boosted set at
+	// every zoom, and the radius API (api-with-limit) has no boost filter, so
+	// force the local path so the list/count stay in sync with the filtered map.
+	const behavior = boostsOnly ? "local-markers" : getZoomBehavior(currentZoom);
 	const listOpen = get(merchantList).isOpen;
 	const allowHeavyFetch = opts?.force || listOpen;
 
@@ -743,8 +747,12 @@ const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
 const syncPlacesToSource = (rawList: Place[]) => {
 	if (!map || !styleLoaded) return;
 	// "Boosted locations only" narrows every sync path (markers, the boosted
-	// source and the heatmap) to currently-boosted places.
-	const list = boostsOnly ? rawList.filter(isBoosted) : rawList;
+	// source and the heatmap) to currently-boosted places — except in search
+	// mode, where an explicit query should surface all matches on the map.
+	const list =
+		boostsOnly && get(merchantList).mode !== "search"
+			? rawList.filter(isBoosted)
+			: rawList;
 	const source = map.getSource("places") as GeoJSONSource | undefined;
 	const boostedSource = map.getSource("places-boosted") as
 		| GeoJSONSource

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -105,6 +105,12 @@ export let data: PageData;
 // a viewport resize can never leave zero or two search surfaces
 const isMobileLayout = browser && window.innerWidth < BREAKPOINTS.md;
 
+// "Boosted locations only" map filter (?boosts=true). The tools modal sets it
+// via a full page reload, so it's constant for the session; it narrows both the
+// map markers and the nearby list to currently-boosted places.
+const boostsOnly =
+	browser && new URLSearchParams(window.location.search).has("boosts");
+
 type PlaceFeature = {
 	type: "Feature";
 	geometry: { type: "Point"; coordinates: [number, number] };
@@ -381,7 +387,8 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 					p.lon >= buffered.west &&
 					p.lon <= buffered.east,
 			);
-			merchantList.setMerchants(visible, center.lat, center.lng);
+			const listed = boostsOnly ? visible.filter(isBoosted) : visible;
+			merchantList.setMerchants(listed, center.lat, center.lng);
 			if (listOpen || currentZoom >= LABEL_VISIBLE_ZOOM) {
 				if (allowHeavyFetch || currentZoom >= LABEL_VISIBLE_ZOOM) {
 					const radiusKm =
@@ -733,8 +740,11 @@ const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
 	m.triggerRepaint();
 };
 
-const syncPlacesToSource = (list: Place[]) => {
+const syncPlacesToSource = (rawList: Place[]) => {
 	if (!map || !styleLoaded) return;
+	// "Boosted locations only" narrows every sync path (markers, the boosted
+	// source and the heatmap) to currently-boosted places.
+	const list = boostsOnly ? rawList.filter(isBoosted) : rawList;
 	const source = map.getSource("places") as GeoJSONSource | undefined;
 	const boostedSource = map.getSource("places-boosted") as
 		| GeoJSONSource

--- a/src/routes/map/components/MapControls.svelte
+++ b/src/routes/map/components/MapControls.svelte
@@ -107,7 +107,8 @@ const onToggleHeatmap = (enabled: boolean) => {
 const onToggleBoost = () => {
 	trackEvent("boost_layer_toggle");
 	const url = new URL(window.location.href);
-	if (url.searchParams.has("boosts")) url.searchParams.delete("boosts");
+	if (url.searchParams.get("boosts") === "true")
+		url.searchParams.delete("boosts");
 	else url.searchParams.set("boosts", "true");
 	window.location.search = url.search;
 };
@@ -130,7 +131,7 @@ onMount(() => {
 	}
 	boostActive =
 		typeof window !== "undefined" &&
-		new URLSearchParams(window.location.search).has("boosts");
+		new URLSearchParams(window.location.search).get("boosts") === "true";
 });
 
 // The triggers are MapLibre IControls, so register them once the map exists


### PR DESCRIPTION
## What

The **"Boosted locations only"** toggle (in the Layers & filters modal) sets `?boosts=true` and reloads, but nothing consumed the param — so the map stayed unfiltered while the switch showed "on."

This restores the filter: when `?boosts=true` is set, the map markers (and the local nearby list) narrow to currently-boosted places.

## Root cause

The filter was wired on the **Leaflet** map in `8177c651` (Apr 26), then **lost in the MapLibre cutover** `0cd16131` (May 24) — the rewrite never re-read the param. `origin/main`'s map page had **0** references to `has("boosts")` outside the toggle itself. (Diagnosed off the recent controls-consolidation work, which only ported the already-dead toggle.)

## Fix

- Read `boostsOnly` once from the URL (the toggle reloads, so it's constant for the session) — mirrors the verified-filter pattern.
- Filter to `isBoosted` at the single **`syncPlacesToSource`** chokepoint, so it covers every sync path (markers, the boosted source, and the heatmap) without sprinkling the check across callers.
- Narrow the local nearby list in **`updateMerchantList`** (zoom 15+ / local-markers branch).

Boosted places already render as orange pins regardless; this restores *filter-to-only-boosted*.

## Testing
- `format` / `lint` (0) / `check` (0 errors) / `vitest` (441) green.
- **Verified live:** at the same Europe view, the synced place count drops from **16,776** (no param) to **54** (`?boosts=true`), and the map shows only boosted pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a boosted-only map view when the URL contains `?boosts=true`, including filtering of nearby results and map markers to boosted places.
* **Bug Fixes**
  * Made boost URL handling value-sensitive: boost is enabled only for `boosts=true`, and toggling now removes the parameter only when it is set to `"true"` to prevent unintended activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->