### PR TITLE
refactor(routes): extract shared area/section loader

### DIFF
--- a/src/lib/areaSectionLoad.test.ts
+++ b/src/lib/areaSectionLoad.test.ts
@@ -1,0 +1,261 @@
+import { isHttpError, isRedirect } from "@sveltejs/kit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadAreaSection } from "./areaSectionLoad";
+
+type ResponseOverrides = {
+	ok?: boolean;
+	status?: number;
+	json?: () => unknown;
+};
+
+type FetchResponses = {
+	areas?: ResponseOverrides;
+	issues?: ResponseOverrides;
+};
+
+const AREA_OK = {
+	id: 42,
+	deleted_at: null,
+	tags: {
+		url_alias: "some-area",
+		name: "Some Area",
+		description: "An area description",
+		"verified:date": "2024-01-01",
+		"icon:square": "https://example.com/icon.png",
+	},
+};
+
+const ISSUES_OK = { requested_issues: [{ id: 1 }, { id: 2 }] };
+
+const buildResponse = (overrides: ResponseOverrides) =>
+	({
+		ok: overrides.ok ?? true,
+		status: overrides.status ?? 200,
+		json: overrides.json ?? (() => ({})),
+	}) as unknown as Response;
+
+const makeFetch = (responses: FetchResponses = {}) =>
+	vi.fn(async (url: string | URL) => {
+		const href = url.toString();
+		if (href.includes("/v3/areas/")) {
+			return buildResponse({ json: () => AREA_OK, ...responses.areas });
+		}
+		if (href.includes("/v4/place-issues")) {
+			return buildResponse({ json: () => ISSUES_OK, ...responses.issues });
+		}
+		throw new Error(`unexpected fetch URL: ${href}`);
+	});
+
+const communityConfig = {
+	notFoundMessage: "Community Not Found",
+	redirectBase: "/community",
+	isValidArea: (area: string) => !area.includes("/"),
+};
+
+const countryConfig = {
+	notFoundMessage: "Country Not Found",
+	redirectBase: "/country",
+	isValidArea: (area: string) => /^[\w-]+$/.test(area),
+};
+
+const captureThrow = async (fn: () => Promise<unknown>): Promise<unknown> => {
+	try {
+		await fn();
+	} catch (err) {
+		return err;
+	}
+	throw new Error("expected the function to throw, but it resolved");
+};
+
+beforeEach(() => {
+	// The helper logs caught errors; silence to keep test output pristine.
+	vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("loadAreaSection", () => {
+	it("rejects an area that fails the config validation with a 404", async () => {
+		const fetch = makeFetch();
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "bad/area", section: "merchants" }, fetch },
+				countryConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(404);
+			expect(err.body.message).toBe("Country Not Found");
+		}
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("allows non-Latin aliases through the community validation", async () => {
+		const fetch = makeFetch();
+
+		const result = await loadAreaSection(
+			{ params: { area: "日本", section: "merchants" }, fetch },
+			communityConfig,
+		);
+
+		expect(result.data.id).toBe("some-area");
+		// The area is percent-encoded in the upstream request.
+		expect(fetch.mock.calls[0][0].toString()).toContain(
+			encodeURIComponent("日本"),
+		);
+	});
+
+	it("redirects to the merchants section when the section is invalid", async () => {
+		const fetch = makeFetch();
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "café", section: "bogus" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isRedirect(err)).toBe(true);
+		if (isRedirect(err)) {
+			expect(err.status).toBe(302);
+			expect(err.location).toBe(
+				`/community/${encodeURIComponent("café")}/merchants`,
+			);
+		}
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("maps a 404 from the area endpoint to a not-found error", async () => {
+		const fetch = makeFetch({ areas: { ok: false, status: 404 } });
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(404);
+			expect(err.body.message).toBe("Community Not Found");
+		}
+	});
+
+	it("maps a 410 from the area endpoint to a not-found error", async () => {
+		const fetch = makeFetch({ areas: { ok: false, status: 410 } });
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				countryConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(404);
+			expect(err.body.message).toBe("Country Not Found");
+		}
+	});
+
+	it("maps other upstream area errors to a 502", async () => {
+		const fetch = makeFetch({ areas: { ok: false, status: 500 } });
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(502);
+		}
+	});
+
+	it("returns a 404 when the area is soft-deleted", async () => {
+		const fetch = makeFetch({
+			areas: { json: () => ({ ...AREA_OK, deleted_at: "2024-05-01" }) },
+		});
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(404);
+		}
+	});
+
+	it("returns a 404 when the area has no tags", async () => {
+		const fetch = makeFetch({
+			areas: { json: () => ({ id: 42, deleted_at: null }) },
+		});
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(404);
+		}
+	});
+
+	it("maps a failed issues fetch to a 502", async () => {
+		const fetch = makeFetch({ issues: { ok: false, status: 500 } });
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(502);
+		}
+	});
+
+	it("returns mapped area + issues data and requests the expected endpoints", async () => {
+		const fetch = makeFetch();
+
+		const result = await loadAreaSection(
+			{ params: { area: "some-area", section: "stats" }, fetch },
+			communityConfig,
+		);
+
+		expect(result.data).toEqual({
+			id: "some-area",
+			numericId: 42,
+			name: "Some Area",
+			tickets: "maintenance",
+			issues: ISSUES_OK.requested_issues,
+			description: "An area description",
+		});
+		expect(result.tags).toEqual(AREA_OK.tags);
+
+		const areaUrl = fetch.mock.calls[0][0].toString();
+		const issuesUrl = fetch.mock.calls[1][0].toString();
+		expect(areaUrl).toContain("/v3/areas/some-area");
+		expect(issuesUrl).toContain(
+			"/v4/place-issues?area_id=42&limit=10000&offset=0",
+		);
+	});
+});

--- a/src/lib/areaSectionLoad.test.ts
+++ b/src/lib/areaSectionLoad.test.ts
@@ -1,6 +1,7 @@
 import { isHttpError, isRedirect } from "@sveltejs/kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AreaSectionConfig } from "./areaSectionLoad";
 import { loadAreaSection } from "./areaSectionLoad";
 
 type ResponseOverrides = {
@@ -47,16 +48,16 @@ const makeFetch = (responses: FetchResponses = {}) =>
 		throw new Error(`unexpected fetch URL: ${href}`);
 	});
 
-const communityConfig = {
+const communityConfig: AreaSectionConfig = {
 	notFoundMessage: "Community Not Found",
 	redirectBase: "/community",
-	isValidArea: (area: string) => !area.includes("/"),
+	isValidArea: (area) => !area.includes("/"),
 };
 
-const countryConfig = {
+const countryConfig: AreaSectionConfig = {
 	notFoundMessage: "Country Not Found",
 	redirectBase: "/country",
-	isValidArea: (area: string) => /^[\w-]+$/.test(area),
+	isValidArea: (area) => /^[\w-]+$/.test(area),
 };
 
 const captureThrow = async (fn: () => Promise<unknown>): Promise<unknown> => {

--- a/src/lib/areaSectionLoad.ts
+++ b/src/lib/areaSectionLoad.ts
@@ -14,7 +14,7 @@ type AreaSectionEvent = {
 	fetch: FetchLike;
 };
 
-type AreaSectionConfig = {
+export type AreaSectionConfig = {
 	notFoundMessage: string;
 	redirectBase: string;
 	isValidArea: (area: string) => boolean;

--- a/src/lib/areaSectionLoad.ts
+++ b/src/lib/areaSectionLoad.ts
@@ -1,0 +1,103 @@
+import { error, isHttpError, redirect } from "@sveltejs/kit";
+
+import { API_BASE } from "$lib/api-base";
+
+// Shared loader for the community/[area]/[section] and country/[area]/[section]
+// pages. Both fetch the same v3 area + v4 place-issues data and share the same
+// error handling; they differ only in how the area slug is validated, the
+// not-found copy, and the redirect base path.
+
+type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
+
+type AreaSectionEvent = {
+	params: { area: string; section: string };
+	fetch: FetchLike;
+};
+
+type AreaSectionConfig = {
+	notFoundMessage: string;
+	redirectBase: string;
+	isValidArea: (area: string) => boolean;
+};
+
+export type AreaSectionResult = {
+	data: {
+		id: string;
+		numericId: number;
+		name: string;
+		tickets: string;
+		issues: unknown;
+		description: string;
+	};
+	tags: Record<string, string>;
+};
+
+const VALID_SECTIONS = ["merchants", "stats", "activity", "maintain"];
+
+export const loadAreaSection = async (
+	{ params, fetch }: AreaSectionEvent,
+	config: AreaSectionConfig,
+): Promise<AreaSectionResult> => {
+	const { area } = params;
+	const section = params.section || "merchants";
+
+	if (!config.isValidArea(area)) {
+		throw error(404, config.notFoundMessage);
+	}
+
+	if (!VALID_SECTIONS.includes(section)) {
+		throw redirect(
+			302,
+			`${config.redirectBase}/${encodeURIComponent(area)}/merchants`,
+		);
+	}
+
+	try {
+		const areaResponse = await fetch(
+			`${API_BASE}/v3/areas/${encodeURIComponent(area)}`,
+		);
+
+		if (!areaResponse.ok) {
+			if (areaResponse.status === 404 || areaResponse.status === 410) {
+				throw error(404, config.notFoundMessage);
+			}
+			throw error(502, "Upstream API error");
+		}
+
+		const fetchedArea = await areaResponse.json();
+
+		// v3 returns no tags for deleted areas
+		if (fetchedArea.deleted_at || !fetchedArea.tags) {
+			throw error(404, config.notFoundMessage);
+		}
+
+		// Ticket syncing is temporarily disabled during maintenance
+		const tickets = "maintenance";
+
+		const issuesResponse = await fetch(
+			`${API_BASE}/v4/place-issues?area_id=${fetchedArea.id}&limit=10000&offset=0`,
+		);
+
+		if (!issuesResponse.ok) {
+			throw error(502, "Upstream API error");
+		}
+
+		const issues = await issuesResponse.json();
+
+		return {
+			data: {
+				id: fetchedArea.tags.url_alias,
+				numericId: fetchedArea.id,
+				name: fetchedArea.tags.name,
+				tickets: tickets,
+				issues: issues.requested_issues,
+				description: fetchedArea.tags.description,
+			},
+			tags: fetchedArea.tags,
+		};
+	} catch (err) {
+		console.error(err);
+		if (isHttpError(err)) throw err;
+		throw error(502, "Upstream API error");
+	}
+};

--- a/src/lib/areaSectionLoad.ts
+++ b/src/lib/areaSectionLoad.ts
@@ -1,6 +1,7 @@
 import { error, isHttpError, redirect } from "@sveltejs/kit";
 
 import { API_BASE } from "$lib/api-base";
+import type { AreaPageProps, AreaTags } from "$lib/types";
 
 // Shared loader for the community/[area]/[section] and country/[area]/[section]
 // pages. Both fetch the same v3 area + v4 place-issues data and share the same
@@ -21,15 +22,10 @@ export type AreaSectionConfig = {
 };
 
 export type AreaSectionResult = {
-	data: {
-		id: string;
-		numericId: number;
-		name: string;
-		tickets: string;
-		issues: unknown;
-		description: string;
-	};
-	tags: Record<string, string>;
+	// The shared AreaPage data; the community route additionally derives
+	// verifiedDate/iconSquare from `tags` below (both optional on AreaPageProps).
+	data: Omit<AreaPageProps, "verifiedDate" | "iconSquare">;
+	tags: AreaTags;
 };
 
 const VALID_SECTIONS = ["merchants", "stats", "activity", "maintain"];

--- a/src/routes/community/[area]/[section]/+page.server.ts
+++ b/src/routes/community/[area]/[section]/+page.server.ts
@@ -1,73 +1,21 @@
-import { error, isHttpError, redirect } from "@sveltejs/kit";
-
-import { API_BASE } from "$lib/api-base";
+import { loadAreaSection } from "$lib/areaSectionLoad";
 
 import type { PageServerLoad } from "./$types";
 
-// Temporarily disabled during maintenance
-// import { getIssues } from '$lib/gitea';
-
 export const load: PageServerLoad = async ({ params, fetch }) => {
-	const { area, section } = params;
+	const { data, tags } = await loadAreaSection(
+		{ params, fetch },
+		{
+			notFoundMessage: "Community Not Found",
+			redirectBase: "/community",
+			// Allow non-Latin aliases while still rejecting malformed path-like values.
+			isValidArea: (area) => !area.includes("/"),
+		},
+	);
 
-	// Allow non-Latin aliases while still rejecting malformed path-like values.
-	if (area.includes("/")) {
-		throw error(404, "Community Not Found");
-	}
-
-	// Validate section parameter
-	const validSections = ["merchants", "stats", "activity", "maintain"];
-	if (!validSections.includes(section)) {
-		throw redirect(302, `/community/${encodeURIComponent(area)}/merchants`);
-	}
-	try {
-		const areaResponse = await fetch(
-			`${API_BASE}/v3/areas/${encodeURIComponent(area)}`,
-		);
-
-		if (!areaResponse.ok) {
-			if (areaResponse.status === 404 || areaResponse.status === 410) {
-				throw error(404, "Community Not Found");
-			}
-			throw error(502, "Upstream API error");
-		}
-
-		const fetchedArea = await areaResponse.json();
-
-		// Check if area is deleted (v3 returns no tags for deleted areas)
-		if (fetchedArea.deleted_at || !fetchedArea.tags) {
-			throw error(404, "Community Not Found");
-		}
-
-		// Temporarily disabled during maintenance
-		// const { issues: tickets } = await getIssues([fetchedArea.tags.url_alias]).catch(() => ({
-		// 	issues: 'error'
-		// }));
-		const tickets = "maintenance";
-
-		const issuesResponse = await fetch(
-			`${API_BASE}/v4/place-issues?area_id=${fetchedArea.id}&limit=10000&offset=0`,
-		);
-
-		if (!issuesResponse.ok) {
-			throw error(502, "Upstream API error");
-		}
-
-		const issues = await issuesResponse.json();
-
-		return {
-			id: fetchedArea.tags.url_alias,
-			numericId: fetchedArea.id,
-			name: fetchedArea.tags.name,
-			tickets: tickets,
-			issues: issues.requested_issues,
-			verifiedDate: fetchedArea.tags["verified:date"],
-			description: fetchedArea.tags.description,
-			iconSquare: fetchedArea.tags["icon:square"],
-		};
-	} catch (err) {
-		console.error(err);
-		if (isHttpError(err)) throw err;
-		throw error(502, "Upstream API error");
-	}
+	return {
+		...data,
+		verifiedDate: tags["verified:date"],
+		iconSquare: tags["icon:square"],
+	};
 };

--- a/src/routes/country/[area]/[section]/+page.server.ts
+++ b/src/routes/country/[area]/[section]/+page.server.ts
@@ -1,73 +1,17 @@
-import { error, isHttpError, redirect } from "@sveltejs/kit";
-
-import { API_BASE } from "$lib/api-base";
+import { loadAreaSection } from "$lib/areaSectionLoad";
 
 import type { PageServerLoad } from "./$types";
 
-// Temporarily disabled during maintenance
-// import { getIssues } from '$lib/gitea';
-
 export const load: PageServerLoad = async ({ params, fetch }) => {
-	const { area, section } = params;
+	const { data } = await loadAreaSection(
+		{ params, fetch },
+		{
+			notFoundMessage: "Country Not Found",
+			redirectBase: "/country",
+			// Alphanumeric, underscores, and hyphens only.
+			isValidArea: (area) => /^[\w-]+$/.test(area),
+		},
+	);
 
-	// Validate area parameter format (alphanumeric, underscores, hyphens only)
-	if (!/^[\w-]+$/.test(area)) {
-		throw error(404, "Country Not Found");
-	}
-
-	// Validate section parameter - default to merchants if not provided
-	const validSections = ["merchants", "stats", "activity", "maintain"];
-	const currentSection = section || "merchants";
-
-	if (!validSections.includes(currentSection)) {
-		throw redirect(302, `/country/${encodeURIComponent(area)}/merchants`);
-	}
-	try {
-		const areaResponse = await fetch(
-			`${API_BASE}/v3/areas/${encodeURIComponent(area)}`,
-		);
-
-		if (!areaResponse.ok) {
-			if (areaResponse.status === 404 || areaResponse.status === 410) {
-				throw error(404, "Country Not Found");
-			}
-			throw error(502, "Upstream API error");
-		}
-
-		const fetchedArea = await areaResponse.json();
-
-		// Check if area is deleted (v3 returns no tags for deleted areas)
-		if (fetchedArea.deleted_at || !fetchedArea.tags) {
-			throw error(404, "Country Not Found");
-		}
-
-		// Temporarily disabled during maintenance
-		// const { issues: tickets } = await getIssues([fetchedArea.tags.url_alias]).catch(() => ({
-		// 	issues: 'error'
-		// }));
-		const tickets = "maintenance";
-
-		const issuesResponse = await fetch(
-			`${API_BASE}/v4/place-issues?area_id=${fetchedArea.id}&limit=10000&offset=0`,
-		);
-
-		if (!issuesResponse.ok) {
-			throw error(502, "Upstream API error");
-		}
-
-		const issues = await issuesResponse.json();
-
-		return {
-			id: fetchedArea.tags.url_alias,
-			numericId: fetchedArea.id,
-			name: fetchedArea.tags.name,
-			tickets: tickets,
-			issues: issues.requested_issues,
-			description: fetchedArea.tags.description,
-		};
-	} catch (err) {
-		console.error(err);
-		if (isHttpError(err)) throw err;
-		throw error(502, "Upstream API error");
-	}
+	return data;
 };


### PR DESCRIPTION
## What

The `community/[area]/[section]` and `country/[area]/[section]` page loaders had drifted into near-identical copies after the RPC→REST migration — same v3 area fetch, deleted/missing-tags guard, v4 `place-issues` fetch, and error handling. This extracts that shared body into a single `loadAreaSection()` helper (`src/lib/areaSectionLoad.ts`).

The helper is parameterized by the only parts that genuinely differ between the two pages:

| | community | country |
|---|---|---|
| not-found copy | `Community Not Found` | `Country Not Found` |
| redirect base | `/community` | `/country` |
| area validation | `!area.includes("/")` (allows non-Latin aliases) | `/^[\w-]+$/` (strict) |
| extra return fields | `verifiedDate`, `iconSquare` | — |

Behavior and returned fields are unchanged — this is a pure refactor.

## Why

Suggested by the biweekly codebase health review: the two `+page.server.ts` files were "near-identical … differing only in the returned fields and the Community/Country 404 text." Consolidating removes the duplicated maintenance surface.

Closes #1112

## Tests

New `src/lib/areaSectionLoad.test.ts` (10 tests, written test-first) covers:
- both area-validation strategies
- the invalid-section → `/…/merchants` redirect
- the 404 / 410 / 502 upstream branches
- soft-deleted and missing-tags areas
- a failed issues fetch
- happy-path field mapping + the exact upstream URLs

## Verification

- `pnpm run format:fix` — clean
- `pnpm run check` — 0 errors, 0 warnings
- `pnpm run lint` — clean
- `pnpm run test --run` — 451 passed (22 files)

Net: **136 lines of duplication removed** from the two routes; shared logic now lives in one tested place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)