### PR TITLE
feat(apps): add beta APK download option

### DIFF
--- a/src/components/AppDownloadModal.svelte
+++ b/src/components/AppDownloadModal.svelte
@@ -24,6 +24,7 @@ $: modalTitle = app
 const storeLabels: Record<StoreKey, string> = {
 	"app-store": "App Store",
 	apk: "APK",
+	"apk-beta": "APK (Beta)",
 	"f-droid": "F-Droid",
 	"google-play": "Google Play",
 	"linux-package": "Linux Package",

--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -3,6 +3,7 @@ export type Platform = "android" | "ios" | "web" | "linux" | "windows" | "mac";
 export type StoreKey =
 	| "app-store"
 	| "apk"
+	| "apk-beta"
 	| "f-droid"
 	| "google-play"
 	| "linux-package"
@@ -47,7 +48,12 @@ export const appConfigs: AppConfig[] = [
 			{
 				store: "apk",
 				platform: "android",
-				url: "https://github.com/teambtcmap/btcmap-android/releases/latest",
+				url: "http://static.btcmap.org/android/apk/latest.apk",
+			},
+			{
+				store: "apk-beta",
+				platform: "android",
+				url: "http://static.btcmap.org/android/apk/beta.apk",
 			},
 			{
 				store: "zapstore",

--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -48,12 +48,12 @@ export const appConfigs: AppConfig[] = [
 			{
 				store: "apk",
 				platform: "android",
-				url: "http://static.btcmap.org/android/apk/latest.apk",
+				url: "https://static.btcmap.org/android/apk/latest.apk",
 			},
 			{
 				store: "apk-beta",
 				platform: "android",
-				url: "http://static.btcmap.org/android/apk/beta.apk",
+				url: "https://static.btcmap.org/android/apk/beta.apk",
 			},
 			{
 				store: "zapstore",

--- a/src/lib/icons/IconApps.svelte
+++ b/src/lib/icons/IconApps.svelte
@@ -15,6 +15,7 @@ import type { AppIconName } from "./types";
 const icons: Record<AppIconName, string> = {
 	android,
 	apk,
+	"apk-beta": apk,
 	"app-store": appStore,
 	"f-droid": fdroid,
 	"google-play": googlePlay,

--- a/src/lib/icons/types.ts
+++ b/src/lib/icons/types.ts
@@ -19,6 +19,7 @@ export type SocialIconName =
 export type AppIconName =
 	| "android"
 	| "apk"
+	| "apk-beta"
 	| "app-store"
 	| "f-droid"
 	| "google-play"


### PR DESCRIPTION
Android APKs are now served directly with no GH deps, also added beta release download option to encourage early feedback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for beta APK downloads in the app download modal.
  * Beta APK entries now appear with the correct label and icon.
  * Android download options now include a dedicated beta build link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->