### PR TITLE
refactor(lnurlp): update donations and zaps identifiers to @lnbits.btcmap.org

### DIFF
--- a/src/routes/.well-known/lnurlp/donations/+server.ts
+++ b/src/routes/.well-known/lnurlp/donations/+server.ts
@@ -8,5 +8,5 @@ export const GET: RequestHandler = ({ fetch }) =>
 	forwardLnurlp({
 		fetch,
 		upstream: UPSTREAM,
-		identifier: "donations@btcmap.org",
+		identifier: "donations@lnbits.btcmap.org",
 	});

--- a/src/routes/.well-known/lnurlp/zaps/+server.ts
+++ b/src/routes/.well-known/lnurlp/zaps/+server.ts
@@ -5,4 +5,8 @@ import type { RequestHandler } from "./$types";
 const UPSTREAM = "https://rizful.com/.well-known/lnurlp/btcmap-zaps";
 
 export const GET: RequestHandler = ({ fetch }) =>
-	forwardLnurlp({ fetch, upstream: UPSTREAM, identifier: "zaps@btcmap.org" });
+	forwardLnurlp({
+		fetch,
+		upstream: UPSTREAM,
+		identifier: "zaps@lnbits.btcmap.org",
+	});


### PR DESCRIPTION
Updates the LNURLp identifiers for the donations and zaps forwards from `@btcmap.org` to `@lnbits.btcmap.org`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated LNURL payment forwarding for donations and zaps to use the correct service identifiers, helping these requests route properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->