### PR TITLE
refactor(areas): use v4 area image endpoint for community icons

### DIFF
--- a/src/components/CommunityRail.svelte
+++ b/src/components/CommunityRail.svelte
@@ -58,7 +58,7 @@ $: if (
 }
 
 const avatarUrl = (community: Area): string =>
-	areaIconSrc(community.tags["icon:square"], 64);
+	areaIconSrc(community.id, community.tags["icon:square"], 64);
 
 const communityHref = (community: Area): string =>
 	resolve(`/community/${encodeURIComponent(community.id)}`);

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -203,7 +203,7 @@ const initializeData = async () => {
 
 	avatar =
 		type === "community"
-			? areaIconSrc(area["icon:square"])
+			? areaIconSrc(areaFound.id, area["icon:square"])
 			: `https://static.btcmap.org/images/countries/${areaFound.id}.svg`;
 	description = area.description;
 

--- a/src/components/leaderboard/AreaLeaderboardItemName.svelte
+++ b/src/components/leaderboard/AreaLeaderboardItemName.svelte
@@ -10,7 +10,7 @@ export let name: string;
 export let id: string;
 export let countryCode: string | undefined = undefined;
 
-$: avatarSrc = type === "community" ? areaIconSrc(avatar) : avatar;
+$: avatarSrc = type === "community" ? areaIconSrc(id, avatar) : avatar;
 
 $: displayName = name || "Unknown";
 $: hasLongName = displayName?.match(/[^ ]{21}/);

--- a/src/components/leaderboard/AreaLeaderboardMobileCard.svelte
+++ b/src/components/leaderboard/AreaLeaderboardMobileCard.svelte
@@ -71,7 +71,7 @@ export let type: AreaType;
 				<!-- Row 1: Larger Avatar -->
 				<div class="flex justify-center">
 					<img
-						src={areaIconSrc(area.icon)}
+						src={areaIconSrc(area.alias, area.icon)}
 						alt="{area.name || 'Unknown'} avatar"
 						class="h-16 w-16 rounded-full object-cover"
 						on:error={(e) => {

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -672,37 +672,44 @@ describe("isValidLongitude", () => {
 });
 
 describe("areaIconSrc", () => {
-	it("returns the raw URL for static.btcmap.org/images/areas paths", () => {
-		const url = "https://static.btcmap.org/images/areas/abc.png";
-		expect(areaIconSrc(url)).toBe(url);
-		expect(areaIconSrc(url, 64)).toBe(url);
-	});
+	// A truthy icon value signals the area has an image; the URL itself is no
+	// longer used to build the src — the area id keys the v4 image endpoint.
+	const icon = "https://static.btcmap.org/images/areas/361.png";
 
-	it("wraps non-static.btcmap.org URLs with the Netlify image service", () => {
-		const url = "https://ugc.production.linktr.ee/foo.webp";
-		expect(areaIconSrc(url)).toBe(
-			`https://btcmap.org/.netlify/images?url=${encodeURIComponent(url)}&fit=cover&w=256&h=256`,
+	it("builds the v4 area image endpoint URL from the area id", () => {
+		expect(areaIconSrc("free-madeira", icon)).toBe(
+			"https://api.btcmap.org/v4/areas/free-madeira/image?type=square&w=256&h=256",
 		);
 	});
 
 	it("respects a custom size", () => {
-		const url = "https://example.com/icon.png";
-		expect(areaIconSrc(url, 64)).toBe(
-			`https://btcmap.org/.netlify/images?url=${encodeURIComponent(url)}&fit=cover&w=64&h=64`,
+		expect(areaIconSrc("free-madeira", icon, 64)).toBe(
+			"https://api.btcmap.org/v4/areas/free-madeira/image?type=square&w=64&h=64",
 		);
 	});
 
-	it("does not bypass for paths outside /images/areas/", () => {
-		const url = "https://static.btcmap.org/images/countries/us.svg";
-		expect(areaIconSrc(url)).toBe(
-			`https://btcmap.org/.netlify/images?url=${encodeURIComponent(url)}&fit=cover&w=256&h=256`,
+	it("accepts a numeric id", () => {
+		expect(areaIconSrc(361, icon)).toBe(
+			"https://api.btcmap.org/v4/areas/361/image?type=square&w=256&h=256",
 		);
 	});
 
-	it("returns the bitcoin fallback for null/undefined/empty inputs", () => {
-		expect(areaIconSrc(null)).toBe("/images/bitcoin.svg");
-		expect(areaIconSrc(undefined)).toBe("/images/bitcoin.svg");
-		expect(areaIconSrc("")).toBe("/images/bitcoin.svg");
+	it("url-encodes the id", () => {
+		expect(areaIconSrc("a b/c", icon)).toBe(
+			"https://api.btcmap.org/v4/areas/a%20b%2Fc/image?type=square&w=256&h=256",
+		);
+	});
+
+	it("returns the bitcoin fallback when the area has no icon", () => {
+		expect(areaIconSrc("free-madeira", null)).toBe("/images/bitcoin.svg");
+		expect(areaIconSrc("free-madeira", undefined)).toBe("/images/bitcoin.svg");
+		expect(areaIconSrc("free-madeira", "")).toBe("/images/bitcoin.svg");
+	});
+
+	it("returns the bitcoin fallback when the id is missing", () => {
+		expect(areaIconSrc(null, icon)).toBe("/images/bitcoin.svg");
+		expect(areaIconSrc(undefined, icon)).toBe("/images/bitcoin.svg");
+		expect(areaIconSrc("", icon)).toBe("/images/bitcoin.svg");
 	});
 });
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -694,6 +694,12 @@ describe("areaIconSrc", () => {
 		);
 	});
 
+	it("treats a numeric id of 0 as valid, not missing", () => {
+		expect(areaIconSrc(0, icon)).toBe(
+			"https://api.btcmap.org/v4/areas/0/image?type=square&w=256&h=256",
+		);
+	});
+
 	it("url-encodes the id", () => {
 		expect(areaIconSrc("a b/c", icon)).toBe(
 			"https://api.btcmap.org/v4/areas/a%20b%2Fc/image?type=square&w=256&h=256",

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -587,6 +587,10 @@ export const areaIconSrc = (
 	icon: string | null | undefined,
 	size = 256,
 ): string => {
-	if (!id || !icon) return "/images/bitcoin.svg";
+	// A numeric id of 0 is valid, so guard on null/undefined/empty string
+	// rather than a plain falsy check (which would drop id 0).
+	if (id === null || id === undefined || id === "" || !icon) {
+		return "/images/bitcoin.svg";
+	}
 	return `${API_BASE}/v4/areas/${encodeURIComponent(String(id))}/image?type=square&w=${size}&h=${size}`;
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -578,22 +578,15 @@ export const buildMetaDescription = (
 	return `${truncated}…`;
 };
 
-// Wraps an area icon URL with Netlify's image optimization service. Skips
-// the wrapper for icons under static.btcmap.org/images/areas/ — the new
-// standardized format there is 256×256 PNG. Migration to that format is
-// incremental, so legacy entries under the same path also bypass and are
-// served at their native size; we accept that trade-off to get the win on
-// already-migrated icons today. Falsy input short-circuits to the bitcoin
-// fallback to avoid a wasted 400 from Netlify. `size` is intentionally
-// ignored for the bypass path — callers asking for smaller sizes get the
-// native asset and rely on the browser to downscale. Issue #622.
+// Builds an area icon URL via the v4 image endpoint, which resizes on the fly.
+// `id` is the area id (url_alias or numeric); `icon` is the area's existing
+// icon:square value, used only as a "does this area have an image?" gate so we
+// fall back to the bitcoin logo instead of pointing at a 404.
 export const areaIconSrc = (
+	id: string | number | null | undefined,
 	icon: string | null | undefined,
 	size = 256,
 ): string => {
-	if (!icon) return "/images/bitcoin.svg";
-	if (icon.startsWith("https://static.btcmap.org/images/areas/")) {
-		return icon;
-	}
-	return `https://btcmap.org/.netlify/images?url=${encodeURIComponent(icon)}&fit=cover&w=${size}&h=${size}`;
+	if (!id || !icon) return "/images/bitcoin.svg";
+	return `${API_BASE}/v4/areas/${encodeURIComponent(String(id))}/image?type=square&w=${size}&h=${size}`;
 };

--- a/src/routes/communities/[section]/components/CommunityCard.svelte
+++ b/src/routes/communities/[section]/components/CommunityCard.svelte
@@ -78,7 +78,7 @@ $: tip =
 		>
 			<img
 				loading="lazy"
-				src={areaIconSrc(image)}
+				src={areaIconSrc(id, image)}
 				alt={tags.name}
 				class="mx-auto h-20 w-20 rounded-full object-cover"
 				on:error={function () {

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -173,7 +173,7 @@ const buildPopupHtml = (
 
 	const img = document.createElement("img");
 	img.loading = "lazy";
-	img.src = areaIconSrc(community.tags["icon:square"]);
+	img.src = areaIconSrc(community.id, community.tags["icon:square"]);
 	img.alt = t("communityMap.avatarAlt");
 	img.className = "w-24 h-24 rounded-full mx-auto";
 	img.title = t("communityMap.communityIconTitle");

--- a/src/routes/merchant/[id]/components/MerchantDetailsPanel.svelte
+++ b/src/routes/merchant/[id]/components/MerchantDetailsPanel.svelte
@@ -146,7 +146,7 @@ const withProtocol = (value: string, base: string): string =>
 						class="flex w-20 flex-col items-center gap-1 transition-transform hover:scale-105"
 					>
 						<img
-							src={areaIconSrc(community.tags['icon:square'])}
+							src={areaIconSrc(community.id, community.tags['icon:square'])}
 							alt={$_('aria.logoAlt')}
 							loading="lazy"
 							class="h-16 w-16 rounded-full object-cover"


### PR DESCRIPTION
## What

Migrates `areaIconSrc` from the `btcmap.org/.netlify/images` proxy to the new **`GET /v4/areas/{id}/image`** endpoint ([btcmap-api docs](https://github.com/teambtcmap/btcmap-api/blob/master/docs/rest/v4/areas.md#get-area-image)), which resizes rasters on the fly.

```ts
// before: keyed on the icon URL, resized via Netlify (static.* served full-size)
areaIconSrc(icon, size)
// after: keyed on the area id, resized by the API
areaIconSrc(id, icon, size) // -> {API_BASE}/v4/areas/{id}/image?type=square&w=…&h=…
```

The area `id` builds the URL (v2 `url_alias`, or numeric id for `MerchantArea`). The existing `icon:square` value is kept **only as an "image exists" gate**, so the `/images/bitcoin.svg` fallback behaves exactly as before — no reliance on 404s.

## Why

Emerged from evaluating whether the new endpoint helps #181. It **does not unblock #181** — that's gated on [btcmap-api #58](https://github.com/teambtcmap/btcmap-api/issues/58) (a bulk v4 `/areas` list with field selection to drop `geo_json`). But it's a good standalone cleanup:

- Drops the third-party Netlify image-proxy dependency.
- Consistent server-side resizing — `static.btcmap.org` icons were previously served at full native size regardless of the requested dimensions.

## Scope — 7 call sites

`CommunityRail`, `CommunityCard`, `communities/map`, `AreaPage`, `MerchantDetailsPanel`, `AreaLeaderboardItemName`, `AreaLeaderboardMobileCard` — all already have an `on:error` → bitcoin fallback.

## Non-goals

- **Countries** — untouched; they already bypass `areaIconSrc` and use their own `static.btcmap.org/images/countries/{cc}.svg` flags.
- **The areas v2→v4 data sync** — out of scope (the real #181 blocker).

## Testing

- `format:fix`, `check` (0 errors), `lint`, `test` (452 passed) all green.
- `areaIconSrc` unit tests rewritten for the new signature (URL build, custom size, numeric id, encoding, both fallback gates).
- Endpoint curl-verified live: `type=square&w=64` → 200 `image/png`; countries → SVG; missing variant/area → 404 (caught by the `on:error` handlers).
- Local browser visual check was blocked by a running-Chrome/profile conflict; `<img>` loads aren't CORS-restricted, so the preview deploy will show icons live.

Relates to #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Community and area avatars now load from the correct image source in cards, leaderboards, maps, and merchant details.
  * Improved fallback behavior so missing images display a default icon more reliably.
  * Avatar sizing is now handled consistently across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->