### PR TITLE
fix(map): stop the places search input from being scrambled while typing

### DIFF
--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -563,6 +563,13 @@ const executeSearch = async (query: string) => {
 		// response (abort only rejects the fetch, not the json() window). Don't
 		// let a late result reopen it.
 		if (!get(merchantList).isOpen) return;
+		// The user kept typing while this request was in flight, so it answers a
+		// query that is no longer on screen. Continuous typing keeps re-arming the
+		// debounce, so no newer request dispatched to abort this one. Dropping it
+		// here matters beyond stale results: openWithSearchResults writes `query`
+		// back into searchQuery, which feeds the search input's `value` prop —
+		// applying it would rewrite the input mid-word and reset the caret.
+		if (get(merchantList).searchQuery !== query) return;
 		merchantList.openWithSearchResults(query, results);
 	} catch (error) {
 		if (error instanceof Error && error.name === "AbortError") return;

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -11,7 +11,7 @@ import type {
 	Map as MapLibreMap,
 	Marker,
 } from "maplibre-gl";
-import { onDestroy, onMount } from "svelte";
+import { onDestroy, onMount, tick } from "svelte";
 import { get } from "svelte/store";
 
 import CommunityRail from "$components/CommunityRail.svelte";
@@ -105,6 +105,9 @@ export let data: PageData;
 // mobile search sheet and the desktop floating bar derive from one value so
 // a viewport resize can never leave zero or two search surfaces
 const isMobileLayout = browser && window.innerWidth < BREAKPOINTS.md;
+
+// Lets the floating search bar hand focus to the panel's input as it unmounts
+let merchantListPanel: MerchantListPanel;
 
 // "Boosted locations only" map filter (?boosts=true). The tools modal sets it
 // via a full page reload, so it's constant for the session; it narrows both the
@@ -2013,9 +2016,16 @@ onDestroy(() => {
 	<div class="pointer-events-none absolute top-3 left-3 z-[1000]">
 		<MapSearchBar
 			onSearch={handlePanelSearch}
-			onFocus={() => {
+			onFocus={async () => {
 				merchantList.open();
 				updateMerchantList({ force: true });
+				// Opening the panel unmounts this bar mid-focus, so focus falls to
+				// <body> and the click looks like it did nothing. Wait for the panel's
+				// input to mount, then hand focus over. Desktop only by construction:
+				// MapSearchBar doesn't render on mobile, where the sheet opens from a
+				// button facade so the on-screen keyboard stays down.
+				await tick();
+				merchantListPanel?.focusSearchInput();
 			}}
 			nearbyCount={$merchantList.totalCount}
 		/>
@@ -2023,6 +2033,7 @@ onDestroy(() => {
 {/if}
 
 <MerchantListPanel
+	bind:this={merchantListPanel}
 	onPanToNearbyMerchant={panToNearbyMerchant}
 	onZoomToSearchResult={zoomToSearchResult}
 	onZoomToNearbyLevel={zoomToNearbyLevel}

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -576,6 +576,12 @@ const executeSearch = async (query: string) => {
 		merchantList.openWithSearchResults(query, results);
 	} catch (error) {
 		if (error instanceof Error && error.name === "AbortError") return;
+		// Same staleness check as the success path. The user has typed past this
+		// query, so a newer request is already scheduled or in flight: toasting
+		// would report a failure for a query that is no longer on screen, and
+		// openSearchMode(false) below would clear the spinner out from under the
+		// newer search. That search reports its own failure if it also fails.
+		if (get(merchantList).searchQuery !== query) return;
 		console.error("Search error:", error);
 		errToast(get(_)("errors.searchUnavailable"));
 		// Mirror the success-path guard: if the panel was closed/collapsed while

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -203,6 +203,14 @@ onMount(() => {
 // Reference for search input component
 let searchInputComponent: SearchInput;
 
+// Called by the page after the desktop floating bar hands the panel over: that
+// bar unmounts as it opens the panel, so focus would otherwise land on <body>.
+// Deliberately not called on mobile — the sheet opens from a button facade, and
+// focusing the real input there raises the on-screen keyboard over the list.
+export function focusSearchInput() {
+	searchInputComponent?.focus();
+}
+
 // Body scroll lock state for mobile (prevents iOS background scroll)
 let scrollLockActive = false;
 

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -203,12 +203,20 @@ onMount(() => {
 // Reference for search input component
 let searchInputComponent: SearchInput;
 
+// Set only while focus is being moved here programmatically, so the resulting
+// focus event isn't tracked as a user interaction. focus() dispatches the event
+// synchronously, so the flag is always cleared by the time anything else runs.
+let focusingProgrammatically = false;
+
 // Called by the page after the desktop floating bar hands the panel over: that
 // bar unmounts as it opens the panel, so focus would otherwise land on <body>.
 // Deliberately not called on mobile — the sheet opens from a button facade, and
 // focusing the real input there raises the on-screen keyboard over the list.
 export function focusSearchInput() {
-	searchInputComponent?.focus();
+	if (!searchInputComponent) return;
+	focusingProgrammatically = true;
+	searchInputComponent.focus();
+	focusingProgrammatically = false;
 }
 
 // Body scroll lock state for mobile (prevents iOS background scroll)
@@ -218,6 +226,9 @@ let scrollLockActive = false;
 let panelElement: HTMLElement;
 
 function handleSearchFocus() {
+	// The floating bar already tracked this interaction before handing focus
+	// over; counting it again would inflate source:"panel" on every desktop open.
+	if (focusingProgrammatically) return;
 	trackEvent("search_input_focus", { source: "panel" });
 }
 

--- a/tests/merchant-list-panel.spec.ts
+++ b/tests/merchant-list-panel.spec.ts
@@ -337,11 +337,15 @@ test.describe('Merchant List Panel', () => {
 		await expect(listPanel).toBeVisible({ timeout: 10000 });
 		const panelInput = listPanel.locator('input[type="search"]');
 
-		// Arm the waiter before typing so the dispatch can't be missed.
-		const firstWordRequest = page.waitForRequest(
-			(r) => r.url().includes('/api/search/places') && r.url().includes('kiosk'),
-			{ timeout: 15000 }
-		);
+		// Arm the waiters before typing so the dispatch can't be missed. Match the
+		// first word exactly — "kiosk%20hamburg" also contains "kiosk".
+		const isFirstWord = (url: string) => url.endsWith('/api/search/places?name=kiosk');
+		const firstWordRequest = page.waitForRequest((r) => isFirstWord(r.url()), {
+			timeout: 15000
+		});
+		const firstWordResponse = page.waitForResponse((r) => isFirstWord(r.url()), {
+			timeout: 15000
+		});
 
 		await panelInput.pressSequentially('kiosk', { delay: 60 });
 		// The user's pause at the space: long enough for the 300ms debounce to fire.
@@ -351,7 +355,69 @@ test.describe('Merchant List Panel', () => {
 		// the debounce, so no newer request dispatches to abort the stale one.
 		await panelInput.pressSequentially(' hamburg', { delay: 100 });
 
+		// The stale answer must actually arrive before we can claim it was ignored,
+		// otherwise this passes for the wrong reason whenever typing outruns it.
+		await firstWordResponse;
+		// The next search dispatches 300ms after the last keystroke. Awaiting its
+		// response proves the stale one was fully processed, and lets the stubbed
+		// route finish instead of being torn down mid-sleep.
+		await page.waitForResponse((r) => r.url().includes('kiosk%20hamburg'), { timeout: 15000 });
+
 		await expect(panelInput).toHaveValue('kiosk hamburg');
+	});
+
+	// The catch path needs the same staleness check as the success path: a failure
+	// for an abandoned query must not toast, nor clear the spinner out from under
+	// the newer search that is already in flight.
+	test('a failed response for an earlier query does not toast or clobber the input', async ({
+		page
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		// "kiosk" fails slowly; the query the user actually ends up with succeeds.
+		await page.route('**/api/search/places*', async (route) => {
+			const url = route.request().url();
+			await new Promise((resolve) => setTimeout(resolve, 600));
+			if (url.endsWith('name=kiosk')) {
+				await route.fulfill({ status: 502, contentType: 'text/plain', body: 'upstream down' });
+				return;
+			}
+			await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+		});
+
+		await page.goto('/map#17/42.2762511/42.7024218', { waitUntil: 'load' });
+		await expect(page.getByRole('button', { name: 'Zoom in' })).toBeVisible();
+		await waitForMarkersToLoad(page);
+
+		const searchInput = page.getByRole('searchbox', { name: /search for bitcoin merchants/i });
+		await expect(searchInput).toBeVisible({ timeout: 15000 });
+		await searchInput.click();
+
+		const listPanel = page.locator('[role="complementary"][aria-label="Merchant list"]');
+		await expect(listPanel).toBeVisible({ timeout: 10000 });
+		const panelInput = listPanel.locator('input[type="search"]');
+
+		const isFirstWord = (url: string) => url.endsWith('/api/search/places?name=kiosk');
+		const firstWordRequest = page.waitForRequest((r) => isFirstWord(r.url()), {
+			timeout: 15000
+		});
+		const firstWordResponse = page.waitForResponse((r) => isFirstWord(r.url()), {
+			timeout: 15000
+		});
+
+		await panelInput.pressSequentially('kiosk', { delay: 60 });
+		await firstWordRequest;
+		await panelInput.pressSequentially(' hamburg', { delay: 100 });
+
+		await firstWordResponse;
+		await page.waitForResponse((r) => r.url().includes('kiosk%20hamburg'), { timeout: 15000 });
+
+		// The abandoned 502 is swallowed: input intact, no error toast. (The
+		// afterEach console-error check also catches its console.error.)
+		await expect(panelInput).toHaveValue('kiosk hamburg');
+		// Snapshot the count rather than expect(...).toHaveCount(0): that retries,
+		// so it would simply wait out the toast's 4s auto-dismiss and pass.
+		expect(await page.getByText(/search temporarily unavailable/i).count()).toBe(0);
 	});
 
 	// Focusing the desktop floating bar opens the panel, which unmounts the bar
@@ -375,9 +441,11 @@ test.describe('Merchant List Panel', () => {
 		const panelInput = listPanel.locator('input[type="search"]');
 		await expect(panelInput).toBeFocused();
 
-		// ...so a single click is enough to start typing
-		await page.keyboard.type('abc');
-		await expect(panelInput).toHaveValue('abc');
+		// ...so a single click is enough to start typing. Stay under the 3-char
+		// search threshold: this test stubs no routes, and a dispatched query would
+		// hit the real API and log a console error on failure.
+		await page.keyboard.type('ab');
+		await expect(panelInput).toHaveValue('ab');
 	});
 
 	// The mobile peek facade is a button, and tapping it must not focus the real

--- a/tests/merchant-list-panel.spec.ts
+++ b/tests/merchant-list-panel.spec.ts
@@ -354,6 +354,50 @@ test.describe('Merchant List Panel', () => {
 		await expect(panelInput).toHaveValue('kiosk hamburg');
 	});
 
+	// Focusing the desktop floating bar opens the panel, which unmounts the bar
+	// mid-focus and drops focus to <body>. The panel's own input has to pick it
+	// up, or the click appears to do nothing and typing goes nowhere.
+	test('desktop: focus moves to the panel search input when the panel opens', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		await page.goto('/map#17/42.2762511/42.7024218', { waitUntil: 'load' });
+		await expect(page.getByRole('button', { name: 'Zoom in' })).toBeVisible();
+		await waitForMarkersToLoad(page);
+
+		const searchInput = page.getByRole('searchbox', { name: /search for bitcoin merchants/i });
+		await expect(searchInput).toBeVisible({ timeout: 15000 });
+		await searchInput.click();
+
+		const listPanel = page.locator('[role="complementary"][aria-label="Merchant list"]');
+		await expect(listPanel).toBeVisible({ timeout: 10000 });
+
+		// The panel's input, not <body>, holds focus after the swap
+		const panelInput = listPanel.locator('input[type="search"]');
+		await expect(panelInput).toBeFocused();
+
+		// ...so a single click is enough to start typing
+		await page.keyboard.type('abc');
+		await expect(panelInput).toHaveValue('abc');
+	});
+
+	// The mobile peek facade is a button, and tapping it must not focus the real
+	// input — an autofocus there raises the on-screen keyboard over the list.
+	test('mobile: opening the sheet does not focus the search input', async ({ page }) => {
+		await page.setViewportSize({ width: 375, height: 667 });
+
+		await page.goto('/map#17/42.2762511/42.7024218', { waitUntil: 'load' });
+		await expect(page.getByRole('button', { name: 'Zoom in' })).toBeVisible();
+		await waitForMarkersToLoad(page);
+
+		const listPanel = page.locator('[role="complementary"][aria-label="Merchant list"]');
+		await expect(listPanel).toBeVisible({ timeout: 15000 });
+		await listPanel.getByRole('button', { name: /search places/i }).click();
+
+		const panelInput = listPanel.locator('input[type="search"]');
+		await expect(panelInput).toBeVisible({ timeout: 5000 });
+		await expect(panelInput).not.toBeFocused();
+	});
+
 	test('panel can be closed and floating search bar reappears', async ({ page }) => {
 		// Desktop viewport
 		await page.setViewportSize({ width: 1280, height: 720 });

--- a/tests/merchant-list-panel.spec.ts
+++ b/tests/merchant-list-panel.spec.ts
@@ -308,6 +308,52 @@ test.describe('Merchant List Panel', () => {
 		await expect(listPanel.locator('li button').first()).toBeVisible({ timeout: 15000 });
 	});
 
+	// Pausing mid-phrase (e.g. at the space in "kiosk hamburg") dispatches the
+	// debounced search for the first word. Resuming typing before that response
+	// lands used to rewrite the input with the in-flight query and reset the
+	// caret, eating the characters typed in between ("kiosk hamburg" → "kioskrg").
+	test('a slow response for an earlier query does not overwrite what the user typed', async ({
+		page
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		// Stub the search endpoint with a latency long enough to still be in
+		// flight while the second word is typed. Keeps the race deterministic
+		// and keeps the real search API out of the test.
+		await page.route('**/api/search/places*', async (route) => {
+			await new Promise((resolve) => setTimeout(resolve, 600));
+			await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+		});
+
+		await page.goto('/map#17/42.2762511/42.7024218', { waitUntil: 'load' });
+		await expect(page.getByRole('button', { name: 'Zoom in' })).toBeVisible();
+		await waitForMarkersToLoad(page);
+
+		const searchInput = page.getByRole('searchbox', { name: /search for bitcoin merchants/i });
+		await expect(searchInput).toBeVisible({ timeout: 15000 });
+		await searchInput.click();
+
+		const listPanel = page.locator('[role="complementary"][aria-label="Merchant list"]');
+		await expect(listPanel).toBeVisible({ timeout: 10000 });
+		const panelInput = listPanel.locator('input[type="search"]');
+
+		// Arm the waiter before typing so the dispatch can't be missed.
+		const firstWordRequest = page.waitForRequest(
+			(r) => r.url().includes('/api/search/places') && r.url().includes('kiosk'),
+			{ timeout: 15000 }
+		);
+
+		await panelInput.pressSequentially('kiosk', { delay: 60 });
+		// The user's pause at the space: long enough for the 300ms debounce to fire.
+		await firstWordRequest;
+
+		// Resume typing while "kiosk" is still in flight. Each keystroke re-arms
+		// the debounce, so no newer request dispatches to abort the stale one.
+		await panelInput.pressSequentially(' hamburg', { delay: 100 });
+
+		await expect(panelInput).toHaveValue('kiosk hamburg');
+	});
+
 	test('panel can be closed and floating search bar reappears', async ({ page }) => {
 		// Desktop viewport
 		await page.setViewportSize({ width: 1280, height: 720 });


### PR DESCRIPTION
## The bug

Typing a query with a natural pause in it — most reliably at a space, e.g. `kiosk hamburg` — scrambles the places search input. Reported as `fast` getting mangled; `kiosk hamburg` reproducibly became `kioskmburg`.

It is not a keystroke-ordering race. A **stale search response overwrites the input**.

`SearchInput` is a *controlled* input (`{value}`, not `bind:value`), so whatever the store holds in `searchQuery` is assigned straight onto `input.value`. `openWithSearchResults(query, results)` wrote back the `query` captured **when the request was dispatched**. When an old response landed, Svelte assigned `input.value = "kiosk"`, the browser reset the caret to the end, and every character typed in the meantime was lost.

Instrumented in a real browser:

```
t=1186  fetch-done         /api/search/places?name=kiosk
t=1189  programmatic-set   from:"kiosk ha" → to:"kiosk"   (SearchInput.svelte:142)
t=1277  user-input         "kioskm"    ← caret jumped to 5, " ha" was eaten
final:  "kioskmburg"
```

### Why a space triggers it

1. Type ≥3 chars, then pause **>300 ms** → the debounce dispatches a search for the first word.
2. Resume typing before the response lands (~370–500 ms, jittery).
3. Continuous typing re-arms the 300 ms debounce on every keystroke, so **no newer request ever dispatches to abort the in-flight one**.
4. The stale response resolves and clobbers the box.

`fast` is simply the shortest word that does it: the search fires at `fas`, and the `t` lands inside the window. The latency jitter is why it feels intermittent.

## The changes

**1. Ignore stale search responses** (`src/routes/map/+page.svelte`)

Drop a response whose query the user has already typed past. This also stops stale *results* painting over newer ones — the same bug wearing a different hat.

```ts
if (get(merchantList).searchQuery !== query) return;
merchantList.openWithSearchResults(query, results);
```

**2. Apply the same guard to failures** (`src/routes/map/+page.svelte`)

The catch block still handled abandoned queries. A `kiosk` request that fails while `" hamburg"` is being typed toasted an error for a query no longer on screen, and `openSearchMode(false)` cleared `isSearching` out from under the newer request already in flight.

**3. Hand focus to the panel search input on desktop** (`MerchantListPanel.svelte`, `+page.svelte`)

Found while reproducing the above: focusing the desktop floating bar opens the panel, which unmounts the bar mid-focus, dropping focus to `<body>`. The first click appeared to do nothing.

Mobile is deliberately untouched — `MapSearchBar` never renders there, and the sheet opens from a button facade precisely so the on-screen keyboard doesn't spring up. A test now pins both halves of that contract.

**4. Don't track the programmatic focus hand-off as a user event** (`MerchantListPanel.svelte`)

Moving focus fires the input's `on:focus`, so every desktop panel-open emitted `search_input_focus` twice (`source:"floating_bar"` **and** `source:"panel"`), which stopped `"panel"` measuring a deliberate click on the panel's own input. Suppressed while focus moves programmatically.

## Tests

Four e2e tests in `tests/merchant-list-panel.spec.ts`, each verified in **both** directions — I reverted each guard individually and confirmed its test fails:

- `a slow response for an earlier query does not overwrite what the user typed` — stubs `/api/search/places` with a 600 ms delay to make the race deterministic and keep the real API out of the test. Fails on `main` with `"kioskrg"`.
- `a failed response for an earlier query does not toast or clobber the input`
- `desktop: focus moves to the panel search input when the panel opens`
- `mobile: opening the sheet does not focus the search input`

Two timing traps worth knowing about, both fixed here:

- `expect(locator).toHaveCount(0)` **retries**, so asserting "no toast" that way simply waits out the toast's 4 s auto-dismiss and passes even when the toast appeared. Uses a one-shot `.count()` instead.
- Asserting the input value without first awaiting the stale response passes for the wrong reason whenever typing outruns the stubbed latency. Both the stale response and the follow-up one are now awaited (which also stops the stubbed route being torn down mid-sleep).

## Verification

- Every regression test fails before its fix, passes after.
- Full panel suite: **12/12 pass** (`--workers=2`). At the default 5 workers an unrelated mobile test intermittently times out in `waitForMarkersToLoad` — pre-existing real-API load flake, passes in isolation.
- Re-ran the instrumented `kiosk hamburg` reproduction against the dev app: value intact, **zero** programmatic writes to the input, stale response dropped, final query's results applied.
- Desktop focus verified with a real click in a browser: one click, typed `berlin`, landed intact.
- `format:fix` clean · `check` 0 errors · `lint` clean · 453 unit tests pass.

## Deliberately not in this PR

`MapSearchBar`'s `handleInput` / `handleKeyDown` / `handleClear` are already unreachable — the bar unmounts on its own focus event, so its input can never receive a keystroke. It predates this PR. Turning the desktop bar into a button facade (as mobile already does) would delete that dead code and remove the focus hand-off entirely, but it flips the a11y role from `searchbox` to `button`. Worth a follow-up.

`/api/search/places` matches **names only**, so `kiosk hamburg` legitimately returns `[]` — expected behavior, being handled upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)