### PR TITLE
ci(e2e): run svelte-kit sync before Playwright tests

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           needs-env: 'true'
-          needs-sync: 'false'
+          needs-sync: 'true'
 
       - name: Cache Playwright browsers
         id: playwright-cache


### PR DESCRIPTION
## Why

Playwright **1.62.0** (published 2026-07-24) made tsconfig loading strict: a missing `extends` target now throws, where 1.61.x silently ignored it ([`resolveConfigFile`](https://github.com/microsoft/playwright/blob/v1.62.0/packages/playwright/src/transform/tsconfigLoader.ts) gained an `existsSync` check).

Our root `tsconfig.json` extends `./.svelte-kit/tsconfig.json`, which only exists after `svelte-kit sync` runs — and the e2e job called the setup action with `needs-sync: 'false'`, so it never did. Result:

```
Error: Failed to load tsconfig file at .../tsconfig.json:
Failed to resolve "extends" path "./.svelte-kit/tsconfig.json" referenced from .../tsconfig.json
```

This is why **all nine Dependabot PRs from the 2026-07-29 batch fail e2e** (#1145–#1153), not just the Playwright bump #1147: `@playwright/test` is declared with a caret range (`^1.59.1`), and Dependabot's pnpm lockfile regeneration floats it to 1.62.0 as a side effect of every bump. Main stays green because its lockfile still pins 1.61.1 and CI installs with `--frozen-lockfile`.

## Fix

Flip `needs-sync` to `'true'` in the e2e workflow so the setup action runs `pnpm svelte-kit sync` after install. Adds ~1–2s to the job.

## After merge

Comment `@dependabot rebase` on the open Dependabot PRs — they should all go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated testing setup by ensuring the local test environment is synchronized before end-to-end tests run.
  * No changes to product functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->