### PR TITLE
refactor(map): scope the verified-years guard to its numeric domain #1156

### DIFF
--- a/src/lib/map/verifiedFilter.ts
+++ b/src/lib/map/verifiedFilter.ts
@@ -24,7 +24,10 @@ export const VERIFIED_FILTER_OPTIONS: {
 	{ value: "outdated", labelKey: "verificationFilter.outdatedOnly" },
 ];
 
-export const isVerifiedFilterYears = (v: unknown): v is 1 | 2 | 3 =>
+// Covers only the numeric year windows — NOT the full VerifiedFilterYears
+// union ("outdated" is parsed separately in getStoredVerifiedFilter), which
+// is why this stays module-private.
+const isVerifiedYearsWindow = (v: unknown): v is 1 | 2 | 3 =>
 	v === 1 || v === 2 || v === 3;
 
 export const getStoredVerifiedFilter = (): VerifiedFilterYears => {
@@ -34,7 +37,7 @@ export const getStoredVerifiedFilter = (): VerifiedFilterYears => {
 		if (raw === "outdated") return "outdated";
 		if (raw) {
 			const n = Number(raw);
-			if (isVerifiedFilterYears(n)) return n;
+			if (isVerifiedYearsWindow(n)) return n;
 		}
 	} catch {
 		// localStorage unavailable


### PR DESCRIPTION
Addresses the one actionable finding from the biweekly codebase health review (#1156):

> the guard's name reads like a full validator for `VerifiedFilterYears` while it only covers the numeric subset — a future caller could reasonably assume it accepts every valid filter value and drop the `"outdated"` branch.

Two-line fix, one step further than the suggested rename: `isVerifiedFilterYears` → `isVerifiedYearsWindow` **and** module-private (it had no users outside `verifiedFilter.ts`), so the misuse surface is removed rather than relabeled. A comment documents why it intentionally excludes `"outdated"`.

No behavior change; `format:fix` / `check` / `lint` / unit tests all clean.

For the record, the review's other notes needed no action: the README `pnpm run typecheck` hedge is fine (the script exists in `package.json` alongside `check`), and the rest was no-drift confirmation.

Refs #1156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal validation of stored verification filter values.
  * No visible changes to the user experience or available filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->