### PR TITLE
fix(map): stop the single-place resync from bypassing every filter #1158

### DIFF
--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -938,11 +938,13 @@ $: if (map && styleLoaded && $places) {
 // In-place mutations to a place (boost confirmation, new comment count)
 // don't change array length or any of the size counters above, so the
 // guard wouldn't repaint the pin. lastUpdatedPlaceId is set by
-// updateSinglePlace() in $lib/sync/places.ts — re-sync the source when
-// it fires, then clear so we don't re-sync next time anything else
-// triggers this reactive block.
+// updateSinglePlace() in $lib/sync/places.ts — invalidate the memo so the
+// marker block above re-runs, recomputes `effective` with the current
+// search/category/recency filters applied, and re-syncs (same idiom as the
+// style-load reset). Never sync raw $places here: that bypasses every
+// filter and poisons lastSyncedList for the heatmap/zoom-crossing paths.
 $: if (map && styleLoaded && $lastUpdatedPlaceId) {
-	syncPlacesToSource($places);
+	lastPlacesLength = -1;
 	lastUpdatedPlaceId.set(undefined);
 }
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -882,7 +882,8 @@ const triggerEnrichmentIfNeeded = debounce(() => {
 
 // In-place mutations to a place (boost confirmation, new comment count)
 // don't change array length or any of the size counters below, so the marker
-// block's guard wouldn't repaint the pin. lastUpdatedPlaceId is set by
+// block's guard wouldn't repaint the pin. lastUpdatedPlaceId is set by the
+// boost/comment flows (BoostContent, CommentAdd) right after they await
 // updateSinglePlace() in $lib/sync/places.ts — invalidate the memo so the
 // marker block re-runs with the current search/category/recency filters and
 // re-syncs (same idiom as the style-load reset). Never sync raw $places here:
@@ -895,7 +896,7 @@ const triggerEnrichmentIfNeeded = debounce(() => {
 // update pass. Note: in search mode pins render from searchResults, which
 // updateSinglePlace doesn't refresh, so the re-sync repaints only data the
 // store already holds.
-$: if (map && styleLoaded && $lastUpdatedPlaceId) {
+$: if (map && styleLoaded && $lastUpdatedPlaceId !== undefined) {
 	lastPlacesLength = -1;
 	lastUpdatedPlaceId.set(undefined);
 }

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -880,6 +880,26 @@ const triggerEnrichmentIfNeeded = debounce(() => {
 	);
 }, ENRICHMENT_DEBOUNCE_DELAY);
 
+// In-place mutations to a place (boost confirmation, new comment count)
+// don't change array length or any of the size counters below, so the marker
+// block's guard wouldn't repaint the pin. lastUpdatedPlaceId is set by
+// updateSinglePlace() in $lib/sync/places.ts — invalidate the memo so the
+// marker block re-runs with the current search/category/recency filters and
+// re-syncs (same idiom as the style-load reset). Never sync raw $places here:
+// that bypasses every filter and poisons lastSyncedList for the heatmap and
+// zoom-crossing paths. ORDERING MATTERS: this block must stay ABOVE the
+// marker block. Svelte 4 excludes self-assigned variables when ordering
+// reactive blocks, so the marker block (which also assigns lastPlacesLength)
+// is not sorted after this one — only source order guarantees the marker
+// block's dirty check sees the bit this assignment sets within the same
+// update pass. Note: in search mode pins render from searchResults, which
+// updateSinglePlace doesn't refresh, so the re-sync repaints only data the
+// store already holds.
+$: if (map && styleLoaded && $lastUpdatedPlaceId) {
+	lastPlacesLength = -1;
+	lastUpdatedPlaceId.set(undefined);
+}
+
 // Rebuild only when the count changes meaningfully (and always on first load),
 // to avoid jank on incremental store updates with ~50k places worldwide.
 // Also rebuild when $savedPlaceIds size changes so the saved badge appears/
@@ -933,19 +953,6 @@ $: if (map && styleLoaded && $places) {
 		lastSearchModeSig = searchSig;
 		syncPlacesToSource(effective);
 	}
-}
-
-// In-place mutations to a place (boost confirmation, new comment count)
-// don't change array length or any of the size counters above, so the
-// guard wouldn't repaint the pin. lastUpdatedPlaceId is set by
-// updateSinglePlace() in $lib/sync/places.ts — invalidate the memo so the
-// marker block above re-runs, recomputes `effective` with the current
-// search/category/recency filters applied, and re-syncs (same idiom as the
-// style-load reset). Never sync raw $places here: that bypasses every
-// filter and poisons lastSyncedList for the heatmap/zoom-crossing paths.
-$: if (map && styleLoaded && $lastUpdatedPlaceId) {
-	lastPlacesLength = -1;
-	lastUpdatedPlaceId.set(undefined);
 }
 
 // Position the locator pulse. Depends on $places too so a deep-linked merchant


### PR DESCRIPTION
Fixes #1158.

## What was happening
Boosting or commenting on a merchant fires `lastUpdatedPlaceId`, whose reactive block synced **raw `$places`** to the map source — bypassing search/category/recency filtering (in search mode even the boosts filter, so it pushed all ~29k places). Worse, it updated none of the marker block's memo variables, so the next reactive run compared the filtered count against a stale memo, saw "no change", and skipped the corrective resync — **the unfiltered map was sticky**. The direct sync also poisoned `lastSyncedList`, which the heatmap seed and the boosted-cluster zoom-crossing resync redraw.

## The fix
One line: invalidate the memo (`lastPlacesLength = -1` — the same idiom the style-load handler already uses) instead of syncing directly. The marker block re-runs in the same flush, recomputes `effective` with all current filters, refreshes every memo coherently, and resyncs. This also un-poisons `lastSyncedList` for the heatmap/zoom-crossing paths for free.

Deliberately **not** extracting shared filter logic here — that is the #1168 `visiblePlaces` refactor; this is the minimal correct fix.

## Verification
Boost/comment both POST to prod, so no e2e (per project test policy). Verified in the browser with a temporary dev-only hook calling `updateSinglePlace(id)` (GET) + `lastUpdatedPlaceId.set(id)` — the exact production trigger path:
- un-fixed: filtered 16,159 pins → jumped to 29,054 and **stayed** across waits (bug reproduced)
- fixed: stays 16,159 immediately and after settling

`format:fix` / `check` / `lint` / 466 unit tests clean.

## Known trade
In search mode a just-boosted pin no longer force-repaints its boost ring instantly (search results are store-held objects, not $places-sourced). The old code only "achieved" that repaint by destroying the filtered view; keeping the view correct wins.

## Merge order
Land this one first among #1158-#1162 — smallest diff; siblings rebase trivially. Whoever does #1168 must preserve or replace the memo-invalidation contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)