### PR TITLE
fix(map): apply the category filter to search-mode pins #1159

### DIFF
--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -158,10 +158,12 @@ let lastSavedIdsSize = -1;
 let lastEnrichedCacheSize = -1;
 let lastLocale: string | null | undefined;
 let lastAppliedLabelTheme: "light" | "dark" | undefined;
-// Signature of the search-mode visible set. Empty string forces an
-// initial sync; "n" = nearby (all places); "s:<id>,<id>,…" = a specific
-// search-result list. Distinct from lastPlacesLength because a fresh
-// search may have the same result count as the previous one.
+// Signature of the mode-dependent visible set. Empty string forces an
+// initial sync; "n" = nearby (all places); "c:<category>" = nearby
+// narrowed by a chip; "s:<category>:<id>,<id>,…" = a search-result list
+// (optionally narrowed by a chip); the sync guard appends "|v:<years>"
+// for the verified-recency window. Distinct from lastPlacesLength
+// because a fresh search or chip switch may leave the count unchanged.
 let lastSearchModeSig = "";
 
 // Last place list fed to the sources, kept so the boosted-clustering boundary

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -18,7 +18,10 @@ import CommunityRail from "$components/CommunityRail.svelte";
 import MapLoadingMain from "$components/MapLoadingMain.svelte";
 import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import { trackEvent } from "$lib/analytics";
-import { filterMerchantsByCategory } from "$lib/categoryMapping";
+import {
+	filterMerchantsByCategory,
+	placeMatchesCategory,
+} from "$lib/categoryMapping";
 import {
 	BREAKPOINTS,
 	CLUSTERING_DISABLED_ZOOM,
@@ -893,7 +896,15 @@ $: if (map && styleLoaded && $places) {
 	const category = $merchantList.selectedCategory;
 	let effective: Place[];
 	if (inSearch) {
-		effective = $merchantList.searchResults;
+		// Apply the category chips to search pins with the panel's exact
+		// predicate (placeMatchesCategory, see filteredSearchResults) so the
+		// list and the map always show the same set.
+		effective =
+			category === "all"
+				? $merchantList.searchResults
+				: $merchantList.searchResults.filter((p) =>
+						placeMatchesCategory(p, category),
+					);
 	} else if (category !== "all") {
 		effective = filterMerchantsByCategory($places, category);
 	} else {
@@ -914,7 +925,7 @@ $: if (map && styleLoaded && $places) {
 	const cacheSize = $merchantList.placeDetailsCache.size;
 	const currentLocale = $locale;
 	const modeSig = inSearch
-		? `s:${$merchantList.searchResults.map((p) => p.id).join(",")}`
+		? `s:${category}:${$merchantList.searchResults.map((p) => p.id).join(",")}`
 		: category !== "all"
 			? `c:${category}`
 			: "n";

--- a/tests/map-search-category-filter.spec.ts
+++ b/tests/map-search-category-filter.spec.ts
@@ -42,10 +42,14 @@ test.describe('Map search category filter', () => {
 				() => (window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount ?? 0
 			);
 
+		// Arm the response waiter BEFORE typing so a fast response can't land
+		// first (repo convention — see merchant-list-panel.spec.ts).
+		const searchResponse = page.waitForResponse(
+			(r) => r.url().includes('/api/search/places'),
+			{ timeout: 15000 }
+		);
 		await listPanel.locator('input[type="search"]').fill('resto');
-		await page.waitForResponse((r) => r.url().includes('/api/search/places'), {
-			timeout: 15000
-		});
+		await searchResponse;
 		// All three stubbed results become pins.
 		await expect
 			.poll(placesCount, { timeout: MARKER_LOAD_TIMEOUT })

--- a/tests/map-search-category-filter.spec.ts
+++ b/tests/map-search-category-filter.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+import { MARKER_LOAD_TIMEOUT, waitForMarkersToLoad } from './helpers';
+
+// Regression guard for #1159: in search mode the category chips must narrow
+// the map pins, not just the list — the marker pipeline previously rendered
+// raw searchResults, so list and pins diverged.
+const searchBody = (places: unknown[] = [], total = places.length) =>
+	JSON.stringify({ places, total, hasMore: total > places.length });
+
+// Near the test viewport (#17/42.2762511/42.7024218) so pins land in view.
+const STUB_PLACES = [
+	{ id: 9001, name: 'Resto One', lat: 42.2761, lon: 42.7023, icon: 'restaurant' },
+	{ id: 9002, name: 'Resto Two', lat: 42.2764, lon: 42.7026, icon: 'restaurant' },
+	{ id: 9003, name: 'Cafe Three', lat: 42.2766, lon: 42.7021, icon: 'local_cafe' }
+];
+
+test.describe('Map search category filter', () => {
+	test('category chips narrow the search pins, All restores them', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		await page.route('**/api/search/places*', async (route) => {
+			await route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: searchBody(STUB_PLACES)
+			});
+		});
+
+		await page.goto('/map#17/42.2762511/42.7024218', { waitUntil: 'load' });
+		await expect(page.getByRole('button', { name: 'Zoom in' })).toBeVisible();
+		await waitForMarkersToLoad(page);
+
+		const searchFacade = page.getByRole('button', { name: /search places/i });
+		await expect(searchFacade).toBeVisible({ timeout: 15000 });
+		await searchFacade.click();
+
+		const listPanel = page.locator('[role="complementary"][aria-label="Merchant list"]');
+		await expect(listPanel).toBeVisible({ timeout: 10000 });
+
+		const placesCount = () =>
+			page.evaluate(
+				() => (window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount ?? 0
+			);
+
+		await listPanel.locator('input[type="search"]').fill('resto');
+		await page.waitForResponse((r) => r.url().includes('/api/search/places'), {
+			timeout: 15000
+		});
+		// All three stubbed results become pins.
+		await expect
+			.poll(placesCount, { timeout: MARKER_LOAD_TIMEOUT })
+			.toBe(STUB_PLACES.length);
+
+		// Chip narrows the pins to the two restaurants (previously: list only).
+		await listPanel.getByRole('radio', { name: /restaurant/i }).click();
+		await expect.poll(placesCount, { timeout: 15000 }).toBe(2);
+
+		// All restores the full result set.
+		await listPanel.getByRole('radio', { name: /^all/i }).click();
+		await expect.poll(placesCount, { timeout: 15000 }).toBe(STUB_PLACES.length);
+	});
+});


### PR DESCRIPTION
Fixes #1159.

## What was happening
In search mode the marker pipeline's search branch rendered **raw `searchResults`** — the category chips filtered the merchant list (via the panel's `filteredSearchResults`) while the map kept every pin. The change-detection signature also omitted the category in search mode, so even a same-length category switch never re-synced.

## The fix
Two small edits in the marker reactive block:
- the search branch now filters with `placeMatchesCategory` — deliberately the **panel's exact predicate**, so list and pins agree by construction (the repo's two category predicates are only extensionally equal today; tying pins to the other one would recreate this bug class the day they diverge)
- the search signature includes the category (`s:${category}:${ids}`), so chip changes re-sync even at equal counts

Recency already reached search pins (the `inSearch` gate bypass); category was the only gap. Filter order matches the panel (category → recency).

## Verification
- Live (real GET-only search): "coffee" → 100 results/100 pins; Coffee chip → panel "82 of 100 result(s)", pins **82**; All → 100. Pre-fix pins stay at 100.
- New e2e (`tests/map-search-category-filter.spec.ts`): stubbed search route, chip narrows `__mapPlacesCount` 3→2→3 — fails on pre-fix code by construction. GET-only, no prod writes.
- `format:fix` / `check` / `lint` / unit suite clean.

## Notes
- Side effect (consistent, intentional): with the heatmap overlay on, search-mode density now also respects the chip.
- Known interim: "Show all on map" still fits **unfiltered** results until #1160 lands — this fix makes that mismatch more visible, sibling PR addresses it.
- Latent footgun documented in the commit: `filterMerchantsByCategory` vs `placeMatchesCategory` consolidation belongs to #1168.

## Merge order
Independent of #1177 (#1158) — different regions of the same file; either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)