### PR TITLE
fix(map): fit 'Show all' to the results the list shows #1160

### DIFF
--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -523,11 +523,11 @@ const isValidCoord = (lat: number, lon: number): boolean =>
 	lon >= -180 &&
 	lon <= 180;
 
-const fitSearchResultBounds = () => {
+// Fits the list the panel passes in (its filteredSearchResults) — never the
+// store's raw searchResults, which may include category/recency-hidden rows.
+const fitSearchResultBounds = (places: Place[]) => {
 	if (!map) return;
-	const results = get(merchantList).searchResults.filter((p) =>
-		isValidCoord(p.lat, p.lon),
-	);
+	const results = places.filter((p) => isValidCoord(p.lat, p.lon));
 	if (results.length === 0) return;
 	if (results.length === 1) {
 		// Match legacy: zoom past CLUSTERING_DISABLED_ZOOM (17) so the

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -62,8 +62,11 @@ export let currentZoom: number = 0;
 export let onSearch: ((query: string) => void) | undefined = undefined;
 // Refresh callback for category filtering
 export let onRefresh: (() => void) | undefined = undefined;
-// Callback to fit map bounds to all search results
-export let onFitSearchResultBounds: (() => void) | undefined = undefined;
+// Callback to fit map bounds to the search results the list actually shows.
+// Receives filteredSearchResults so the camera frames exactly the visible
+// set — deriving it page-side from raw searchResults is how it drifted.
+export let onFitSearchResultBounds: ((places: Place[]) => void) | undefined =
+	undefined;
 // Map style readiness — gates the mobile peek sheet so it doesn't show over the loading screen
 export let mapReady = false;
 // Layout decision locked at page init (same pattern as MerchantDrawerHash);
@@ -667,7 +670,7 @@ onDestroy(() => {
 						type="button"
 						on:click={() => {
 							trackEvent('show_all_on_map_click');
-							onFitSearchResultBounds?.();
+							onFitSearchResultBounds?.(filteredSearchResults);
 						}}
 						disabled={filteredSearchResults.length === 0}
 						class="flex shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors


### PR DESCRIPTION
Fixes #1160.

## What was happening
The "Show all on map" button's label and disabled state derive from the panel's `filteredSearchResults`, but the camera fit read **raw `searchResults`** from the store — with a category or verified filter active it framed places the user couldn't see.

## The fix
The panel passes its rendered `filteredSearchResults` through the callback (`onFitSearchResultBounds(places)`), and the page fits exactly what it's given — the store read is gone. Re-deriving the filtered set page-side was rejected: it would be a third copy of the filter pipeline, and the page's existing copy already drifted once (#1159). The empty-set race also closes: button disabled state and the page's zero-guard now key off the same array.

## Verification
Live browser QA with a geographically decisive case: "coffee" search + Restaurants chip → "5 of 100 result(s)" spanning SF/Dresden/Marbella/Boston. Click fit → camera centers at **lon −54.34**, the filtered bbox midpoint (predicted −54.35); the raw 100 (Japan → South Africa) would center near **+4**. Single-result zoom-17 ease and disabled-at-zero behavior unchanged. `format:fix` / `check` / `lint` / unit suite clean. Camera assertions aren't reasonably e2e-able (no map handle exposed); the existing panel spec still covers button absence in nearby mode.

## Notes
- Related but separate: the "N of M" status line has its own staleness when only the verified filter is active — that's #1162's territory (its fix includes the one-token condition widening).
- Until #1159 lands, category-hidden pins may sit outside the fitted bounds (pins don't yet respect chips); the button's contract — frame what the list shows — is correct either way.

## Merge order
Independent; any order with #1177/#1178.

🤖 Generated with [Claude Code](https://claude.com/claude-code)