### PR TITLE
fix(map): count the filtered set in the closed-panel badge #1161

### DIFF
--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -490,6 +490,35 @@ describe("merchantListStore", () => {
 			expect(get(merchantList).totalCount).toBe(2);
 		});
 
+		// Consistency guard for the open/close boundary: the closed-panel badge
+		// and the open panel's list must report the same total for the same
+		// rows under every filter mode, so the count never jumps on open.
+		it("agrees with fetchAndReplaceList's totalCount for the same rows under every filter", async () => {
+			const recent = new Date(Date.now() - 30 * 86400000).toISOString();
+			const old = new Date(Date.now() - 2 * 365 * 86400000).toISOString();
+			const rows = [
+				{ id: 1, lat: 0, lon: 0, name: "A", verified_at: recent },
+				{ id: 2, lat: 0, lon: 0, name: "B", verified_at: old },
+				{ id: 3, lat: 0, lon: 0, name: "C" },
+			];
+
+			for (const filter of [null, 1, "outdated"] as const) {
+				merchantList.setVerifiedFilter(filter, { persist: false });
+
+				(api.get as Mock).mockResolvedValueOnce({ data: rows });
+				await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+				const closedPanelCount = get(merchantList).totalCount;
+
+				(api.get as Mock).mockResolvedValueOnce({ data: rows });
+				await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+				const openPanelCount = get(merchantList).totalCount;
+
+				expect(closedPanelCount, `filter ${String(filter)}`).toBe(
+					openPanelCount,
+				);
+			}
+		});
+
 		it("should set totalCount from response length", async () => {
 			const mockIds = [{ id: 1 }, { id: 2 }, { id: 3 }];
 			(api.get as Mock).mockResolvedValueOnce({ data: mockIds });

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -430,7 +430,7 @@ describe("merchantListStore", () => {
 	});
 
 	describe("fetchCountOnly", () => {
-		it("should request only id field", async () => {
+		it("should request only id field while no recency filter is active", async () => {
 			(api.get as Mock).mockResolvedValueOnce({ data: [] });
 
 			await merchantList.fetchCountOnly({ lat: 10, lon: 20 }, 5);
@@ -439,6 +439,55 @@ describe("merchantListStore", () => {
 				expect.stringContaining("fields=id"),
 				expect.any(Object),
 			);
+			expect((api.get as Mock).mock.calls[0][0]).not.toContain("verified_at");
+		});
+
+		it("should widen the fields with verified_at while a recency filter is active", async () => {
+			merchantList.setVerifiedFilter(1, { persist: false });
+			(api.get as Mock).mockResolvedValueOnce({ data: [] });
+
+			await merchantList.fetchCountOnly({ lat: 10, lon: 20 }, 5);
+
+			expect(api.get).toHaveBeenCalledWith(
+				expect.stringContaining("fields=id,verified_at"),
+				expect.any(Object),
+			);
+		});
+
+		it("should count only recently verified places when a year window is active", async () => {
+			merchantList.setVerifiedFilter(1, { persist: false });
+			const recent = new Date(Date.now() - 30 * 86400000).toISOString();
+			const old = new Date(Date.now() - 2 * 365 * 86400000).toISOString();
+			(api.get as Mock).mockResolvedValueOnce({
+				data: [
+					{ id: 1, verified_at: recent },
+					{ id: 2, verified_at: old },
+					{ id: 3 },
+				],
+			});
+
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+			const state = get(merchantList);
+
+			expect(state.totalCount).toBe(1);
+			expect(state.merchants).toEqual([]);
+		});
+
+		it("should count stale and never-verified places in outdated mode", async () => {
+			merchantList.setVerifiedFilter("outdated", { persist: false });
+			const recent = new Date(Date.now() - 30 * 86400000).toISOString();
+			const old = new Date(Date.now() - 2 * 365 * 86400000).toISOString();
+			(api.get as Mock).mockResolvedValueOnce({
+				data: [
+					{ id: 1, verified_at: recent },
+					{ id: 2, verified_at: old },
+					{ id: 3 },
+				],
+			});
+
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).totalCount).toBe(2);
 		});
 
 		it("should set totalCount from response length", async () => {

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -502,6 +502,11 @@ describe("merchantListStore", () => {
 				{ id: 3, lat: 0, lon: 0, name: "C" },
 			];
 
+			// Absolute expectations per filter so both paths agreeing on a
+			// wrong value (or a swallowed rejection leaving the previous
+			// count in place) cannot pass vacuously.
+			const expected = { null: 3, 1: 1, outdated: 2 } as const;
+
 			for (const filter of [null, 1, "outdated"] as const) {
 				merchantList.setVerifiedFilter(filter, { persist: false });
 
@@ -516,7 +521,23 @@ describe("merchantListStore", () => {
 				expect(closedPanelCount, `filter ${String(filter)}`).toBe(
 					openPanelCount,
 				);
+				expect(closedPanelCount, `filter ${String(filter)}`).toBe(
+					expected[String(filter) as keyof typeof expected],
+				);
+
+				// The over-ceiling (hideIfExceeds) branch is the state users
+				// actually transition into over dense areas — its recency-only
+				// policy is the one fetchCountOnly mirrors; pin that too.
+				(api.get as Mock).mockResolvedValueOnce({ data: rows });
+				await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10, {
+					hideIfExceeds: 0,
+				});
+				expect(
+					get(merchantList).totalCount,
+					`over-ceiling, filter ${String(filter)}`,
+				).toBe(closedPanelCount);
 			}
+			expect(errToast).not.toHaveBeenCalled();
 		});
 
 		it("should set totalCount from response length", async () => {

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -331,7 +331,13 @@ function createMerchantListStore() {
 		// which is the state users transition into on open). Category needs
 		// nothing here: close() resets it to "all" and this path only runs with
 		// the panel closed. Search rows carry verified_at natively, so no
-		// verifiedDatesLoaded gate applies.
+		// verifiedDatesLoaded gate applies — that gate exists for the bulk
+		// $places feed, which lacks dates until enrichment. Deliberate trade:
+		// during the one-time enrichment fetch the badge (like the open panel
+		// list, which filters ungated for the same reason) is filtered while
+		// the markers briefly are not; gating the badge instead would make it
+		// disagree with the list at the open/close boundary — the exact
+		// mismatch this method exists to prevent.
 		async fetchCountOnly(
 			center: { lat: number; lon: number },
 			radiusKm: number,

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -348,7 +348,9 @@ function createMerchantListStore() {
 			const fields = verifiedWithinYears == null ? "id" : "id,verified_at";
 
 			try {
-				const response = await api.get<Place[]>(
+				// Typed to the payload actually requested — these rows are not
+				// full Places and must not be handed to anything expecting one.
+				const response = await api.get<Pick<Place, "id" | "verified_at">[]>(
 					`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`,
 					{ timeout: 10000, signal: listAbortController.signal },
 				);

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -365,6 +365,16 @@ function createMerchantListStore() {
 					verifiedWithinYears,
 				);
 
+				// A response that raced a filter change can settle before the
+				// re-invocation aborts it (e.g. during applyVerifiedFilter's
+				// ensureVerifiedDates await) — drop the stale count (the forced
+				// follow-up refetch owns the fresh one) but never strand the
+				// spinner.
+				if (get(store).verifiedWithinYears !== verifiedWithinYears) {
+					update((state) => ({ ...state, isLoadingList: false }));
+					return;
+				}
+
 				update((state) => ({
 					...state,
 					merchants: [],

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -324,8 +324,14 @@ function createMerchantListStore() {
 			}
 		},
 
-		// Fetch only IDs to get count (minimal payload for button badge)
-		// Used at zoom 10-14 when panel is closed - avoids fetching full data unnecessarily
+		// Count-only fetch for the closed-panel badge at zoom 10-14. Minimal
+		// payload: ids alone, widened with verified_at only while the recency
+		// filter is active so the badge counts the same set the markers and the
+		// open panel show (matching fetchAndReplaceList's hideIfExceeds policy,
+		// which is the state users transition into on open). Category needs
+		// nothing here: close() resets it to "all" and this path only runs with
+		// the panel closed. Search rows carry verified_at natively, so no
+		// verifiedDatesLoaded gate applies.
 		async fetchCountOnly(
 			center: { lat: number; lon: number },
 			radiusKm: number,
@@ -335,9 +341,15 @@ function createMerchantListStore() {
 
 			update((state) => ({ ...state, isLoadingList: true }));
 
+			// One snapshot so the fields param and the post-response filter can
+			// never disagree; a mid-flight filter change re-invokes this method,
+			// which aborts the stale request above.
+			const { verifiedWithinYears } = get(store);
+			const fields = verifiedWithinYears == null ? "id" : "id,verified_at";
+
 			try {
-				const response = await api.get<{ id: number }[]>(
-					`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=id`,
+				const response = await api.get<Place[]>(
+					`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`,
 					{ timeout: 10000, signal: listAbortController.signal },
 				);
 
@@ -348,11 +360,15 @@ function createMerchantListStore() {
 
 				// Filter out invalid items missing required id field
 				const validItems = filterValidPlaces(response.data);
+				const recencyPlaces = filterPlacesByRecency(
+					validItems,
+					verifiedWithinYears,
+				);
 
 				update((state) => ({
 					...state,
 					merchants: [],
-					totalCount: validItems.length,
+					totalCount: recencyPlaces.length,
 					isLoadingList: false,
 					// Preserve existing categoryCounts since we don't have actual merchant data to recalculate them
 				}));

--- a/src/lib/verification.ts
+++ b/src/lib/verification.ts
@@ -53,10 +53,13 @@ export type RecencyFilter = 1 | 2 | 3 | "outdated" | null;
 // excluded when a year filter is active, matching the Android app. "outdated"
 // inverts the 12-month window — only places whose verification is missing or
 // stale remain (the re-verification worklist, /map?outdated).
-export function filterPlacesByRecency(
-	places: Place[],
+// Generic over anything carrying verified_at so partial-field API rows
+// (e.g. the count-only id,verified_at fetch) filter without pretending to
+// be full Places.
+export function filterPlacesByRecency<T extends Pick<Place, "verified_at">>(
+	places: T[],
 	filter: RecencyFilter,
-): Place[] {
+): T[] {
 	if (filter == null) return places;
 	if (filter === "outdated") {
 		return places.filter((p) => !isRecentlyVerified(p.verified_at));


### PR DESCRIPTION
Fixes #1161.

## What was happening
At zoom 10-14 with the panel closed, `fetchCountOnly` requested `fields=id` and wrote `totalCount` straight from the raw array — the nearby pill and search-bar badge ignored the verified/outdated filter. This fired on **first paint** for `?outdated` deep links and returning users with a persisted window: filtered markers, unfiltered count.

## The fix
Store-local, inside `fetchCountOnly`:
- snapshot the filter once so the `fields` param and the post-response filter can never disagree (a mid-flight change re-invokes and aborts)
- widen to `fields=id,verified_at` **only while a filter is active** — the common filter-off request stays byte-identical to today
- count the recency-filtered set

**Deliberately recency-only** (analysis findings): category would be dead code — `close()` resets it to `'all'` and this path only runs with the panel closed; boost needs nothing — `?boosts=true` forces the local-markers path, making this fetch unreachable. The policy exactly matches `fetchAndReplaceList`'s `hideIfExceeds` branch (recency-only), the state users transition into on open — so the count no longer jumps at the open/close boundary. A filtered count of 0 now correctly falls through to "no merchants" instead of a phantom "zoom in" prompt.

## Verification
- Unit (TDD, red→green): fields stay `id` with filter off (tightened to assert **absence** of `verified_at`), widen with filter on, year-window counting, outdated-mode counting (stale + never-verified). 68 store tests green.
- Live at zoom 12 over Hamburg: badge **18 nearby** unfiltered vs **7 nearby** with `?outdated` (pre-fix: 18 both).
- `format:fix` / `check` / `lint` / full unit suite clean.

## Notes
Pre-existing and intentionally untouched: closing a panel that had a category selected leaves the category-filtered count on the pill until the next moveend — #1171's territory.

## Merge order
Independent of the sibling PRs (#1177/#1178/#1179); same file as #1162's fix but ~150 lines apart, disjoint hunks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)