### PR TITLE
fix(map): keep search-mode category counts in sync with the verified filter #1162

### DIFF
--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store";
 import type { Mock } from "vitest";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CATEGORIES, placeMatchesCategory } from "$lib/categoryMapping";
 import {
@@ -92,6 +92,14 @@ describe("merchantListStore", () => {
 			lastUpdated: null,
 			usesMetricSystem: null,
 		});
+	});
+
+	afterEach(() => {
+		// Defensive: tests that persist the verified filter clean up inline,
+		// but a failing assertion would skip that — never leak the key. (Note
+		// reset() restores module-init state and does NOT re-read storage, so
+		// today a leak is inert; this guards the day that changes.)
+		localStorage.removeItem(VERIFIED_FILTER_STORAGE_KEY);
 	});
 
 	describe("state toggles", () => {

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -6,6 +6,7 @@ import {
 	MERCHANT_LIST_FETCH_CEILING,
 	MERCHANT_LIST_MAX_ITEMS,
 } from "$lib/constants";
+import { VERIFIED_FILTER_STORAGE_KEY } from "$lib/map/verifiedFilter";
 import type { Place } from "$lib/types";
 
 // Mock the centralized axios instance
@@ -746,6 +747,115 @@ describe("merchantListStore", () => {
 			expect(state.mode).toBe("nearby");
 			expect(state.searchQuery).toBe("pizza");
 			expect(state.searchResults.length).toBe(1);
+		});
+	});
+
+	describe("setVerifiedFilter", () => {
+		const recent = () => new Date(Date.now() - 30 * 86400000).toISOString();
+		const old = () => new Date(Date.now() - 2 * 365 * 86400000).toISOString();
+
+		it("recomputes search-mode category counts for the new window", () => {
+			merchantList.openWithSearchResults("test query", [
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: recent() }),
+				createMockPlace({ id: 2, icon: "restaurant", verified_at: old() }),
+				createMockPlace({ id: 3, icon: "local_cafe", verified_at: recent() }),
+				createMockPlace({ id: 4, icon: "local_atm", verified_at: old() }),
+			]);
+			expect(get(merchantList).categoryCounts.all).toBe(4);
+
+			merchantList.setVerifiedFilter(1, { persist: false });
+			const counts = get(merchantList).categoryCounts;
+
+			expect(counts.all).toBe(2);
+			expect(counts.restaurants).toBe(1);
+			expect(counts.coffee).toBe(1);
+			expect(counts.atms).toBe(0);
+		});
+
+		it("restores the full counts when the filter clears", () => {
+			merchantList.openWithSearchResults("test query", [
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: recent() }),
+				createMockPlace({ id: 2, icon: "local_cafe", verified_at: old() }),
+			]);
+			merchantList.setVerifiedFilter(1, { persist: false });
+			expect(get(merchantList).categoryCounts.all).toBe(1);
+
+			merchantList.setVerifiedFilter(null, { persist: false });
+			expect(get(merchantList).categoryCounts.all).toBe(2);
+		});
+
+		it("inverts the window in outdated mode", () => {
+			merchantList.openWithSearchResults("test query", [
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: recent() }),
+				createMockPlace({ id: 2, icon: "restaurant", verified_at: old() }),
+				createMockPlace({ id: 3, icon: "local_cafe", verified_at: recent() }),
+				createMockPlace({ id: 4, icon: "local_atm" }),
+			]);
+
+			merchantList.setVerifiedFilter("outdated", { persist: false });
+			const counts = get(merchantList).categoryCounts;
+
+			expect(counts.all).toBe(2);
+			expect(counts.restaurants).toBe(1);
+			expect(counts.atms).toBe(1);
+			expect(counts.coffee).toBe(0);
+		});
+
+		it("auto-resets a selected category the new window zeroes", () => {
+			merchantList.openWithSearchResults("test query", [
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: old() }),
+				createMockPlace({ id: 2, icon: "local_cafe", verified_at: recent() }),
+			]);
+			merchantList.setSelectedCategory("restaurants");
+
+			merchantList.setVerifiedFilter(1, { persist: false });
+
+			expect(get(merchantList).selectedCategory).toBe("all");
+		});
+
+		it("keeps a selected category the new window still populates", () => {
+			merchantList.openWithSearchResults("test query", [
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: recent() }),
+				createMockPlace({ id: 2, icon: "local_cafe", verified_at: old() }),
+			]);
+			merchantList.setSelectedCategory("restaurants");
+
+			merchantList.setVerifiedFilter(1, { persist: false });
+
+			expect(get(merchantList).selectedCategory).toBe("restaurants");
+		});
+
+		it("leaves nearby-mode counts to the page-driven refresh", () => {
+			merchantList.setMerchants([
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: old() }),
+			]);
+
+			merchantList.setVerifiedFilter(1, { persist: false });
+			const state = get(merchantList);
+
+			expect(state.verifiedWithinYears).toBe(1);
+			expect(state.categoryCounts.all).toBe(1);
+		});
+
+		it("does not touch counts when the search has no results", () => {
+			merchantList.openWithSearchResults("test query", [
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: old() }),
+			]);
+			merchantList.clearSearchInput();
+
+			merchantList.setVerifiedFilter(1, { persist: false });
+
+			expect(get(merchantList).categoryCounts.all).toBe(1);
+		});
+
+		it("persist option still controls storage", () => {
+			merchantList.setVerifiedFilter(2);
+			expect(localStorage.getItem(VERIFIED_FILTER_STORAGE_KEY)).toBe("2");
+
+			merchantList.setVerifiedFilter(1, { persist: false });
+			expect(localStorage.getItem(VERIFIED_FILTER_STORAGE_KEY)).toBe("2");
+
+			localStorage.removeItem(VERIFIED_FILTER_STORAGE_KEY);
 		});
 	});
 

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -2,12 +2,14 @@ import { get } from "svelte/store";
 import type { Mock } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { CATEGORIES, placeMatchesCategory } from "$lib/categoryMapping";
 import {
 	MERCHANT_LIST_FETCH_CEILING,
 	MERCHANT_LIST_MAX_ITEMS,
 } from "$lib/constants";
 import { VERIFIED_FILTER_STORAGE_KEY } from "$lib/map/verifiedFilter";
 import type { Place } from "$lib/types";
+import { filterPlacesByRecency } from "$lib/verification";
 
 // Mock the centralized axios instance
 vi.mock("$lib/axios", () => ({
@@ -856,6 +858,45 @@ describe("merchantListStore", () => {
 			expect(localStorage.getItem(VERIFIED_FILTER_STORAGE_KEY)).toBe("2");
 
 			localStorage.removeItem(VERIFIED_FILTER_STORAGE_KEY);
+		});
+
+		// Consistency oracle: whatever the filter mode, the chip counts must
+		// describe exactly the selection the panel renders — its
+		// filteredSearchResults rule (recency window, then per-category via
+		// placeMatchesCategory) replicated here as the reference.
+		it("counts always describe the selection the panel renders", () => {
+			const recent = new Date(Date.now() - 30 * 86400000).toISOString();
+			const old = new Date(Date.now() - 2 * 365 * 86400000).toISOString();
+			merchantList.openWithSearchResults("test query", [
+				createMockPlace({ id: 1, icon: "restaurant", verified_at: recent }),
+				createMockPlace({ id: 2, icon: "restaurant", verified_at: old }),
+				createMockPlace({ id: 3, icon: "local_cafe", verified_at: recent }),
+				createMockPlace({ id: 4, icon: "local_cafe" }),
+				createMockPlace({ id: 5, icon: "local_atm", verified_at: old }),
+				createMockPlace({ id: 6, icon: "storefront", verified_at: recent }),
+				createMockPlace({ id: 7, icon: "hotel", verified_at: old }),
+				createMockPlace({ id: 8, icon: "some_unknown", verified_at: recent }),
+				createMockPlace({ id: 9, verified_at: old }),
+			]);
+
+			for (const filter of [null, 1, 2, 3, "outdated"] as const) {
+				merchantList.setVerifiedFilter(filter, { persist: false });
+				const { categoryCounts, searchResults } = get(merchantList);
+				const rendered = filterPlacesByRecency(searchResults, filter);
+
+				expect(categoryCounts.all, `filter ${String(filter)}`).toBe(
+					rendered.length,
+				);
+				for (const category of CATEGORIES) {
+					if (category === "all") continue;
+					expect(
+						categoryCounts[category],
+						`filter ${String(filter)} / category ${category}`,
+					).toBe(
+						rendered.filter((p) => placeMatchesCategory(p, category)).length,
+					);
+				}
+			}
 		});
 	});
 

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -76,6 +76,19 @@ function resetCategoryState<T extends MerchantListState>(state: T): T {
 	return { ...state, selectedCategory: "all" };
 }
 
+// The auto-reset rule shared by every counts recompute: a selected chip whose
+// count dropped to zero (while other merchants remain) snaps back to "all".
+function shouldResetCategory(
+	selectedCategory: CategoryKey,
+	categoryCounts: CategoryCounts,
+): boolean {
+	return (
+		selectedCategory !== "all" &&
+		categoryCounts.all > 0 &&
+		categoryCounts[selectedCategory] === 0
+	);
+}
+
 // Helper to apply category filtering with auto-reset when selected category has no matches
 // Returns filtered merchants and the effective category (may be reset to 'all')
 function applyCategoryFilter(
@@ -83,13 +96,12 @@ function applyCategoryFilter(
 	selectedCategory: CategoryKey,
 	categoryCounts: CategoryCounts,
 ): { filtered: Place[]; effectiveCategory: CategoryKey } {
-	// Auto-reset if selected category has no matches but other merchants exist
-	const shouldReset =
-		selectedCategory !== "all" &&
-		categoryCounts.all > 0 &&
-		categoryCounts[selectedCategory] === 0;
-
-	const effectiveCategory = shouldReset ? "all" : selectedCategory;
+	const effectiveCategory = shouldResetCategory(
+		selectedCategory,
+		categoryCounts,
+	)
+		? "all"
+		: selectedCategory;
 
 	const filtered =
 		effectiveCategory !== "all"
@@ -518,20 +530,21 @@ function createMerchantListStore() {
 						years,
 					);
 					const categoryCounts = countMerchantsByCategory(recencyResults);
-					// Auto-reset from the counts alone (applyCategoryFilter's rule,
-					// minus its filtered list, which nothing here consumes — and
-					// whose predicate differs from the one the panel renders with):
-					// a window that zeroes the selected chip snaps selection to
-					// "all", exactly as nearby mode does.
-					const shouldReset =
-						state.selectedCategory !== "all" &&
-						categoryCounts.all > 0 &&
-						categoryCounts[state.selectedCategory] === 0;
+					// Shared auto-reset rule, counts-only (deliberately not
+					// applyCategoryFilter: its filtered list is unused here and
+					// built with a different predicate than the panel renders
+					// with): a window that zeroes the selected chip snaps
+					// selection to "all", exactly as nearby mode does.
 					return {
 						...state,
 						verifiedWithinYears: years,
 						categoryCounts,
-						selectedCategory: shouldReset ? "all" : state.selectedCategory,
+						selectedCategory: shouldResetCategory(
+							state.selectedCategory,
+							categoryCounts,
+						)
+							? "all"
+							: state.selectedCategory,
 					};
 				}
 				return { ...state, verifiedWithinYears: years };

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -530,10 +530,14 @@ function createMerchantListStore() {
 						years,
 					);
 					const categoryCounts = countMerchantsByCategory(recencyResults);
-					// Shared auto-reset rule, counts-only (deliberately not
-					// applyCategoryFilter: its filtered list is unused here and
-					// built with a different predicate than the panel renders
-					// with): a window that zeroes the selected chip snaps
+					// Shared auto-reset rule, counts-only. Deliberately not
+					// applyCategoryFilter: its filtered list is unused here, and
+					// it filters via filterMerchantsByCategory (group icon-list
+					// scan) while the panel renders via placeMatchesCategory
+					// (ICON_TO_CATEGORY lookup) — two implementations that agree
+					// only while the categoryMapping equivalence tests hold, so
+					// this path avoids depending on the one the panel doesn't
+					// use. A window that zeroes the selected chip snaps
 					// selection to "all", exactly as nearby mode does.
 					return {
 						...state,

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -502,7 +502,39 @@ function createMerchantListStore() {
 			opts: { persist?: boolean } = {},
 		) {
 			if (opts.persist !== false) storeVerifiedFilter(years);
-			update((state) => ({ ...state, verifiedWithinYears: years }));
+			update((state) => {
+				// In search mode the page-level refresh (updateMerchantList)
+				// early-returns, so recompute the chip counts here from the same
+				// recency-filtered selection the panel renders — otherwise they
+				// freeze at search time and disagree with the visible list.
+				// Search results carry their own verified_at (from /v4/search),
+				// so no verifiedDatesLoaded gate applies, matching the panel and
+				// the marker block's inSearch bypass. Nearby mode stays untouched:
+				// the forced update re-runs setMerchants/fetchAndReplaceList,
+				// which own that recompute.
+				if (state.mode === "search" && state.searchResults.length > 0) {
+					const recencyResults = filterPlacesByRecency(
+						state.searchResults,
+						years,
+					);
+					const categoryCounts = countMerchantsByCategory(recencyResults);
+					// applyCategoryFilter keeps the auto-reset semantics single-owner:
+					// a window that zeroes the selected chip snaps selection to "all",
+					// exactly as nearby mode does.
+					const { effectiveCategory } = applyCategoryFilter(
+						recencyResults,
+						state.selectedCategory,
+						categoryCounts,
+					);
+					return {
+						...state,
+						verifiedWithinYears: years,
+						categoryCounts,
+						selectedCategory: effectiveCategory,
+					};
+				}
+				return { ...state, verifiedWithinYears: years };
+			});
 		},
 
 		// Reset the selected category to 'all'

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -518,19 +518,20 @@ function createMerchantListStore() {
 						years,
 					);
 					const categoryCounts = countMerchantsByCategory(recencyResults);
-					// applyCategoryFilter keeps the auto-reset semantics single-owner:
-					// a window that zeroes the selected chip snaps selection to "all",
-					// exactly as nearby mode does.
-					const { effectiveCategory } = applyCategoryFilter(
-						recencyResults,
-						state.selectedCategory,
-						categoryCounts,
-					);
+					// Auto-reset from the counts alone (applyCategoryFilter's rule,
+					// minus its filtered list, which nothing here consumes — and
+					// whose predicate differs from the one the panel renders with):
+					// a window that zeroes the selected chip snaps selection to
+					// "all", exactly as nearby mode does.
+					const shouldReset =
+						state.selectedCategory !== "all" &&
+						categoryCounts.all > 0 &&
+						categoryCounts[state.selectedCategory] === 0;
 					return {
 						...state,
 						verifiedWithinYears: years,
 						categoryCounts,
-						selectedCategory: effectiveCategory,
+						selectedCategory: shouldReset ? "all" : state.selectedCategory,
 					};
 				}
 				return { ...state, verifiedWithinYears: years };

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -630,7 +630,10 @@ onDestroy(() => {
 							{$_('search.noResults')}
 						{:else if searchResults.length === 0}
 							{$_('search.prompt')}
-						{:else if selectedCategory !== 'all' && filteredSearchResults.length !== searchResults.length}
+						{:else if filteredSearchResults.length !== searchResults.length}
+							<!-- Any client-side narrowing (category chip OR verified filter)
+							     shows shown-of-returned, so the line always describes the
+							     rows actually rendered below it -->
 							{$_('search.resultsCountOf', {
 								values: {
 									shown: filteredSearchResults.length,


### PR DESCRIPTION
Fixes #1162. Two commits, two halves of the same divergence:

## 1. Store: recompute counts on filter change
In search mode `applyVerifiedFilter`'s forced list refresh early-returns, so `categoryCounts` froze at search time while the rendered list re-derived reactively — chip enabled/disabled state and the "N of M" line disagreed with the visible rows. `setVerifiedFilter` now recomputes the counts from the **same recency-filtered selection the panel renders** (search rows carry their own `verified_at`, so no readiness gate — matching the panel and the marker block's `inSearch` bypass), reusing `applyCategoryFilter` so a window that zeroes the selected chip snaps selection back to All exactly as nearby mode does.

Deliberately scoped (analysis findings): nearby mode is untouched — the forced refresh already recomputes its counts via `setMerchants`/`fetchAndReplaceList`; the one nearby hole (closed-panel count path) is #1161's separate fix. Guarded on non-empty results so the empty search prompt and the `?outdated` mount-time seed stay no-ops. Fresh searches with a filter already active were already correct.

## 2. Panel: status line describes the rendered rows
The "N of M" branch required a category chip, so a verified-filter-only reduction reported raw `searchResults.length` — "100 results" above a 90-row list. The condition now fires on any length mismatch. Known trade (documented in the commit): truncated **and** filtered searches read shown-of-returned rather than returned-of-server-total, since the server total for the filtered set is unknowable client-side.

## Verification
- Unit (TDD, red→green): 8 new `setVerifiedFilter` cases — recompute per window, restore on clear, outdated inversion, auto-reset of a zeroed chip, keep of a populated chip, nearby untouched, empty-search untouched, persist contract. 73 store tests green.
- Live: "coffee" search (100 results) + "Verified within 1 year" → status "**90 of 100 result(s)**" with exactly 90 rows rendered; chips re-derive. Pre-fix: "100 of 1,091" above the same 90 rows.
- `format:fix` / `check` / `lint` / full suite clean.

## Merge order
Same file as #1180 but disjoint hunks (~150 lines apart); tests placed in a separate describe to avoid append conflicts. Any order with the other four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)