### PR TITLE
test(map): guard the equivalence of the two category predicates #1159

### DIFF
--- a/src/lib/categoryMapping.test.ts
+++ b/src/lib/categoryMapping.test.ts
@@ -420,4 +420,65 @@ describe("categoryMapping", () => {
 			expect(getIconColorWithFallback("some_unknown_icon")).not.toBe("");
 		});
 	});
+
+	// The map pins (search branch), the panel's filteredSearchResults, and the
+	// store's applyCategoryFilter split between filterMerchantsByCategory
+	// (group icon-list membership) and placeMatchesCategory (last-write-wins
+	// icon→category lookup). They are only extensionally equal while no icon
+	// appears in two groups — the moment that breaks, pins and list silently
+	// diverge again (the #1159 bug class). These tests make that divergence
+	// loud instead of silent.
+	describe("category predicate equivalence", () => {
+		// Every mapped icon, plus the shapes callers actually see: unknown,
+		// empty, and missing icons.
+		const corpus: Place[] = [
+			...CATEGORY_ENTRIES.flatMap(([, group]) =>
+				group.icons.map((icon) => createMockPlace({ icon })),
+			),
+			createMockPlace({ icon: "some_unknown_icon" }),
+			createMockPlace({ icon: "" }),
+			createMockPlace({}),
+		];
+
+		it("no icon belongs to two category groups", () => {
+			const seen = new Map<string, CategoryKey>();
+			for (const [key, group] of CATEGORY_ENTRIES) {
+				for (const icon of group.icons) {
+					const previous = seen.get(icon);
+					expect(
+						previous,
+						`icon "${icon}" is in both "${previous}" and "${key}" — filterMerchantsByCategory and placeMatchesCategory now disagree; consolidate to one predicate (#1168) before shipping this`,
+					).toBeUndefined();
+					seen.set(icon, key);
+				}
+			}
+		});
+
+		it("filterMerchantsByCategory and placeMatchesCategory select the same set for every category", () => {
+			for (const category of CATEGORIES) {
+				const viaGroupFilter = filterMerchantsByCategory(corpus, category).map(
+					(p) => p.id,
+				);
+				const viaPlacePredicate = corpus
+					.filter((p) => placeMatchesCategory(p, category))
+					.map((p) => p.id);
+				expect(viaGroupFilter, `category "${category}"`).toEqual(
+					viaPlacePredicate,
+				);
+			}
+		});
+
+		it("countMerchantsByCategory agrees with both predicates for every category", () => {
+			const counts = countMerchantsByCategory(corpus);
+			for (const category of CATEGORIES) {
+				if (category === "all") {
+					expect(counts.all).toBe(corpus.length);
+					continue;
+				}
+				expect(counts[category], `category "${category}"`).toBe(
+					filterMerchantsByCategory(corpus, category).length,
+				);
+			}
+		});
+	});
 });

--- a/src/lib/categoryMapping.test.ts
+++ b/src/lib/categoryMapping.test.ts
@@ -451,9 +451,14 @@ describe("categoryMapping", () => {
 						`falsy icon in group "${key}" — placeMatchesCategory early-returns on falsy icons while filterMerchantsByCategory matches them`,
 					).toBeTruthy();
 					const previous = seen.get(icon);
+					// Distinguish the repeat cases: a duplicate WITHIN a group is
+					// harmless to predicate equivalence but still a config mistake;
+					// a repeat ACROSS groups is the divergence hazard itself.
 					expect(
 						previous,
-						`icon "${icon}" is in both "${previous}" and "${key}" — filterMerchantsByCategory and placeMatchesCategory now disagree; consolidate to one predicate (#1168) before shipping this`,
+						previous === key
+							? `icon "${icon}" is listed twice in group "${key}" — remove the duplicate`
+							: `icon "${icon}" is in both "${previous}" and "${key}" — filterMerchantsByCategory and placeMatchesCategory now disagree; consolidate to one predicate (#1168) before shipping this`,
 					).toBeUndefined();
 					seen.set(icon, key);
 				}

--- a/src/lib/categoryMapping.test.ts
+++ b/src/lib/categoryMapping.test.ts
@@ -468,13 +468,16 @@ describe("categoryMapping", () => {
 		it("filterMerchantsByCategory and placeMatchesCategory select the same set for every category", () => {
 			// Compare by icon, not id: a divergence failure then names the
 			// offending icon directly instead of printing random mock ids.
+			// Sorted so the claim is literally about the SET — a reimplementation
+			// that reorders while selecting the same places must not fail this.
 			for (const category of CATEGORIES) {
-				const viaGroupFilter = filterMerchantsByCategory(corpus, category).map(
-					(p) => p.icon ?? "<missing>",
-				);
+				const viaGroupFilter = filterMerchantsByCategory(corpus, category)
+					.map((p) => p.icon ?? "<missing>")
+					.sort();
 				const viaPlacePredicate = corpus
 					.filter((p) => placeMatchesCategory(p, category))
-					.map((p) => p.icon ?? "<missing>");
+					.map((p) => p.icon ?? "<missing>")
+					.sort();
 				expect(viaGroupFilter, `category "${category}"`).toEqual(
 					viaPlacePredicate,
 				);

--- a/src/lib/categoryMapping.test.ts
+++ b/src/lib/categoryMapping.test.ts
@@ -424,10 +424,12 @@ describe("categoryMapping", () => {
 	// The map pins (search branch), the panel's filteredSearchResults, and the
 	// store's applyCategoryFilter split between filterMerchantsByCategory
 	// (group icon-list membership) and placeMatchesCategory (last-write-wins
-	// icon→category lookup). They are only extensionally equal while no icon
-	// appears in two groups — the moment that breaks, pins and list silently
-	// diverge again (the #1159 bug class). These tests make that divergence
-	// loud instead of silent.
+	// icon→category lookup). They are extensionally equal only while every
+	// configured icon is truthy AND no icon appears in two groups (a falsy
+	// icon would match `=== ""` in one predicate and early-return in the
+	// other) — the moment either breaks, pins and list silently diverge again
+	// (the #1159 bug class). These tests make that divergence loud instead of
+	// silent.
 	describe("category predicate equivalence", () => {
 		// Every mapped icon, plus the shapes callers actually see: unknown,
 		// empty, and missing icons.
@@ -440,10 +442,14 @@ describe("categoryMapping", () => {
 			createMockPlace({}),
 		];
 
-		it("no icon belongs to two category groups", () => {
+		it("every icon is truthy and belongs to exactly one category group", () => {
 			const seen = new Map<string, CategoryKey>();
 			for (const [key, group] of CATEGORY_ENTRIES) {
 				for (const icon of group.icons) {
+					expect(
+						icon,
+						`falsy icon in group "${key}" — placeMatchesCategory early-returns on falsy icons while filterMerchantsByCategory matches them`,
+					).toBeTruthy();
 					const previous = seen.get(icon);
 					expect(
 						previous,
@@ -455,13 +461,15 @@ describe("categoryMapping", () => {
 		});
 
 		it("filterMerchantsByCategory and placeMatchesCategory select the same set for every category", () => {
+			// Compare by icon, not id: a divergence failure then names the
+			// offending icon directly instead of printing random mock ids.
 			for (const category of CATEGORIES) {
 				const viaGroupFilter = filterMerchantsByCategory(corpus, category).map(
-					(p) => p.id,
+					(p) => p.icon ?? "<missing>",
 				);
 				const viaPlacePredicate = corpus
 					.filter((p) => placeMatchesCategory(p, category))
-					.map((p) => p.id);
+					.map((p) => p.icon ?? "<missing>");
 				expect(viaGroupFilter, `category "${category}"`).toEqual(
 					viaPlacePredicate,
 				);


### PR DESCRIPTION
Consistency guard requested on top of the #1158–#1162 fixes.

The codebase filters by category through two predicates: `filterMerchantsByCategory` (group icon-list membership — used by the store's `applyCategoryFilter` and the nearby marker branch) and `placeMatchesCategory` (last-write-wins `ICON_TO_CATEGORY` lookup — used by the panel's `filteredSearchResults` and, after #1178, the search-mode pins). They are only extensionally equal **while no icon appears in two category groups**. The day that breaks, list and pins silently diverge again — the exact #1159 bug class.

Three new tests make that failure loud:
- the disjointness invariant itself, with a pointed failure message naming the offending icon and both groups
- predicate equivalence over every mapped icon plus unknown/empty/missing shapes, for every category
- `countMerchantsByCategory` agreement with both predicates

Passes on main today (no behavior change anywhere — pure guard). Consolidating to one predicate remains #1168's job; until then this is the tripwire.

Related consistency tests ride on the fix PRs where the behavior lives: #1180 gains "count path ≡ list path" totals, #1181 gains "chip counts ≡ rendered selection" oracles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for category-based merchant filtering.
  * Verified consistent results across category matching, filtering, and counting.
  * Added validation for configured, unknown, empty, and missing category icons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->