### PR TITLE
perf(area-page): skip unused syncs #1165

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -40,9 +40,7 @@ import {
 } from "$lib/store";
 import { areasSync } from "$lib/sync/areas";
 import { batchSync } from "$lib/sync/batchSync";
-import { eventsSync } from "$lib/sync/events";
 import { reportsSync } from "$lib/sync/reports";
-import { usersSync } from "$lib/sync/users";
 import type {
 	AreaPageProps,
 	AreaTags,
@@ -60,7 +58,7 @@ import {
 import { isRecentlyVerified } from "$lib/verification";
 
 onMount(() => {
-	batchSync([areasSync, reportsSync, eventsSync, usersSync]);
+	batchSync([areasSync, reportsSync]);
 });
 
 // alert for user errors

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -31,12 +31,10 @@ import api from "$lib/axios";
 import {
 	areaError,
 	areas,
-	eventError,
 	places,
 	placesError,
 	reportError,
 	reports,
-	userError,
 } from "$lib/store";
 import { areasSync } from "$lib/sync/areas";
 import { batchSync } from "$lib/sync/batchSync";
@@ -61,10 +59,6 @@ onMount(() => {
 	batchSync([areasSync, reportsSync]);
 });
 
-// alert for user errors
-$: $userError && errToast($userError);
-// alert for event errors
-$: $eventError && errToast($eventError);
 // alert for element errors
 $: $placesError && errToast($placesError);
 // alert for area errors


### PR DESCRIPTION
## Summary
- stop preloading `eventsSync` and `usersSync` on area pages
- keep the existing area and reports syncs unchanged

Closes #1165

## Validation
- `pnpm install --frozen-lockfile` resolved the lockfile but the environment blocked dependency build scripts; the installed local binaries were used directly
- `pnpm run format:fix` was executed via the repository's Biome binary
- Biome check passed
- Svelte check passed with 0 errors and 0 warnings
- Vitest passed: 24 files, 466 tests
- `git diff --check` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined area page initialization by limiting synchronization to area and report data.
  * Removed unnecessary event and user synchronization and related error notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->