### PR TITLE
fix(area): grade the area map stars from the real report data #1163

### DIFF
--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -76,8 +76,13 @@ const closeDrawer = () => {
 };
 
 let grade: Grade | undefined;
+// Round before grading so the stars agree with AreaStats, which displays the
+// same value via toFixed(0) — a fractional 94.6 must not show "95%" in Stats
+// while the header grades it below the 95% five-star boundary.
 $: grade =
-	upToDatePercent === undefined ? undefined : getGrade(upToDatePercent);
+	upToDatePercent === undefined
+		? undefined
+		: getGrade(Math.round(upToDatePercent));
 
 let gradeTooltip: HTMLButtonElement;
 

--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -33,6 +33,10 @@ import { browser } from "$app/environment";
 export let name: string;
 export let geoJSON: GeoJSON;
 export let filteredPlaces: Place[];
+// Latest report's up_to_date_percent for this area (same source AreaStats
+// renders); undefined while reports load or when the area has none — the
+// stars stay in their loading state rather than fabricating a grade.
+export let upToDatePercent: number | undefined = undefined;
 
 type PlaceFeature = {
 	type: "Feature";
@@ -71,11 +75,9 @@ const closeDrawer = () => {
 	selectedMerchantId = null;
 };
 
-let total: number | undefined;
-let upToDate: number | undefined;
-let upToDatePercent: string | undefined;
-
-let grade: Grade;
+let grade: Grade | undefined;
+$: grade =
+	upToDatePercent === undefined ? undefined : getGrade(upToDatePercent);
 
 let gradeTooltip: HTMLButtonElement;
 
@@ -470,19 +472,7 @@ const initializeMap = async () => {
 		mapLoaded = true;
 		lastAppliedGeoJSON = geoJSON;
 		lastAppliedFilteredPlaces = filteredPlaces;
-
-		updateAreaGrade();
 	});
-};
-
-// Compute area grade from the rendered place set. The legacy component
-// treated every place in `filteredPlaces` as up-to-date (the parent
-// AreaPage already filters by verification), so mirror that here.
-const updateAreaGrade = () => {
-	total = filteredPlaces.length;
-	upToDate = filteredPlaces.length;
-	upToDatePercent = upToDate ? (upToDate / (total / 100)).toFixed(0) : "0";
-	grade = getGrade(Number(upToDatePercent));
 };
 
 // Theme reactivity — swap the basemap, then re-register area + places overlays
@@ -540,7 +530,6 @@ $: if (
 		closeDrawer();
 	}
 	fitToArea(map, true);
-	updateAreaGrade();
 }
 
 $: if (map && styleLoaded) {
@@ -555,7 +544,7 @@ $: if (map && styleLoaded) {
 	>
 		{name || 'BTC Map Area'} Map
 		<div class="flex items-center space-x-1 text-link">
-			{#if dataInitialized && mapLoaded}
+			{#if dataInitialized && mapLoaded && grade !== undefined}
 				<div class="flex items-center space-x-1">
 					{#each Array(grade) as _, index (index)}
 						<Icon type="fa" icon="star" w="16" h="16" />

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -533,7 +533,12 @@ let issues: PlaceIssue[] = [];
 	</div>
 
 	{#if activeSection === Sections.merchants}
-		<AreaMap {name} geoJSON={area?.geo_json} {filteredPlaces} />
+		<AreaMap
+			{name}
+			geoJSON={area?.geo_json}
+			{filteredPlaces}
+			upToDatePercent={areaReports?.[0]?.tags.up_to_date_percent}
+		/>
 		<AreaMerchantHighlights {dataInitialized} {filteredPlaces} />
 		{#if browser}
 			<Boost />

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -10,6 +10,7 @@ import {
 	formatDistance,
 	formatNearbyPillCount,
 	getCommunitiesAtCoordinates,
+	getGrade,
 	isValidLatitude,
 	isValidLightningTip,
 	isValidLongitude,
@@ -782,5 +783,22 @@ describe("isValidLightningTip", () => {
 
 	it("rejects an address containing whitespace", () => {
 		expect(isValidLightningTip("alice @getalby.com")).toBe(false);
+	});
+});
+
+describe("getGrade", () => {
+	// The star rating in the area map header renders directly from these
+	// boundaries (5 stars must mean >=95% up to date) — pin every edge.
+	it("maps the documented percentage boundaries to grades", () => {
+		expect(getGrade(100)).toBe(5);
+		expect(getGrade(95)).toBe(5);
+		expect(getGrade(94)).toBe(4);
+		expect(getGrade(75)).toBe(4);
+		expect(getGrade(74)).toBe(3);
+		expect(getGrade(50)).toBe(3);
+		expect(getGrade(49)).toBe(2);
+		expect(getGrade(25)).toBe(2);
+		expect(getGrade(24)).toBe(1);
+		expect(getGrade(0)).toBe(1);
 	});
 });


### PR DESCRIPTION
Fixes #1163.

## What was happening
`updateAreaGrade` in `AreaMap.svelte` set `upToDate = filteredPlaces.length` — the numerator equalled the denominator, so `upToDatePercent` was always `100` (or `0` for an empty area) and `getGrade` returned **5 stars for every area**. The header's own tooltip says 5 stars means ≥95% up-to-date; South Africa sits at **60%** and still showed five.

## The fix
The header now grades from the **latest report's `up_to_date_percent`** — the exact value the Stats section already renders — passed from `AreaPage`'s existing `areaReports` (no new fetches). The grade derives reactively; `updateAreaGrade` and its dead locals are gone.

Honest-degradation choice: while reports are loading — or for an area with no reports at all — the stars keep their existing pulsing placeholder rather than fabricating a rating. Showing nothing truthful beats showing five wrong stars, which is how this bug shipped in the first place.

## Verification
- Live: `/country/za` renders **3 filled + 2 dimmed** stars (60% → grade 3 band), previously 5; header settles out of the pulse state once reports land.
- `getGrade`'s percentage boundaries had zero test coverage — now pinned edge-by-edge (95/94, 75/74, 50/49, 25/24) since the visible stars finally depend on them.
- `format:fix` / `check` / `lint` / full unit suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Area map grades now reflect the latest available area report percentage.
  * Grade stars remain in a loading state until map data and a valid grade are available.
  * Improved accuracy of percentage-to-grade boundary handling across the full range.

* **Tests**
  * Added coverage for grade calculations from 0% through 100%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->