### PR TITLE
fix(sync): heal corrupt cached rows and guard the area-type filters #1187

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -172,7 +172,7 @@ const initializeData = async () => {
 		if (type === "community") {
 			return (
 				area.id === data.id &&
-				area.tags.type === "community" &&
+				area.tags?.type === "community" &&
 				area.tags.geo_json &&
 				area.tags.name &&
 				area.tags["icon:square"] &&
@@ -181,7 +181,7 @@ const initializeData = async () => {
 		} else {
 			return (
 				area.id === data.id &&
-				area.tags.type === "country" &&
+				area.tags?.type === "country" &&
 				area.id.length === 2 &&
 				area.tags.geo_json &&
 				area.tags.name &&

--- a/src/lib/sync/createSyncFactory.test.ts
+++ b/src/lib/sync/createSyncFactory.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { isSyncableRow } from "./createSyncFactory";
+
+describe("isSyncableRow", () => {
+	it("accepts a well-formed entity row", () => {
+		expect(
+			isSyncableRow({ id: "de", updated_at: "2026-01-01T00:00:00Z" }),
+		).toBe(true);
+		expect(isSyncableRow({ id: 42, updated_at: "2026-01-01T00:00:00Z" })).toBe(
+			true,
+		);
+	});
+
+	// The corruption observed in the field: a non-JSON API response parsed as
+	// a string gets character-iterated by the crawl loops, and the dedup
+	// collapse leaves one stray character (a trailing newline) that then
+	// survives every incremental merge in the persisted cache.
+	it("rejects stray string fragments", () => {
+		expect(isSyncableRow("\n")).toBe(false);
+		expect(isSyncableRow("")).toBe(false);
+		expect(isSyncableRow("<html>")).toBe(false);
+	});
+
+	it("rejects null, undefined, and primitives", () => {
+		expect(isSyncableRow(null)).toBe(false);
+		expect(isSyncableRow(undefined)).toBe(false);
+		expect(isSyncableRow(0)).toBe(false);
+		expect(isSyncableRow(true)).toBe(false);
+	});
+
+	it("rejects objects without a usable id", () => {
+		expect(isSyncableRow({})).toBe(false);
+		expect(isSyncableRow({ id: null, updated_at: "2026-01-01" })).toBe(false);
+		expect(isSyncableRow({ id: undefined, updated_at: "2026-01-01" })).toBe(
+			false,
+		);
+	});
+
+	it("rejects rows whose updated_at cannot drive the sync cursor", () => {
+		expect(isSyncableRow({ id: 1 })).toBe(false);
+		expect(isSyncableRow({ id: 1, updated_at: null })).toBe(false);
+		expect(isSyncableRow({ id: 1, updated_at: 12345 })).toBe(false);
+	});
+});

--- a/src/lib/sync/createSyncFactory.test.ts
+++ b/src/lib/sync/createSyncFactory.test.ts
@@ -35,11 +35,17 @@ describe("isSyncableRow", () => {
 		expect(isSyncableRow({ id: undefined, updated_at: "2026-01-01" })).toBe(
 			false,
 		);
+		// The merge maps key on id — only string/number keys dedupe correctly.
+		expect(isSyncableRow({ id: {}, updated_at: "2026-01-01" })).toBe(false);
+		expect(isSyncableRow({ id: [], updated_at: "2026-01-01" })).toBe(false);
 	});
 
 	it("rejects rows whose updated_at cannot drive the sync cursor", () => {
 		expect(isSyncableRow({ id: 1 })).toBe(false);
 		expect(isSyncableRow({ id: 1, updated_at: null })).toBe(false);
 		expect(isSyncableRow({ id: 1, updated_at: 12345 })).toBe(false);
+		// A string that isn't a date would poison the updated_since cursor.
+		expect(isSyncableRow({ id: 1, updated_at: "not-a-date" })).toBe(false);
+		expect(isSyncableRow({ id: 1, updated_at: "" })).toBe(false);
 	});
 });

--- a/src/lib/sync/createSyncFactory.test.ts
+++ b/src/lib/sync/createSyncFactory.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isSyncableRow } from "./createSyncFactory";
+import { isSyncableRow, validateSyncPage } from "./createSyncFactory";
 
 describe("isSyncableRow", () => {
 	it("accepts a well-formed entity row", () => {
@@ -47,5 +47,39 @@ describe("isSyncableRow", () => {
 		// A string that isn't a date would poison the updated_since cursor.
 		expect(isSyncableRow({ id: 1, updated_at: "not-a-date" })).toBe(false);
 		expect(isSyncableRow({ id: 1, updated_at: "" })).toBe(false);
+	});
+});
+
+describe("validateSyncPage", () => {
+	const valid = (id: number) => ({
+		id,
+		updated_at: "2026-01-01T00:00:00Z",
+	});
+
+	it("passes a valid page through with its raw count", () => {
+		const page = [valid(1), valid(2)];
+		expect(validateSyncPage(page)).toEqual({ rows: page, rawCount: 2 });
+	});
+
+	it("treats an empty page as the normal end of data", () => {
+		expect(validateSyncPage([])).toEqual({ rows: [], rawCount: 0 });
+	});
+
+	it("throws on a non-JSON (string) response instead of iterating it", () => {
+		expect(() => validateSyncPage("<html>maintenance</html>\n")).toThrow(
+			"invalid data format",
+		);
+		expect(() => validateSyncPage(undefined)).toThrow("invalid data format");
+	});
+
+	it("throws on a non-empty page with zero valid rows", () => {
+		expect(() => validateSyncPage(["\n", null, {}])).toThrow("no valid rows");
+	});
+
+	it("drops invalid rows but keeps the raw count for pagination", () => {
+		const page = [valid(1), "\n", valid(2)];
+		const result = validateSyncPage(page);
+		expect(result.rows).toEqual([valid(1), valid(2)]);
+		expect(result.rawCount).toBe(3);
 	});
 });

--- a/src/lib/sync/createSyncFactory.ts
+++ b/src/lib/sync/createSyncFactory.ts
@@ -31,6 +31,25 @@ export interface SyncConfig<T extends SyncableEntity> {
 	cacheDuration?: number;
 }
 
+// A usable row is an object with an id. Anything else is corruption: a
+// non-JSON API response (maintenance page, proxy error) parsed as a string
+// gets character-iterated by the crawl loops, and the dedup collapse leaves
+// exactly one stray character (typically a trailing "\n") that then survives
+// every incremental merge in the persisted cache forever — crashing every
+// consumer that trusts the row shape. Validate at both trust boundaries:
+// API responses and cache hydration (so already-poisoned caches self-heal).
+export function isSyncableRow<T extends SyncableEntity>(
+	item: unknown,
+): item is T {
+	return (
+		typeof item === "object" &&
+		item !== null &&
+		"id" in item &&
+		(item as { id: unknown }).id != null &&
+		typeof (item as { updated_at?: unknown }).updated_at === "string"
+	);
+}
+
 // Factory function that creates a sync function with its own state
 export function createSyncFunction<T extends SyncableEntity>(
 	config: SyncConfig<T>,
@@ -86,6 +105,12 @@ export function createSyncFunction<T extends SyncableEntity>(
 			if (!isServerSide) {
 				try {
 					cachedData = await localforage.getItem(config.storageKey);
+					// Persisted data is untrusted input: drop corrupt rows (or the
+					// whole value if it isn't an array) so a poisoned cache heals
+					// on the next sync instead of crashing consumers forever.
+					cachedData = Array.isArray(cachedData)
+						? cachedData.filter((item) => isSyncableRow<T>(item))
+						: null;
 				} catch (err) {
 					console.error(`Could not load ${config.name} locally:`, err);
 					config.errorStore.set(
@@ -170,11 +195,19 @@ async function initialSync<T extends SyncableEntity>(
 				`${API_BASE}/v2/${apiEndpoint}?updated_since=${updatedSince}&limit=${limit}`,
 			);
 
-			const newItems = response.data;
+			// A non-JSON response (maintenance page, proxy error) arrives as a
+			// string — iterating it would merge stray characters into the cache.
+			if (!Array.isArray(response.data)) {
+				throw new Error("API returned invalid data format");
+			}
+			// Pagination advances on the RAW count; the cursor and the merge use
+			// only validated rows. Break when nothing usable remains so a
+			// garbage page can't loop forever on a stuck cursor.
+			responseCount = response.data.length;
+			const newItems = response.data.filter((item) => isSyncableRow<T>(item));
 			if (!newItems.length) break;
 
 			updatedSince = newItems[newItems.length - 1].updated_at;
-			responseCount = newItems.length;
 
 			// Add new items, avoiding duplicates
 			for (const item of newItems) {
@@ -226,11 +259,16 @@ async function incrementalSync<T extends SyncableEntity>(
 			`${API_BASE}/v2/${apiEndpoint}?updated_since=${updatedSince}&limit=${limit}`,
 		);
 
-		const newItems = response.data;
+		// Same trust-boundary rules as initialSync; a throw here propagates to
+		// the caller, which falls back to the (already sanitized) cached data.
+		if (!Array.isArray(response.data)) {
+			throw new Error("API returned invalid data format");
+		}
+		responseCount = response.data.length;
+		const newItems = response.data.filter((item) => isSyncableRow<T>(item));
 		if (!newItems.length) break;
 
 		updatedSince = newItems[newItems.length - 1].updated_at;
-		responseCount = newItems.length;
 
 		// Update or add items
 		for (const item of newItems) {

--- a/src/lib/sync/createSyncFactory.ts
+++ b/src/lib/sync/createSyncFactory.ts
@@ -31,22 +31,24 @@ export interface SyncConfig<T extends SyncableEntity> {
 	cacheDuration?: number;
 }
 
-// A usable row is an object with an id. Anything else is corruption: a
-// non-JSON API response (maintenance page, proxy error) parsed as a string
-// gets character-iterated by the crawl loops, and the dedup collapse leaves
-// exactly one stray character (typically a trailing "\n") that then survives
-// every incremental merge in the persisted cache forever — crashing every
-// consumer that trusts the row shape. Validate at both trust boundaries:
-// API responses and cache hydration (so already-poisoned caches self-heal).
+// A usable row is an object with a string/number id and a parseable
+// updated_at — the two fields the merge maps and the pagination cursor
+// actually rely on. Anything else is corruption: a non-JSON API response
+// (maintenance page, proxy error) parsed as a string gets character-iterated
+// by the crawl loops, and the dedup collapse leaves exactly one stray
+// character (typically a trailing "\n") that then survives every incremental
+// merge in the persisted cache forever — crashing every consumer that trusts
+// the row shape. Validate at both trust boundaries: API responses and cache
+// hydration (so already-poisoned caches self-heal).
 export function isSyncableRow<T extends SyncableEntity>(
 	item: unknown,
 ): item is T {
+	if (typeof item !== "object" || item === null) return false;
+	const { id, updated_at } = item as { id?: unknown; updated_at?: unknown };
 	return (
-		typeof item === "object" &&
-		item !== null &&
-		"id" in item &&
-		(item as { id: unknown }).id != null &&
-		typeof (item as { updated_at?: unknown }).updated_at === "string"
+		(typeof id === "string" || typeof id === "number") &&
+		typeof updated_at === "string" &&
+		!Number.isNaN(Date.parse(updated_at))
 	);
 }
 
@@ -201,11 +203,16 @@ async function initialSync<T extends SyncableEntity>(
 				throw new Error("API returned invalid data format");
 			}
 			// Pagination advances on the RAW count; the cursor and the merge use
-			// only validated rows. Break when nothing usable remains so a
-			// garbage page can't loop forever on a stuck cursor.
+			// only validated rows. An empty page is the normal end of data; a
+			// non-empty page with zero valid rows is an anomaly — surface it as
+			// an error rather than silently truncating the sync (it also can't
+			// advance the cursor, so continuing would spin in place).
 			responseCount = response.data.length;
+			if (!responseCount) break;
 			const newItems = response.data.filter((item) => isSyncableRow<T>(item));
-			if (!newItems.length) break;
+			if (!newItems.length) {
+				throw new Error("API page contained no valid rows");
+			}
 
 			updatedSince = newItems[newItems.length - 1].updated_at;
 
@@ -265,8 +272,11 @@ async function incrementalSync<T extends SyncableEntity>(
 			throw new Error("API returned invalid data format");
 		}
 		responseCount = response.data.length;
+		if (!responseCount) break;
 		const newItems = response.data.filter((item) => isSyncableRow<T>(item));
-		if (!newItems.length) break;
+		if (!newItems.length) {
+			throw new Error("API page contained no valid rows");
+		}
 
 		updatedSince = newItems[newItems.length - 1].updated_at;
 

--- a/src/lib/sync/createSyncFactory.ts
+++ b/src/lib/sync/createSyncFactory.ts
@@ -52,6 +52,27 @@ export function isSyncableRow<T extends SyncableEntity>(
 	);
 }
 
+// Validates one crawl page at the API trust boundary — shared by both crawl
+// loops so their anomaly semantics cannot drift. Throws on a non-JSON
+// response (a string would otherwise be character-iterated into the cache)
+// and on a non-empty page with zero valid rows (which must surface as an
+// error, not silently truncate the sync — it also can't advance the cursor,
+// so continuing would spin in place). An empty page is the normal end of
+// data. Pagination advances on the RAW count; the cursor and the merge use
+// only the validated rows.
+export function validateSyncPage<T extends SyncableEntity>(
+	data: unknown,
+): { rows: T[]; rawCount: number } {
+	if (!Array.isArray(data)) {
+		throw new Error("API returned invalid data format");
+	}
+	const rows = data.filter((item) => isSyncableRow<T>(item));
+	if (data.length && !rows.length) {
+		throw new Error("API page contained no valid rows");
+	}
+	return { rows, rawCount: data.length };
+}
+
 // Factory function that creates a sync function with its own state
 export function createSyncFunction<T extends SyncableEntity>(
 	config: SyncConfig<T>,
@@ -197,22 +218,9 @@ async function initialSync<T extends SyncableEntity>(
 				`${API_BASE}/v2/${apiEndpoint}?updated_since=${updatedSince}&limit=${limit}`,
 			);
 
-			// A non-JSON response (maintenance page, proxy error) arrives as a
-			// string — iterating it would merge stray characters into the cache.
-			if (!Array.isArray(response.data)) {
-				throw new Error("API returned invalid data format");
-			}
-			// Pagination advances on the RAW count; the cursor and the merge use
-			// only validated rows. An empty page is the normal end of data; a
-			// non-empty page with zero valid rows is an anomaly — surface it as
-			// an error rather than silently truncating the sync (it also can't
-			// advance the cursor, so continuing would spin in place).
-			responseCount = response.data.length;
+			const { rows: newItems, rawCount } = validateSyncPage<T>(response.data);
+			responseCount = rawCount;
 			if (!responseCount) break;
-			const newItems = response.data.filter((item) => isSyncableRow<T>(item));
-			if (!newItems.length) {
-				throw new Error("API page contained no valid rows");
-			}
 
 			updatedSince = newItems[newItems.length - 1].updated_at;
 
@@ -266,17 +274,11 @@ async function incrementalSync<T extends SyncableEntity>(
 			`${API_BASE}/v2/${apiEndpoint}?updated_since=${updatedSince}&limit=${limit}`,
 		);
 
-		// Same trust-boundary rules as initialSync; a throw here propagates to
-		// the caller, which falls back to the (already sanitized) cached data.
-		if (!Array.isArray(response.data)) {
-			throw new Error("API returned invalid data format");
-		}
-		responseCount = response.data.length;
+		// A throw from validateSyncPage propagates to the caller, which falls
+		// back to the (already sanitized) cached data.
+		const { rows: newItems, rawCount } = validateSyncPage<T>(response.data);
+		responseCount = rawCount;
 		if (!responseCount) break;
-		const newItems = response.data.filter((item) => isSyncableRow<T>(item));
-		if (!newItems.length) {
-			throw new Error("API page contained no valid rows");
-		}
 
 		updatedSince = newItems[newItems.length - 1].updated_at;
 

--- a/src/routes/communities/[section]/+page.svelte
+++ b/src/routes/communities/[section]/+page.svelte
@@ -34,7 +34,7 @@ $: communities = $areas?.length
 	? ($areas
 			.filter(
 				(area): area is Community =>
-					area.tags.type === "community" &&
+					area.tags?.type === "community" &&
 					!!area.tags.geo_json &&
 					!!area.tags.name &&
 					!!area.tags["icon:square"] &&

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -257,7 +257,7 @@ const initializeCommunities = async () => {
 
 	const communitiesFiltered = $areas.filter(
 		(area) =>
-			area.tags.type === "community" &&
+			area.tags?.type === "community" &&
 			area.tags.geo_json &&
 			area.tags.name &&
 			area.tags["icon:square"] &&

--- a/src/routes/countries/[section]/+page.svelte
+++ b/src/routes/countries/[section]/+page.svelte
@@ -28,7 +28,7 @@ $: countries = $areas?.length
 	? $areas
 			.filter(
 				(area) =>
-					area.tags.type === "country" &&
+					area.tags?.type === "country" &&
 					area.id.length === 2 &&
 					area.tags.geo_json &&
 					area.tags.name &&

--- a/tests/communities-corrupt-cache.spec.ts
+++ b/tests/communities-corrupt-cache.spec.ts
@@ -58,17 +58,22 @@ test.describe('Communities directory with a corrupted cache', () => {
 					open.onsuccess = () => {
 						const db = open.result;
 						const tx = db.transaction('keyvaluepairs', 'readwrite');
+						// Resolve on the TRANSACTION committing, not the request
+						// succeeding: request success fires before the commit is
+						// durable, and navigating away can abort an uncommitted
+						// transaction — which would make this test flaky.
+						tx.oncomplete = () => {
+							db.close();
+							resolve();
+						};
+						tx.onabort = () => reject(tx.error ?? new Error('tx aborted'));
+						tx.onerror = () => reject(tx.error ?? new Error('tx error'));
 						const store = tx.objectStore('keyvaluepairs');
 						const get = store.get('areas_v4');
 						get.onsuccess = () => {
 							const rows = get.result;
 							rows.splice(Math.min(900, rows.length), 0, '\n');
-							const put = store.put(rows, 'areas_v4');
-							put.onsuccess = () => {
-								db.close();
-								resolve();
-							};
-							put.onerror = () => reject(put.error);
+							store.put(rows, 'areas_v4');
 						};
 						get.onerror = () => reject(get.error);
 					};

--- a/tests/communities-corrupt-cache.spec.ts
+++ b/tests/communities-corrupt-cache.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+// Regression guard for #1187: a corrupt row in the persisted areas cache (a
+// stray "\n" string left behind by a non-JSON API response) crashed the
+// communities directory into a silent empty page, forever, for any browser
+// whose cache caught it. The sync layer now validates rows at hydrate and the
+// render filters guard tags access — this spec pins both by poisoning the
+// cache exactly like the field corruption and demanding the page still work.
+test.describe('Communities directory with a corrupted cache', () => {
+	const cardCount = (page: import('@playwright/test').Page) =>
+		page.locator('a[href*="/community/"]').count();
+
+	test('renders and self-heals after a corrupt cached row', async ({ page }) => {
+		await page.goto('/communities/africa', { waitUntil: 'load' });
+
+		// First load: areas sync populates the store and persists the cache.
+		await expect.poll(() => cardCount(page), { timeout: 60000 }).toBeGreaterThan(0);
+
+		// Wait for the persisted cache to exist, then inject the exact field
+		// corruption: the literal string "\n" as an areas row.
+		await expect
+			.poll(
+				() =>
+					page.evaluate(
+						() =>
+							new Promise((resolve) => {
+								const open = indexedDB.open('BTC Map');
+								open.onsuccess = () => {
+									const db = open.result;
+									try {
+										const tx = db.transaction('keyvaluepairs', 'readonly');
+										const get = tx.objectStore('keyvaluepairs').get('areas_v4');
+										get.onsuccess = () => {
+											const isArray = Array.isArray(get.result);
+											db.close();
+											resolve(isArray);
+										};
+										get.onerror = () => {
+											db.close();
+											resolve(false);
+										};
+									} catch {
+										db.close();
+										resolve(false);
+									}
+								};
+								open.onerror = () => resolve(false);
+							})
+					),
+				{ timeout: 30000 }
+			)
+			.toBe(true);
+
+		await page.evaluate(
+			() =>
+				new Promise<void>((resolve, reject) => {
+					const open = indexedDB.open('BTC Map');
+					open.onsuccess = () => {
+						const db = open.result;
+						const tx = db.transaction('keyvaluepairs', 'readwrite');
+						const store = tx.objectStore('keyvaluepairs');
+						const get = store.get('areas_v4');
+						get.onsuccess = () => {
+							const rows = get.result;
+							rows.splice(Math.min(900, rows.length), 0, '\n');
+							const put = store.put(rows, 'areas_v4');
+							put.onsuccess = () => {
+								db.close();
+								resolve();
+							};
+							put.onerror = () => reject(put.error);
+						};
+						get.onerror = () => reject(get.error);
+					};
+					open.onerror = () => reject(open.error);
+				})
+		);
+
+		// The reload hydrates from the poisoned cache. Pre-fix this crashed the
+		// reactive and rendered zero cards; post-fix the corrupt row is dropped
+		// at hydrate and the directory renders normally.
+		await page.reload({ waitUntil: 'load' });
+		await expect.poll(() => cardCount(page), { timeout: 60000 }).toBeGreaterThan(0);
+	});
+});

--- a/tests/communities.spec.ts
+++ b/tests/communities.spec.ts
@@ -19,6 +19,18 @@ test.describe('Communities Page', () => {
 		).toBeVisible();
 	});
 
+	test('renders community cards once the areas sync lands', async ({ page }) => {
+		// The directory previously passed CI while rendering ZERO cards (a
+		// crashed reactive left the page silently empty — #1187), because no
+		// test asserted the actual content. Pin it: the list must populate.
+		await page.goto('/communities/africa', { waitUntil: 'load' });
+		await expect
+			.poll(() => page.locator('a[href*="/community/"]').count(), {
+				timeout: 60000
+			})
+			.toBeGreaterThan(0);
+	});
+
 	test('displays navigation buttons', async ({ page }) => {
 		await page.goto('/communities');
 


### PR DESCRIPTION
Fixes #1187 — the user-reported crash on https://btcmap.org/communities/africa.

## The forensics
Affected browsers carry **the literal string `"\n"` as a row** in their persisted `areas_v4` cache. Reading `.tags` on a string → `undefined` → `.type` throws inside the communities filter, killing the reactive: the directory renders a **silent empty page**, forever, on every visit.

Origin: if the v2 API ever returns a non-JSON response (maintenance page, proxy error), axios hands the crawl a *string* — `for (const item of newItems)` iterates its **characters**, and the dedup collapse (every char has `id === undefined`) leaves exactly one survivor: the trailing newline. Once persisted, it passes `filterDeleted` (`tags?.type !== "trash"`) on every hydrate and survives every incremental merge. Current API data is clean — the corruption lives in long-lived caches, which is why fresh profiles and CI never reproduced it.

## The fix (two layers)
1. **`createSyncFactory`** — validate at both trust boundaries: reject non-array API responses outright (the same defense `merchantListStore` already had), run `isSyncableRow` over both crawls (raw count still drives pagination; cursor + merge use only valid rows, with a break so a garbage page can't spin on a stuck cursor), and **sanitize cache hydration so poisoned caches self-heal** on the next sync — for all four entity caches (areas/reports/events/users).
2. **Render guards** — the five unguarded `area.tags.type` reads become `area.tags?.type` (communities/countries directories, communities map, AreaPage ×2), matching the guard `getCommunitiesAtCoordinates` has carried for this exact observed phenomenon.

## Why nothing caught it (and what now does)
- No error telemetry, no toast: an uncaught rejection in a reactive is invisible.
- CI always starts with a fresh cache — stale-cache corruption is structurally unreachable.
- The existing communities e2e asserted title/buttons/chart but **never that cards render** — an empty directory passed CI.

New coverage: `communities.spec.ts` now asserts the directory actually populates, and `communities-corrupt-cache.spec.ts` poisons the cached areas with the exact field corruption, reloads, and demands the page still render (fails on pre-fix code: zero cards). Plus unit tests pinning `isSyncableRow` against the whole corruption class.

## Verification
- Reproduced the production crash (btcmap.org, readable stack on local dev), located the corrupt row live in an affected cache (index 908 of 916, value `"\n"`).
- Injected the identical corruption into a local cache: un-fixed → crash, 0 cards; fixed → **0 errors, 60 cards, cache re-persisted clean (915 rows, 0 corrupt)**.
- `format:fix` / `check` / `lint` / full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)