### PR TITLE
fix(sync): unstick the crawl cursor on shared timestamps #1164

### DIFF
--- a/src/lib/sync/createSyncFactory.test.ts
+++ b/src/lib/sync/createSyncFactory.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isSyncableRow, validateSyncPage } from "./createSyncFactory";
+import {
+	isSyncableRow,
+	nextCursor,
+	validateSyncPage,
+} from "./createSyncFactory";
 
 describe("isSyncableRow", () => {
 	it("accepts a well-formed entity row", () => {
@@ -81,5 +85,31 @@ describe("validateSyncPage", () => {
 		const result = validateSyncPage(page);
 		expect(result.rows).toEqual([valid(1), valid(2)]);
 		expect(result.rawCount).toBe(3);
+	});
+});
+
+describe("nextCursor", () => {
+	it("advances to the page's last timestamp when it moved", () => {
+		expect(
+			nextCursor("2026-01-01T00:00:00.000Z", "2026-01-02T00:00:00.000Z"),
+		).toBe("2026-01-02T00:00:00.000Z");
+	});
+
+	// The v2 updated_since is inclusive (the crawl dedup exists because each
+	// page's last row reappears on the next). A FULL page sharing one
+	// timestamp can therefore never advance the cursor — the crawl would
+	// refetch the same page forever. Nudging one millisecond past the stuck
+	// timestamp trades bounded staleness (skipped rows return whenever they
+	// next update) for guaranteed progress.
+	it("nudges one millisecond past a stuck timestamp", () => {
+		expect(
+			nextCursor("2025-07-07T08:08:14.974Z", "2025-07-07T08:08:14.974Z"),
+		).toBe("2025-07-07T08:08:14.975Z");
+	});
+
+	it("rolls the nudge across a second boundary", () => {
+		expect(
+			nextCursor("2025-07-07T08:08:14.999Z", "2025-07-07T08:08:14.999Z"),
+		).toBe("2025-07-07T08:08:15.000Z");
 	});
 });

--- a/src/lib/sync/createSyncFactory.test.ts
+++ b/src/lib/sync/createSyncFactory.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
 	isSyncableRow,
@@ -89,10 +89,13 @@ describe("validateSyncPage", () => {
 });
 
 describe("nextCursor", () => {
-	it("advances to the page's last timestamp when it moved", () => {
+	it("advances to the page's last timestamp when it moved, silently", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		expect(
 			nextCursor("2026-01-01T00:00:00.000Z", "2026-01-02T00:00:00.000Z"),
 		).toBe("2026-01-02T00:00:00.000Z");
+		expect(warn).not.toHaveBeenCalled();
+		warn.mockRestore();
 	});
 
 	// The v2 updated_since is inclusive (the crawl dedup exists because each
@@ -101,15 +104,27 @@ describe("nextCursor", () => {
 	// refetch the same page forever. Nudging one millisecond past the stuck
 	// timestamp trades bounded staleness (skipped rows return whenever they
 	// next update) for guaranteed progress.
-	it("nudges one millisecond past a stuck timestamp", () => {
+	it("nudges one millisecond past a stuck timestamp and warns loudly", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		expect(
-			nextCursor("2025-07-07T08:08:14.974Z", "2025-07-07T08:08:14.974Z"),
+			nextCursor(
+				"2025-07-07T08:08:14.974Z",
+				"2025-07-07T08:08:14.974Z",
+				"reports",
+			),
 		).toBe("2025-07-07T08:08:14.975Z");
+		// The deferral of same-timestamp rows must never be silent.
+		expect(warn).toHaveBeenCalledOnce();
+		expect(warn.mock.calls[0][0]).toContain("reports");
+		expect(warn.mock.calls[0][0]).toContain("2025-07-07T08:08:14.974Z");
+		warn.mockRestore();
 	});
 
 	it("rolls the nudge across a second boundary", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		expect(
 			nextCursor("2025-07-07T08:08:14.999Z", "2025-07-07T08:08:14.999Z"),
 		).toBe("2025-07-07T08:08:15.000Z");
+		warn.mockRestore();
 	});
 });

--- a/src/lib/sync/createSyncFactory.ts
+++ b/src/lib/sync/createSyncFactory.ts
@@ -80,11 +80,22 @@ export function validateSyncPage<T extends SyncableEntity>(
 // forever (#1164; real data: a reports backfill wrote 10k rows in under 7s,
 // so a bulk write with identical timestamps is one migration away). When the
 // cursor is stuck, nudge one millisecond past it: rows sharing the timestamp
-// beyond the page boundary are skipped for now and picked up whenever they
-// next update — bounded staleness beats an unbreakable refetch loop.
-// isSyncableRow guarantees pageLast parses.
-export function nextCursor(previous: string, pageLast: string): string {
+// beyond the page boundary are deferred until they next update — bounded
+// staleness beats an unbreakable refetch loop. A within-timestamp
+// continuation is impossible against this API (updated_since + limit is the
+// whole pagination surface — no page token, no id tiebreak; a full re-crawl
+// pages through the same API and hits the same tie), so the nudge is the
+// only progress-guaranteeing option; the warn keeps the deferral from being
+// silent. isSyncableRow guarantees pageLast parses.
+export function nextCursor(
+	previous: string,
+	pageLast: string,
+	label = "sync",
+): string {
 	if (pageLast !== previous) return pageLast;
+	console.warn(
+		`${label}: pagination cursor stuck at ${pageLast} (full page of identical timestamps); nudging +1ms — rows sharing this timestamp beyond the page boundary are deferred until they next update`,
+	);
 	return new Date(Date.parse(pageLast) + 1).toISOString();
 }
 
@@ -242,6 +253,7 @@ async function initialSync<T extends SyncableEntity>(
 			updatedSince = nextCursor(
 				updatedSince,
 				newItems[newItems.length - 1].updated_at,
+				apiEndpoint,
 			);
 
 			for (const item of newItems) {
@@ -293,6 +305,7 @@ async function incrementalSync<T extends SyncableEntity>(
 		updatedSince = nextCursor(
 			updatedSince,
 			newItems[newItems.length - 1].updated_at,
+			apiEndpoint,
 		);
 
 		// Update or add items

--- a/src/lib/sync/createSyncFactory.ts
+++ b/src/lib/sync/createSyncFactory.ts
@@ -73,6 +73,21 @@ export function validateSyncPage<T extends SyncableEntity>(
 	return { rows, rawCount: data.length };
 }
 
+// Advances the pagination cursor past a page. The v2 updated_since is
+// inclusive (the crawl dedup exists precisely because each page's last row
+// reappears on the next), so a FULL page whose rows all share one timestamp
+// can never advance the cursor — the crawl would refetch the same page
+// forever (#1164; real data: a reports backfill wrote 10k rows in under 7s,
+// so a bulk write with identical timestamps is one migration away). When the
+// cursor is stuck, nudge one millisecond past it: rows sharing the timestamp
+// beyond the page boundary are skipped for now and picked up whenever they
+// next update — bounded staleness beats an unbreakable refetch loop.
+// isSyncableRow guarantees pageLast parses.
+export function nextCursor(previous: string, pageLast: string): string {
+	if (pageLast !== previous) return pageLast;
+	return new Date(Date.parse(pageLast) + 1).toISOString();
+}
+
 // Factory function that creates a sync function with its own state
 export function createSyncFunction<T extends SyncableEntity>(
 	config: SyncConfig<T>,
@@ -209,8 +224,10 @@ async function initialSync<T extends SyncableEntity>(
 ): Promise<T[]> {
 	let updatedSince = "2022-01-01T00:00:00.000Z";
 	let responseCount: number;
-	const allData: T[] = [];
-	const seenIds = new Set<string | number>();
+	// Map dedup: keys keep insertion order and set() updates in place, so this
+	// matches the previous push-or-replace semantics at O(1) per row instead
+	// of a findIndex scan (quadratic over 100k+ event rows on the dupe path).
+	const dataMap = new Map<string | number, T>();
 
 	do {
 		try {
@@ -222,20 +239,13 @@ async function initialSync<T extends SyncableEntity>(
 			responseCount = rawCount;
 			if (!responseCount) break;
 
-			updatedSince = newItems[newItems.length - 1].updated_at;
+			updatedSince = nextCursor(
+				updatedSince,
+				newItems[newItems.length - 1].updated_at,
+			);
 
-			// Add new items, avoiding duplicates
 			for (const item of newItems) {
-				if (!seenIds.has(item.id)) {
-					seenIds.add(item.id);
-					allData.push(item);
-				} else {
-					// Update existing item
-					const idx = allData.findIndex((d) => d.id === item.id);
-					if (idx !== -1) {
-						allData[idx] = item;
-					}
-				}
+				dataMap.set(item.id, item);
 			}
 		} catch (error) {
 			errorStore.set(
@@ -247,7 +257,7 @@ async function initialSync<T extends SyncableEntity>(
 	} while (responseCount === limit);
 
 	// Filter out deleted items
-	return allData.filter(filterDeleted);
+	return Array.from(dataMap.values()).filter(filterDeleted);
 }
 
 // Incremental sync - update from existing cached data
@@ -280,7 +290,10 @@ async function incrementalSync<T extends SyncableEntity>(
 		responseCount = rawCount;
 		if (!responseCount) break;
 
-		updatedSince = newItems[newItems.length - 1].updated_at;
+		updatedSince = nextCursor(
+			updatedSince,
+			newItems[newItems.length - 1].updated_at,
+		);
 
 		// Update or add items
 		for (const item of newItems) {


### PR DESCRIPTION
Fixes #1164.

## The hazard
The v2 `updated_since` parameter is **inclusive** — the proof is in the codebase itself: both crawl loops carry dedup logic that only exists because each page's last row reappears at the start of the next page. That inclusivity means a *full* page whose rows all share one `updated_at` can never advance the cursor: the crawl refetches the identical page until the tab dies. Not hypothetical-adjacent: the reports table already contains a backfill that wrote 10,000 rows in under 7 seconds — one bulk migration with identical timestamps away from every long-session user spinning on `/v2/reports` forever.

## The fix
`nextCursor(previous, pageLast)` — when the page's last timestamp equals the current cursor (only possible on the stuck-full-page case; a non-full page exits the loop regardless), nudge **one millisecond** past it. Rows sharing that timestamp beyond the page boundary are skipped for now and picked up whenever they next update: bounded, self-correcting staleness instead of an unbreakable loop. The alternative (bailing with an error) would stall the same user permanently — every retry hits the same wall.

Both crawl loops use the shared helper (per this PR set's no-drift convention), and #1188's `isSyncableRow` already guarantees the timestamp parses before it reaches the nudge.

## Also in the block
The initial crawl's dedup used `allData.findIndex` inside the page loop — quadratic on the duplicate path over 100k+ event rows (flagged in the same issue). It now uses the same insertion-ordered `Map` the incremental path already had; `Map.set` updates in place, so replace-at-original-position semantics are identical at O(1) per row.

## Verification
- Unit (TDD, red→green): cursor advances normally, nudges +1ms when stuck, rolls across second boundaries. 13 sync-factory tests green.
- A true end-to-end trigger needs the API to serve a full page of identical timestamps — not safely reproducible against prod; the helper *is* the decision point, and it's pinned directly.
- `format:fix` / `check` / `lint` / full unit suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization pagination when multiple records share the same timestamp.
  * Prevented repeated fetches and sync loops at page boundaries.
  * Preserved correct handling of duplicate and deleted records during initial synchronization.
  * Added reliable cursor advancement across timestamp and second-boundary transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->