### PR TITLE
docs(agents): drop deleted Element type reference #1166

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,7 @@ Use [https://nostrhub.io/nips](https://nostrhub.io/nips) as the definitive NIP s
 ## Project Structure Notes
 
 - `src/lib/sync/places.ts` always runs first and populates the `$places` store with `Place[]` data
-- Use `Place` type for v4 API data, `Element` type for v2 API data
+- Use `Place` type for v4 API data; the remaining v2 surfaces (area/report/event/user crawls via `createSyncFactory`, per-place issues on the merchant page from `/v2/elements`) use their own types (`Area`, `Report`, `Event`, `User`, `Issue`) — there is no `Element` type anymore
 - Prefer editing existing files over creating new ones
 - Only create documentation files when explicitly requested
 - **Svelte v4** — do not use Svelte v5 runes syntax (`$state`, `$derived`, `$effect`, etc.); we intentionally stay on v4


### PR DESCRIPTION
Fixes #1166.

AGENTS.md instructed "use `Element` type for v2 API data" — a type deleted in the v4 migration, making the instruction unfollowable for both humans and the AI agents the file exists to brief. The bullet now describes current reality: `Place` for v4, and the surviving v2 surfaces (area/report/event/user crawls via `createSyncFactory`, per-place issues from `/v2/elements`) carrying their own types.

One deliberate non-edit: **CLAUDE.md is a symlink to AGENTS.md** (mode 120000) — editing it through the link path with a file-replacing tool would sever the link and fork the docs. Only AGENTS.md is touched; the symlink is verified intact.

Docs-only; checklist run regardless, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)