### PR TITLE
refactor(workers): remove dead filterDeleted/mergeUpdates paths #1167

### DIFF
--- a/src/lib/workers/sync-worker-manager.ts
+++ b/src/lib/workers/sync-worker-manager.ts
@@ -1,12 +1,5 @@
 import type { WorkerMessage, WorkerResponse } from "./sync-worker";
-import type {
-	Area,
-	Event,
-	Place,
-	ProgressUpdate,
-	Report,
-	User,
-} from "../types";
+import type { Place, ProgressUpdate } from "../types";
 
 let worker: Worker | null = null;
 let workerInitialized = false;
@@ -49,7 +42,6 @@ function handleWorkerMessage(response: WorkerResponse) {
 
 		case "PARSED":
 		case "FILTERED":
-		case "MERGED":
 			request.resolve(response.payload);
 			pendingRequests.delete(response.id);
 			break;
@@ -177,48 +169,6 @@ export async function filterPlaces(
 		recentUpdates.forEach((place) => {
 			if (!place.deleted_at) {
 				merged.push(place);
-			}
-		});
-		return merged;
-	}
-}
-
-export async function filterDeleted<
-	T extends Place | Area | User | Event | Report,
->(
-	items: T[],
-	type: "places" | "areas" | "users" | "events" | "reports",
-): Promise<T[]> {
-	try {
-		return await sendWorkerMessage<T[]>("FILTER_DELETED", { items, type });
-	} catch (error) {
-		// Fallback to synchronous filtering
-		console.warn("Worker filtering failed, using synchronous fallback:", error);
-		return items.filter((item) => !item.deleted_at);
-	}
-}
-
-export async function mergeUpdates<T extends Area | User | Event | Report>(
-	cached: T[],
-	updates: T[],
-	type: "areas" | "users" | "events" | "reports",
-): Promise<T[]> {
-	try {
-		return await sendWorkerMessage<T[]>("MERGE_UPDATES", {
-			cached,
-			updates,
-			type,
-		});
-	} catch (error) {
-		// Fallback to synchronous merging
-		// Type-safe: T is constrained to Area | User | Event | Report, all have id and deleted_at
-		console.warn("Worker merging failed, using synchronous fallback:", error);
-		const updatesMap = new Map(updates.map((item) => [item.id, item]));
-		const filtered = cached.filter((item) => !updatesMap.has(item.id));
-		const merged = [...filtered];
-		updates.forEach((item) => {
-			if (!item.deleted_at) {
-				merged.push(item);
 			}
 		});
 		return merged;

--- a/src/lib/workers/sync-worker.ts
+++ b/src/lib/workers/sync-worker.ts
@@ -1,27 +1,27 @@
 import type { Place, ProgressUpdate } from "../types";
 
-export interface ParseJSONPayload {
+export type ParseJSONPayload = {
 	json: string;
 	type: "places" | "areas" | "users" | "events" | "reports";
-}
+};
 
-export interface FilterPlacesPayload {
+export type FilterPlacesPayload = {
 	places: Place[];
 	updatedPlaceIds: number[];
 	recentUpdates: Place[];
-}
+};
 
-export interface WorkerMessage {
+export type WorkerMessage = {
 	type: "PARSE_JSON" | "FILTER_PLACES";
 	payload: ParseJSONPayload | FilterPlacesPayload;
 	id: string;
-}
+};
 
-export interface WorkerResponse {
+export type WorkerResponse = {
 	type: "PARSED" | "FILTERED" | "ERROR" | "PROGRESS";
 	payload: unknown;
 	id: string;
-}
+};
 
 function serializeError(error: unknown): string {
 	if (error instanceof Error) {

--- a/src/lib/workers/sync-worker.ts
+++ b/src/lib/workers/sync-worker.ts
@@ -1,28 +1,4 @@
-import type {
-	Area,
-	Event,
-	Place,
-	ProgressUpdate,
-	Report,
-	User,
-} from "../types";
-
-// Type constraint to ensure items have required properties
-type ItemWithId = Area | User | Event | Report;
-
-// Type guard to validate runtime types
-function hasRequiredProperties(item: unknown): item is ItemWithId {
-	return (
-		typeof item === "object" &&
-		item !== null &&
-		"id" in item &&
-		"deleted_at" in item &&
-		(typeof (item as ItemWithId).id === "string" ||
-			typeof (item as ItemWithId).id === "number") &&
-		(typeof (item as ItemWithId).deleted_at === "string" ||
-			(item as ItemWithId).deleted_at === null)
-	);
-}
+import type { Place, ProgressUpdate } from "../types";
 
 export interface ParseJSONPayload {
 	json: string;
@@ -35,29 +11,14 @@ export interface FilterPlacesPayload {
 	recentUpdates: Place[];
 }
 
-export interface FilterDeletedPayload {
-	items: (Place | Area | User | Event | Report)[];
-	type: "places" | "areas" | "users" | "events" | "reports";
-}
-
-export interface MergeUpdatesPayload {
-	cached: ItemWithId[];
-	updates: ItemWithId[];
-	type: "areas" | "users" | "events" | "reports";
-}
-
 export interface WorkerMessage {
-	type: "PARSE_JSON" | "FILTER_PLACES" | "FILTER_DELETED" | "MERGE_UPDATES";
-	payload:
-		| ParseJSONPayload
-		| FilterPlacesPayload
-		| FilterDeletedPayload
-		| MergeUpdatesPayload;
+	type: "PARSE_JSON" | "FILTER_PLACES";
+	payload: ParseJSONPayload | FilterPlacesPayload;
 	id: string;
 }
 
 export interface WorkerResponse {
-	type: "PARSED" | "FILTERED" | "MERGED" | "ERROR" | "PROGRESS";
+	type: "PARSED" | "FILTERED" | "ERROR" | "PROGRESS";
 	payload: unknown;
 	id: string;
 }
@@ -181,81 +142,6 @@ self.onmessage = (event: MessageEvent<WorkerMessage>) => {
 				self.postMessage({
 					type: "FILTERED",
 					payload: deduplicated,
-					id,
-				} as WorkerResponse);
-				break;
-			}
-
-			case "FILTER_DELETED": {
-				const filterPayload = payload as FilterDeletedPayload;
-				let filtered: unknown[];
-
-				switch (filterPayload.type) {
-					case "areas":
-						filtered = (filterPayload.items as Area[]).filter(
-							(area) => !area.deleted_at && area.tags?.type !== "trash",
-						);
-						break;
-					case "places":
-						filtered = (filterPayload.items as Place[]).filter(
-							(place) => !place.deleted_at,
-						);
-						break;
-					case "users":
-						filtered = (filterPayload.items as User[]).filter(
-							(user) => !user.deleted_at,
-						);
-						break;
-					case "events":
-						filtered = (filterPayload.items as Event[]).filter(
-							(event) => !event.deleted_at,
-						);
-						break;
-					case "reports":
-						filtered = (filterPayload.items as Report[]).filter(
-							(report) => !report.deleted_at,
-						);
-						break;
-					default:
-						filtered = filterPayload.items;
-				}
-
-				self.postMessage({
-					type: "FILTERED",
-					payload: filtered,
-					id,
-				} as WorkerResponse);
-				break;
-			}
-
-			case "MERGE_UPDATES": {
-				const mergePayload = payload as MergeUpdatesPayload;
-
-				// Type-safe mapping: handle both string and number IDs
-				const updatesMap = new Map<string | number, ItemWithId>();
-				mergePayload.updates.forEach((item) => {
-					if (hasRequiredProperties(item)) {
-						updatesMap.set(item.id, item);
-					}
-				});
-
-				// Filter out items that have updates
-				const filtered = mergePayload.cached.filter((item) => {
-					if (!hasRequiredProperties(item)) return false;
-					return !updatesMap.has(item.id);
-				});
-
-				// Add non-deleted updates
-				const merged = [...filtered];
-				mergePayload.updates.forEach((item) => {
-					if (hasRequiredProperties(item) && !item.deleted_at) {
-						merged.push(item);
-					}
-				});
-
-				self.postMessage({
-					type: "MERGED",
-					payload: merged,
 					id,
 				} as WorkerResponse);
 				break;


### PR DESCRIPTION
Fixes #1167.

## What
Deletes ~130 lines of dead worker surface: `filterDeleted` and `mergeUpdates` in `sync-worker-manager.ts` (zero call sites — every other `filterDeleted` in the repo is the unrelated `SyncConfig` field), their `FILTER_DELETED`/`MERGE_UPDATES` handlers in `sync-worker.ts` (messages nobody sends), and the now-unused payload types, type guard, and union members. The live worker paths — `parseJSON` and `filterPlaces`, used by `places.ts` — and all plumbing are untouched.

## Why delete instead of wire
The issue offered both options; the recent sync hardening settles it. The worker's `mergeUpdates` duplicates **pre-hardening** merge semantics: its row guard doesn't validate `updated_at` parseability (the exact #1187 corruption vector), it has no `validateSyncPage`/`nextCursor`, and its append-style merge re-introduces the intra-page duplicate class the Map dedup just fixed. Wiring it in would create a second, unhardened implementation of freshly-fixed logic — the drift pattern this PR series has been eliminating. Two structural blockers besides: predicates can't cross `postMessage` (the areas trash-filter is a function), and `createSyncFactory` also runs server-side where `Worker` doesn't exist. If off-thread merging is ever wanted, the hardened logic gets ported then.

## Scope note
`terminate()` in the manager is also uncalled but belongs to the live plumbing — flagged here, not deleted, to keep this strictly to #1167's surface.

Verified: type-check catches any missed reference (clean), lint clean, full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified background synchronization by limiting worker processing to JSON parsing and place filtering.
  * Removed support for deleted-item filtering and generic update merging.
  * Updated synchronization responses to exclude merged-result handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->