### PR TITLE
fix(merchant-list): don't toast on cancelled list fetches #1184

### DIFF
--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -1,3 +1,4 @@
+import { CanceledError } from "axios";
 import { get } from "svelte/store";
 import type { Mock } from "vitest";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -438,9 +439,33 @@ describe("merchantListStore", () => {
 
 			expect(errToast).not.toHaveBeenCalled();
 		});
+
+		// Deliberate aborts through our AbortControllers reject with axios v1's
+		// CanceledError (name "CanceledError"), NOT "AbortError" — rapid pans
+		// cancel the prior request every time and must never toast.
+		it("should ignore axios CanceledError (no toast, no warn)", async () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
+
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+
+			expect(errToast).not.toHaveBeenCalled();
+			expect(warnSpy).not.toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
 	});
 
 	describe("fetchCountOnly", () => {
+		it("should ignore axios CanceledError (no warn)", async () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
+
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+
+			expect(warnSpy).not.toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
 		it("should request only id field while no recency filter is active", async () => {
 			(api.get as Mock).mockResolvedValueOnce({ data: [] });
 
@@ -582,6 +607,16 @@ describe("merchantListStore", () => {
 	});
 
 	describe("fetchEnrichedDetails", () => {
+		it("should ignore axios CanceledError (no warn)", async () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
+
+			await merchantList.fetchEnrichedDetails({ lat: 0, lon: 0 }, 5);
+
+			expect(warnSpy).not.toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
+
 		it("should merge into existing cache (not replace)", async () => {
 			// Set up initial cache
 			const initialPlace = createMockPlace({ id: 1 });

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -444,26 +444,34 @@ describe("merchantListStore", () => {
 		// CanceledError (name "CanceledError"), NOT "AbortError" — rapid pans
 		// cancel the prior request every time and must never toast.
 		it("should ignore axios CanceledError (no toast, no warn)", async () => {
+			// try/finally: a failing assertion must not leave console.warn
+			// mocked for later tests (beforeEach clears, but doesn't restore)
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
+			try {
+				(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
 
-			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+				await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
 
-			expect(errToast).not.toHaveBeenCalled();
-			expect(warnSpy).not.toHaveBeenCalled();
-			warnSpy.mockRestore();
+				expect(errToast).not.toHaveBeenCalled();
+				expect(warnSpy).not.toHaveBeenCalled();
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 	});
 
 	describe("fetchCountOnly", () => {
 		it("should ignore axios CanceledError (no warn)", async () => {
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
+			try {
+				(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
 
-			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+				await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
 
-			expect(warnSpy).not.toHaveBeenCalled();
-			warnSpy.mockRestore();
+				expect(warnSpy).not.toHaveBeenCalled();
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 
 		it("should request only id field while no recency filter is active", async () => {
@@ -609,12 +617,15 @@ describe("merchantListStore", () => {
 	describe("fetchEnrichedDetails", () => {
 		it("should ignore axios CanceledError (no warn)", async () => {
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
+			try {
+				(api.get as Mock).mockRejectedValueOnce(new CanceledError("canceled"));
 
-			await merchantList.fetchEnrichedDetails({ lat: 0, lon: 0 }, 5);
+				await merchantList.fetchEnrichedDetails({ lat: 0, lon: 0 }, 5);
 
-			expect(warnSpy).not.toHaveBeenCalled();
-			warnSpy.mockRestore();
+				expect(warnSpy).not.toHaveBeenCalled();
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 
 		it("should merge into existing cache (not replace)", async () => {

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -1,3 +1,4 @@
+import axios from "axios";
 import { get, writable } from "svelte/store";
 
 import { API_BASE } from "$lib/api-base";
@@ -113,6 +114,13 @@ function sortMerchants(
 		// Fallback to alphabetical
 		return (a.name || "").localeCompare(b.name || "");
 	});
+}
+
+// Deliberate aborts from our AbortControllers surface as axios CanceledError
+// (axios.isCancel) — or a native AbortError — and are not failures: rapid
+// pans and zoom-boundary crossings cancel the prior request every time.
+function isCancellation(error: Error): boolean {
+	return axios.isCancel(error) || error.name === "AbortError";
 }
 
 // Filter out invalid API response items missing required id field
@@ -294,7 +302,7 @@ function createMerchantListStore() {
 					}));
 				}
 			} catch (error) {
-				if (error instanceof Error && error.name !== "AbortError") {
+				if (error instanceof Error && !isCancellation(error)) {
 					console.warn("Failed to fetch merchant list:", error.message);
 					errToast(get(_)("errors.loadFailed"));
 				}
@@ -369,7 +377,7 @@ function createMerchantListStore() {
 					// Preserve existing categoryCounts since we don't have actual merchant data to recalculate them
 				}));
 			} catch (error) {
-				if (error instanceof Error && error.name !== "AbortError") {
+				if (error instanceof Error && !isCancellation(error)) {
 					console.warn("Failed to fetch merchant count:", error.message);
 				}
 				update((state) => ({ ...state, isLoadingList: false }));
@@ -407,7 +415,7 @@ function createMerchantListStore() {
 					};
 				});
 			} catch (error) {
-				if (error instanceof Error && error.name !== "AbortError") {
+				if (error instanceof Error && !isCancellation(error)) {
 					console.warn("Failed to fetch enriched details:", error.message);
 				}
 				update((state) => ({ ...state, isEnrichingDetails: false }));


### PR DESCRIPTION
Fixes #1184.

## What was happening
The store's three catch guards checked `error.name !== "AbortError"` — but the app's axios **v1** instance rejects deliberate aborts with `CanceledError` (name `CanceledError`, code `ERR_CANCELED`), which passes every guard. Consequences: every rapid pan at zoom 10+ aborts the prior list request and showed a **user-visible "failed to load" toast** for a cancellation the app itself issued; cancelled count/enrichment fetches logged spurious console warns. Pre-existing on main since the axios-instance migration; surfaced during the #1180 review.

## The fix
A module-local `isCancellation(error)`: `axios.isCancel(error) || error.name === "AbortError"` — `isCancel` is the canonical marker check and matches the repo's three existing call sites; the AbortError name check is kept defensively (and keeps the pre-existing tests exact). All three guards route through it.

Deliberately unchanged:
- **Timeouts still toast** — `ECONNABORTED` is a real failure, not a cancellation. Stated here so nobody "fixes" the timeout toast as a follow-on.
- **`map/+page.svelte`'s search guard untouched** — that's a native `fetch`, where `AbortError` is the genuine cancel name.

## Tests
TDD (red→green): three new tests, one per method, reject with a **real `CanceledError`** — not a hand-rolled `{name, code}` shape, since `axios.isCancel` keys on the `__CANCEL__` marker — and assert no toast and no warn. The pre-existing AbortError tests stay green unchanged. 81 store tests passing; full checklist clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of canceled requests so users no longer see unnecessary error notifications or warnings.
  * Loading indicators now clear correctly when list, count, or detail requests are canceled.
* **Tests**
  * Added coverage to verify consistent behavior across all supported request cancellation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->