### PR TITLE
test(e2e): hermetic map-data fixtures, tools-panel exemplar #1185

### DIFF
--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,20 +2,91 @@ import type { Page } from '@playwright/test';
 
 export const MARKER_LOAD_TIMEOUT = 60000;
 
+// Deterministic bulk-feed fixture for hermetic map specs (#1185). Fields are
+// exactly what the pipeline reads: places.ts wants a non-empty array;
+// buildFeatureCollectionFor reads id/lat/lon/icon/comments/boosted_until/
+// name; the nearby-list local path reads deleted_at plus lat/lon against the
+// buffered viewport. Coordinates sit inside the specs' shared
+// #17/42.2762511/42.7024218 viewport so nearby counts are deterministic too.
+// verified_at is deliberately absent — matching the real CDN feed.
+export const STUB_PLACES = [
+	{ id: 1, lat: 42.2762, lon: 42.7024, icon: 'restaurant', name: 'Stub Cafe' },
+	{ id: 2, lat: 42.277, lon: 42.703, icon: 'question_mark', name: 'Stub Shop' },
+	{
+		id: 3,
+		lat: 42.2755,
+		lon: 42.7018,
+		icon: 'cafe',
+		name: 'Stub Bar',
+		boosted_until: '2099-01-01T00:00:00Z'
+	}
+];
+
+// Stub every btcmap data request the /map page makes at boot so a spec runs
+// hermetically: the CDN bulk feed (GET + the HEAD staleness probe) serves the
+// fixture, and every api.btcmap.org /v4/places* call (update check, radius
+// search, count, enrichment, verified dates) serves []. A catch-all for both
+// data hosts is registered FIRST so the specific routes win (Playwright
+// matches routes in reverse registration order) and any request this
+// inventory missed gets a stubbed [] instead of a live hit.
+//
+// IMPORTANT for callers: the prod build registers a service worker whose
+// fetch handler does NOT bypass cdn.static.btcmap.org, and page.route cannot
+// see SW-mediated fetches — specs using this helper MUST also set
+// `test.use({ serviceWorkers: 'block' })`.
+export async function stubMapData(page: Page, places: unknown[] = STUB_PLACES) {
+	await page.route(
+		(u) =>
+			(u.hostname === 'api.btcmap.org' || u.hostname === 'cdn.static.btcmap.org') &&
+			(u.pathname.startsWith('/v4/') || u.pathname.startsWith('/api/v4/')),
+		(route) =>
+			route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+	);
+	await page.route('https://cdn.static.btcmap.org/api/v4/places.json', async (route) => {
+		if (route.request().method() === 'HEAD') {
+			// A current Last-Modified keeps the staleness check happy so the
+			// update-check cursor stays deterministic.
+			await route.fulfill({
+				status: 200,
+				headers: { 'last-modified': new Date().toUTCString() }
+			});
+			return;
+		}
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify(places)
+		});
+	});
+	await page.route(
+		(u) => u.hostname === 'api.btcmap.org' && u.pathname.startsWith('/v4/places'),
+		(route) =>
+			route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+	);
+}
+
 // Wait for places API response and markers to render on the map.
 // MapLibre draws pins on a WebGL canvas (no DOM markers like Leaflet had),
 // so DOM-count probes won't work. Use querySourceFeatures on the
 // "places" source to detect that real features have flowed in.
-export async function waitForMarkersToLoad(page: Page) {
-	// First wait for the places API to respond
-	try {
-		await page.waitForResponse(
-			(response) => response.url().includes('api.btcmap.org/v4/places') && response.ok(),
-			{ timeout: 30000 }
-		);
-	} catch {
-		// API may have already responded before we started waiting
-		// Continue and check if markers exist
+// skipApiWait: stubbed specs answer instantly, so the response can land
+// before this helper starts listening — the try/catch below would then eat a
+// silent 30s. The __mapPlacesCount poll is the real gate either way.
+export async function waitForMarkersToLoad(
+	page: Page,
+	opts: { skipApiWait?: boolean } = {}
+) {
+	if (!opts.skipApiWait) {
+		// First wait for the places API to respond
+		try {
+			await page.waitForResponse(
+				(response) => response.url().includes('api.btcmap.org/v4/places') && response.ok(),
+				{ timeout: 30000 }
+			);
+		} catch {
+			// API may have already responded before we started waiting
+			// Continue and check if markers exist
+		}
 	}
 
 	// MapLibre canvas must be present before features can be queried.

--- a/tests/map-tools-panel.spec.ts
+++ b/tests/map-tools-panel.spec.ts
@@ -1,17 +1,33 @@
 import { test, expect } from '@playwright/test';
-import { waitForMarkersToLoad } from './helpers';
+import { STUB_PLACES, stubMapData, waitForMarkersToLoad } from './helpers';
 
 // The consolidated "Layers & filters" panel: one trigger button opens a
 // modal with basemap, verified-filter, overlay (heatmap + boost) and view
 // (globe) sections.
+//
+// Hermetic exemplar (#1185): all btcmap data requests are stubbed, so this
+// spec is deterministic and independent of API/CDN availability. Blocking
+// service workers is load-bearing — the prod build's SW does not bypass the
+// CDN host, and SW-mediated fetches are invisible to page.route.
 test.describe('Map tools panel', () => {
+	test.use({ serviceWorkers: 'block' });
+
 	const toolsButton = (page: import('@playwright/test').Page) =>
 		page.getByRole('button', { name: /layers & filters/i });
 
 	test('opens a modal with every section, then closes', async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 720 });
+		await stubMapData(page);
 		await page.goto('/map#17/42.2762511/42.7024218', { waitUntil: 'load' });
-		await waitForMarkersToLoad(page);
+		await waitForMarkersToLoad(page, { skipApiWait: true });
+
+		// The fixture is the whole world: the rendered count is exact — the
+		// hermeticity payoff (with live data this was nondeterministic).
+		expect(
+			await page.evaluate(
+				() => (window as unknown as { __mapPlacesCount: number }).__mapPlacesCount
+			)
+		).toBe(STUB_PLACES.length);
 
 		await expect(toolsButton(page)).toBeVisible();
 		await toolsButton(page).click();


### PR DESCRIPTION
Fixes #1185 (first slice — remaining map specs opt in incrementally).

## What
- **`stubMapData(page)`** in `tests/helpers.ts`: stubs every btcmap data request the /map page makes at boot. A catch-all for both data hosts is registered *first* (Playwright matches in reverse order), so the specific routes win and anything the request inventory missed gets a stubbed `[]` instead of a silent live hit — hermeticity fails loud, not leaky. The CDN bulk feed serves a 3-place fixture (both the GET and the HEAD staleness probe, with a current `Last-Modified` so the update-check cursor stays deterministic); every `api.btcmap.org/v4/places*` call (update check, radius search, count, enrichment, verified dates) serves `[]`.
- **`waitForMarkersToLoad(page, { skipApiWait })`**: an instant stub can respond before the helper starts listening, and the existing try/catch would eat a silent 30s — stubbed specs skip the response wait; the `__mapPlacesCount` poll is the real gate. Backward compatible; no other caller changes.
- **Exemplar conversion**: `map-tools-panel.spec.ts` runs hermetically and gains the payoff assertion — an *exact* rendered-count check (`__mapPlacesCount === 3`) that was nondeterministic against live data.

## The load-bearing detail
`test.use({ serviceWorkers: 'block' })` is **not optional**: CI runs the prod build, whose service worker does not bypass `cdn.static.btcmap.org`, and SW-mediated fetches are invisible to `page.route`. Single-goto specs only escape today because the SW lacks `clients.claim()` — any second navigation would silently pull the real multi-MB feed. Blocking removes the ambiguity; each spec that opts in must carry it.

## Deliberately out of scope
Style tiles (`tiles.openfreemap.org`) and iconify sprites stay live — this issue is about *data* determinism; the style fetch remains a pre-existing render-path dependency, and sprite failures degrade to transparent stubs without affecting `__mapPlacesCount`. Worth keeping one live-API spec as a canary when the remaining six opt in.

## Verification
Local Playwright is known-broken on this machine, so **CI arbitrates** — draft until it proves itself, ideally with a `--repeat-each` determinism run. Static gates (format/check/lint/unit) all green; the helper change is backward compatible so the six unconverted specs must stay green, which is itself the regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)