### PR TITLE
refactor(map): visiblePlaces — one pipeline for which places are visible #1168

### DIFF
--- a/src/components/Boost.svelte
+++ b/src/components/Boost.svelte
@@ -4,7 +4,7 @@ import OutClick from "svelte-outclick";
 
 import BoostContent from "$components/BoostContent.svelte";
 import CloseButton from "$components/CloseButton.svelte";
-import { boost, lastUpdatedPlaceId, resetBoost } from "$lib/store";
+import { boost, resetBoost } from "$lib/store";
 
 import { invalidateAll } from "$app/navigation";
 
@@ -16,7 +16,6 @@ const closeModal = () => {
 	}
 	$boost = undefined;
 	$resetBoost = $resetBoost + 1;
-	$lastUpdatedPlaceId = undefined;
 	boostComplete = false;
 };
 

--- a/src/components/BoostContent.svelte
+++ b/src/components/BoostContent.svelte
@@ -9,7 +9,7 @@ import PrimaryButton from "$components/PrimaryButton.svelte";
 import { _ } from "$lib/i18n";
 import IconSocials from "$lib/icons/IconSocials.svelte";
 import { classifyBoostError } from "$lib/payment";
-import { boost, boostHash, lastUpdatedPlaceId } from "$lib/store";
+import { boost, boostHash } from "$lib/store";
 import { updateSinglePlace } from "$lib/sync/places";
 import { errToast, warningToast } from "$lib/utils";
 
@@ -58,7 +58,6 @@ const handlePaymentSuccess = async () => {
 
 		if (merchantId) {
 			await updateSinglePlace(merchantId);
-			lastUpdatedPlaceId.set(Number(merchantId));
 		}
 
 		if (onComplete) {

--- a/src/lib/map/maplibreSprites.ts
+++ b/src/lib/map/maplibreSprites.ts
@@ -137,6 +137,31 @@ const markRealSprite = (m: MapLibreMap, name: string): void => {
 	set.add(name);
 };
 
+// For fixed sprites owned by other modules (badges, hit-targets): hasImage()
+// alone can't distinguish a real sprite from the 1×1 stub the
+// styleimagemissing handler inserts while a load is failing or pending — a
+// loader gating on it would treat the stub as done and never retry. These
+// share the real-registration tracking (cleared on style.load) so retries
+// after a transient failure or a style rebuild replace the stub.
+export const hasRealImage = (m: MapLibreMap, name: string): boolean => {
+	ensureStyleResetListener(m);
+	return hasRealSprite(m, name);
+};
+
+export const addRealImage = (
+	m: MapLibreMap,
+	name: string,
+	img: Parameters<MapLibreMap["addImage"]>[1],
+	opts: { pixelRatio: number },
+): void => {
+	ensureStyleResetListener(m);
+	// Remove any stub the placeholder handler installed before we got here —
+	// addImage throws on a duplicate name, and updateImage drops pixelRatio.
+	if (m.hasImage(name)) m.removeImage(name);
+	m.addImage(name, img, opts);
+	markRealSprite(m, name);
+};
+
 export const ensureSprite = (
 	m: MapLibreMap,
 	icon: string,

--- a/src/lib/map/placePinSource.test.ts
+++ b/src/lib/map/placePinSource.test.ts
@@ -1,0 +1,201 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
+import type { Place } from "$lib/types";
+
+const { ensureSpritesMock } = vi.hoisted(() => ({
+	ensureSpritesMock: vi.fn(),
+}));
+
+vi.mock("$lib/map/maplibreSprites", () => ({
+	ensureSpritesForPlaces: ensureSpritesMock,
+	loadSvgImage: vi.fn(),
+}));
+
+import { createPlacePinSource } from "./placePinSource";
+
+// BOOSTED_CLUSTERING_MAX_ZOOM is 5: boosted places fold into the clustered
+// source at integer zoom ≤ 5 and ride the standalone source above it.
+const CLUSTERED_ZOOM = 3;
+const STANDALONE_ZOOM = 12;
+
+type FakeSource = { setData: ReturnType<typeof vi.fn> };
+
+const makeFakeMap = (zoom: number) => {
+	const sources: Record<string, FakeSource> = {
+		places: { setData: vi.fn() },
+		"places-boosted": { setData: vi.fn() },
+		"places-heatmap": { setData: vi.fn() },
+	};
+	const layoutCalls: [string, string, string][] = [];
+	let currentZoom = zoom;
+	return {
+		sources,
+		layoutCalls,
+		setZoom: (z: number) => {
+			currentZoom = z;
+		},
+		map: {
+			getZoom: () => currentZoom,
+			getSource: (id: string) => sources[id],
+			getLayer: (_id: string) => true,
+			setLayoutProperty: (layer: string, prop: string, value: string) => {
+				layoutCalls.push([layer, prop, value]);
+			},
+		} as unknown as MapLibreMap,
+	};
+};
+
+const makePlace = (overrides: Partial<Place> = {}): Place =>
+	({
+		id: 1,
+		lat: 10,
+		lon: 20,
+		icon: "cafe",
+		...overrides,
+	}) as Place;
+
+const boostedPlace = (id: number): Place =>
+	makePlace({
+		id,
+		boosted_until: new Date(Date.now() + 86_400_000).toISOString(),
+	});
+
+const makeSource = (onRendered?: (count: number) => void) =>
+	createPlacePinSource({
+		getSavedIds: () => new Set<number>([1]),
+		getEnrichedCache: () => new Map<number, Place>(),
+		getDisplayLang: () => "en",
+		onRendered,
+	});
+
+const featuresOf = (source: FakeSource) =>
+	source.setData.mock.calls[source.setData.mock.calls.length - 1][0].features;
+
+beforeEach(() => {
+	ensureSpritesMock.mockClear();
+	localStorage.clear();
+});
+
+describe("render", () => {
+	it("routes boosted places to the standalone source above the clustering zoom", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const pin = makeSource();
+		pin.render(map, [makePlace({ id: 1 }), boostedPlace(2)]);
+
+		expect(
+			featuresOf(sources.places).map(
+				(f: { properties: { id: number } }) => f.properties.id,
+			),
+		).toEqual([1]);
+		expect(
+			featuresOf(sources["places-boosted"]).map(
+				(f: { properties: { id: number } }) => f.properties.id,
+			),
+		).toEqual([2]);
+	});
+
+	it("folds boosted places into the clustered source at low zoom", () => {
+		const { map, sources } = makeFakeMap(CLUSTERED_ZOOM);
+		const pin = makeSource();
+		pin.render(map, [makePlace({ id: 1 }), boostedPlace(2)]);
+
+		expect(featuresOf(sources.places)).toHaveLength(2);
+		expect(featuresOf(sources["places-boosted"])).toHaveLength(0);
+	});
+
+	it("skips the heatmap source while the heatmap is off, reports the count, loads sprites", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const counts: number[] = [];
+		const pin = makeSource((count) => counts.push(count));
+		const list = [makePlace({ id: 1 }), makePlace({ id: 2 })];
+		pin.render(map, list);
+
+		expect(sources["places-heatmap"].setData).not.toHaveBeenCalled();
+		expect(counts).toEqual([2]);
+		expect(ensureSpritesMock).toHaveBeenCalledWith(map, list);
+	});
+
+	it("builds feature properties from the injected deps", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const enriched = new Map<number, Place>([
+			[1, { localized_name: { de: "Café Eins" } } as unknown as Place],
+		]);
+		const pin = createPlacePinSource({
+			getSavedIds: () => new Set([1]),
+			getEnrichedCache: () => enriched,
+			getDisplayLang: () => "de",
+		});
+		pin.render(map, [makePlace({ id: 1, name: "Cafe One" })]);
+
+		const [feature] = featuresOf(sources.places);
+		expect(feature.properties.name).toBe("Café Eins");
+		expect(feature.properties.saved).toBe(true);
+		expect(feature.properties.boosted).toBe(false);
+	});
+});
+
+describe("resyncForZoom", () => {
+	it("re-renders only when the zoom crossing actually flips the routing", () => {
+		const fake = makeFakeMap(CLUSTERED_ZOOM);
+		const pin = makeSource();
+		pin.render(fake.map, [makePlace({ id: 1 }), boostedPlace(2)]);
+		expect(fake.sources.places.setData).toHaveBeenCalledTimes(1);
+
+		// Same side of the boundary — no re-render
+		fake.setZoom(CLUSTERED_ZOOM + 1);
+		pin.resyncForZoom(fake.map);
+		expect(fake.sources.places.setData).toHaveBeenCalledTimes(1);
+
+		// Crossing the boundary re-renders from the remembered list
+		fake.setZoom(STANDALONE_ZOOM);
+		pin.resyncForZoom(fake.map);
+		expect(fake.sources.places.setData).toHaveBeenCalledTimes(2);
+		expect(featuresOf(fake.sources["places-boosted"])).toHaveLength(1);
+	});
+});
+
+describe("heatmap", () => {
+	it("seeds the heatmap source from the last synced list on enable", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const pin = makeSource();
+		pin.render(map, [makePlace({ id: 1 }), makePlace({ id: 2 })]);
+		expect(sources["places-heatmap"].setData).not.toHaveBeenCalled();
+
+		pin.setHeatmapEnabled(map, true);
+		expect(featuresOf(sources["places-heatmap"])).toHaveLength(2);
+
+		// While enabled, render refreshes the heatmap with the full list
+		pin.render(map, [makePlace({ id: 3 })]);
+		expect(featuresOf(sources["places-heatmap"])).toHaveLength(1);
+	});
+
+	it("conceals pin layers below the reveal zoom and shows them above it", () => {
+		const fake = makeFakeMap(10);
+		const pin = makeSource();
+		pin.setHeatmapEnabled(fake.map, true);
+		const heatmapVis = fake.layoutCalls.find(([l]) => l === "place-heatmap");
+		expect(heatmapVis?.[2]).toBe("visible");
+		const pinVis = fake.layoutCalls.find(([l]) => l === "unclustered-point");
+		expect(pinVis?.[2]).toBe("none");
+
+		// Past the reveal zoom (15.5) pins show through the fading heatmap
+		fake.layoutCalls.length = 0;
+		fake.setZoom(16);
+		pin.applyHeatmapVisibility(fake.map);
+		const pinVisHigh = fake.layoutCalls.find(
+			([l]) => l === "unclustered-point",
+		);
+		expect(pinVisHigh?.[2]).toBe("visible");
+	});
+
+	it("reads the persisted on state and re-applies it after a style load", () => {
+		localStorage.setItem(HEATMAP_STORAGE_KEY, "true");
+		const fake = makeFakeMap(10);
+		const pin = makeSource();
+		pin.refreshHeatmapAfterStyle(fake.map);
+		const heatmapVis = fake.layoutCalls.find(([l]) => l === "place-heatmap");
+		expect(heatmapVis?.[2]).toBe("visible");
+	});
+});

--- a/src/lib/map/placePinSource.ts
+++ b/src/lib/map/placePinSource.ts
@@ -1,0 +1,783 @@
+import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+
+import { CLUSTERING_DISABLED_ZOOM, LABEL_VISIBLE_ZOOM } from "$lib/constants";
+import {
+	routePlacesByBoostAndZoom,
+	shouldClusterBoostedAtZoom,
+} from "$lib/map/boostedClustering";
+import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
+import { ensureSpritesForPlaces, loadSvgImage } from "$lib/map/maplibreSprites";
+import type { Place } from "$lib/types";
+import { isBoosted } from "$lib/utils";
+
+export type PlaceFeature = {
+	type: "Feature";
+	geometry: { type: "Point"; coordinates: [number, number] };
+	properties: {
+		id: number;
+		boosted: boolean;
+		icon: string;
+		comments: number;
+		saved: boolean;
+		name: string;
+	};
+};
+
+export type PlaceFeatureCollection = {
+	type: "FeatureCollection";
+	features: PlaceFeature[];
+};
+
+const EMPTY_COLLECTION: PlaceFeatureCollection = {
+	type: "FeatureCollection",
+	features: [],
+};
+
+// The custom sources + layers this module adds on top of whatever basemap is
+// active. The /map page's applyBasemap() carries these across a setStyle() so
+// the pins, clusters, and labels survive a basemap/theme swap untouched
+// (MapLibre's style differ leaves byte-identical layers in place — only the
+// basemap layers below them get swapped).
+export const CUSTOM_SOURCE_IDS: readonly string[] = [
+	"places",
+	"places-boosted",
+	"places-heatmap",
+];
+export const CUSTOM_LAYER_IDS: readonly string[] = [
+	"place-heatmap",
+	"clusters-outer",
+	"clusters-inner",
+	"cluster-count",
+	"unclustered-point",
+	"boosted-point",
+	"comment-badge",
+	"comment-badge-count",
+	"saved-badge",
+	"place-label",
+	"boosted-comment-badge",
+	"boosted-comment-badge-count",
+	"boosted-saved-badge",
+	"boosted-place-label",
+	"clusters-hit",
+];
+// All point/cluster/badge/label layers that the heatmap conceals while
+// active below CLUSTERING_DISABLED_ZOOM (17).  At zoom 17+ the heatmap
+// layer naturally disappears (its maxzoom), so these layers are revealed
+// again without the user having to toggle heatmap off.
+const HEATMAP_HIDDEN_LAYER_IDS = [
+	"clusters-outer",
+	"clusters-inner",
+	"cluster-count",
+	"clusters-hit",
+	"unclustered-point",
+	"boosted-point",
+	"comment-badge",
+	"comment-badge-count",
+	"saved-badge",
+	"place-label",
+	"boosted-comment-badge",
+	"boosted-comment-badge-count",
+	"boosted-saved-badge",
+	"boosted-place-label",
+];
+
+// Tailwind `text-link` color (tailwind.config.js → colors.link).
+const LINK_COLOR = "#0099AF";
+
+// Composite saved-badge SVG. Outer SVG is rasterized at 2× its declared
+// dimensions (viewBox stays the same) and registered with pixelRatio: 2
+// so it draws crisp at the same logical 16×16 — same trick as
+// PIN_RENDER_SCALE for the main pin sprite.
+const SAVED_BADGE_SCALE = 2;
+const buildSavedBadgeSvg = (bookmarkSvg: string): string => {
+	const w = 16 * SAVED_BADGE_SCALE;
+	const h = 16 * SAVED_BADGE_SCALE;
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" fill="#fff" stroke="${LINK_COLOR}" stroke-width="1"/><g transform="translate(3, 3)">${bookmarkSvg}</g></svg>`;
+};
+
+// Near-invisible circular hit-target sprite used as the icon for the
+// symbol cluster layer that spiderfy hooks into. The visible cluster discs
+// render as circle layers (not symbols), so this symbol layer exists purely
+// so the spiderfy library can register click handlers targeting it. 1/255
+// alpha keeps pixels effectively invisible while ensuring
+// queryRenderedFeatures registers hits on the icon footprint.
+const loadClusterHitSprite = async (m: MapLibreMap): Promise<void> => {
+	if (m.hasImage("cluster-hit")) return;
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="rgba(0,0,0,0.004)"/></svg>`;
+	const img = await loadSvgImage(svg);
+	if (!m.hasImage("cluster-hit"))
+		m.addImage("cluster-hit", img, { pixelRatio: 1 });
+};
+
+// 16×16 green disc to back the comment count text. Matches /map's
+// Tailwind `bg-green-600 w-4 h-4 rounded-full` exactly. Drawn directly
+// on a canvas — simpler than the SVG → data-URL → <img> roundtrip for
+// a flat shape.
+const loadCommentBadgeSprite = (m: MapLibreMap): void => {
+	if (m.hasImage("comment-badge-bg")) return;
+	// Draw at 2× the logical 16×16 (= 32×32 backing canvas) and register
+	// with pixelRatio: 2 so MapLibre displays at the same logical size
+	// but reads from a higher-density bitmap — keeps the green disc
+	// crisp on retina/phone DPRs instead of upscaling 16×16 bitmap pixels.
+	const SIZE = 16;
+	const SCALE = 2;
+	const canvas = document.createElement("canvas");
+	canvas.width = SIZE * SCALE;
+	canvas.height = SIZE * SCALE;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return;
+	ctx.fillStyle = "#16A34A";
+	ctx.beginPath();
+	ctx.arc(
+		(SIZE * SCALE) / 2,
+		(SIZE * SCALE) / 2,
+		(SIZE * SCALE) / 2,
+		0,
+		Math.PI * 2,
+	);
+	ctx.fill();
+	m.addImage(
+		"comment-badge-bg",
+		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
+		{ pixelRatio: SCALE },
+	);
+};
+
+const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
+	if (m.hasImage("saved-badge")) return;
+	const encodedColor = encodeURIComponent(LINK_COLOR);
+	const url = `https://api.iconify.design/ic/baseline-bookmark-added.svg?color=${encodedColor}&width=10&height=10`;
+	const res = await fetch(url);
+	if (!res.ok) {
+		throw new Error(`saved-badge bookmark fetch failed: ${res.status} ${url}`);
+	}
+	const bookmarkSvg = await res.text();
+	const composite = buildSavedBadgeSvg(bookmarkSvg);
+	const img = await loadSvgImage(composite);
+	if (!m.hasImage("saved-badge"))
+		m.addImage("saved-badge", img, { pixelRatio: SAVED_BADGE_SCALE });
+	m.triggerRepaint();
+};
+
+export type PlacePinSourceDeps = {
+	// Snapshots read once per feature-collection build — saved state and
+	// enriched names arrive lazily and are re-read on every render.
+	getSavedIds: () => Set<number>;
+	getEnrichedCache: () => Map<number, Place>;
+	getDisplayLang: () => string;
+	// Fired after each render with the rendered count. The /map page uses it
+	// for the loading-screen gate and the e2e __mapPlacesCount hook.
+	onRendered?: (count: number) => void;
+};
+
+export type PlacePinSource = ReturnType<typeof createPlacePinSource>;
+
+// The pin/cluster/badge/label/heatmap rendering facade for the main /map.
+// Owns: the three GeoJSON sources and fifteen layers, the badge sprites, the
+// Place → feature-collection build (with lazy name resolution), the
+// boosted-routing render path, the zoom-boundary re-sync, and heatmap
+// visibility. Does NOT own: interactions, spiderfy, camera, label palette,
+// or any visibility policy — callers must pass the already-filtered list
+// (selectVisiblePlaces upstream) and render() renders exactly what it gets.
+export const createPlacePinSource = (deps: PlacePinSourceDeps) => {
+	// Last place list fed to the sources, kept so the boosted-clustering
+	// boundary re-sync (on zoom crossing BOOSTED_CLUSTERING_MAX_ZOOM) can
+	// rebuild without a $places change. `boostedAreClustered` mirrors the
+	// routing decision of the most recent render so the moveend handler only
+	// re-syncs when it actually flips.
+	let lastSyncedList: Place[] = [];
+	let boostedAreClustered = false;
+
+	// Merchant-density heatmap on/off. Off by default unless the user
+	// previously enabled it (persisted in localStorage by the toggle control).
+	let heatmapEnabled = false;
+	if (typeof window !== "undefined") {
+		try {
+			heatmapEnabled = localStorage.getItem(HEATMAP_STORAGE_KEY) === "true";
+		} catch {
+			// localStorage may be unavailable (private mode)
+		}
+	}
+
+	const buildFeatureCollection = (list: Place[]): PlaceFeatureCollection => {
+		const saved = deps.getSavedIds();
+		// Snapshot the enriched cache once per build — names arrive lazily as
+		// the viewport-bound /v4/places/search fetch resolves.
+		const enrichedCache = deps.getEnrichedCache();
+		const displayLang = deps.getDisplayLang();
+		const resolveName = (p: Place): string => {
+			const enriched = enrichedCache.get(p.id);
+			// Priority: enriched localized name → enriched plain name →
+			// $places localized name → $places plain name → OSM amenity fallback.
+			return (
+				enriched?.localized_name?.[displayLang] ??
+				enriched?.name ??
+				p.localized_name?.[displayLang] ??
+				p.name ??
+				p["osm:amenity"] ??
+				""
+			);
+		};
+		return {
+			type: "FeatureCollection",
+			features: list.map((p) => ({
+				type: "Feature",
+				geometry: { type: "Point", coordinates: [p.lon, p.lat] },
+				properties: {
+					id: p.id,
+					// Per-place so a boosted marker folded into the clustered source
+					// at low zoom still renders its orange pin when it sits
+					// unclustered.
+					boosted: !!isBoosted(p),
+					icon: p.icon ?? "question_mark",
+					comments: p.comments ?? 0,
+					saved: saved.has(p.id),
+					name: resolveName(p),
+				},
+			})),
+		};
+	};
+
+	// Badge + cluster-hit sprites. The saved-badge fetch goes to a
+	// third-party CDN and must NOT block or fail map init — a transient
+	// Iconify outage just degrades the saved-state badge. All loaders are
+	// hasImage-guarded, so re-running after a basemap swap is a cheap no-op
+	// on the normal (style-diff) path.
+	const loadSprites = async (map: MapLibreMap): Promise<void> => {
+		await Promise.all([
+			loadSavedBadgeSprite(map).catch((err) => {
+				console.warn("Saved-badge sprite failed to load:", err);
+			}),
+			loadCommentBadgeSprite(map),
+			loadClusterHitSprite(map).catch((err) => {
+				console.warn("Cluster-hit sprite failed to load:", err);
+			}),
+		]);
+	};
+
+	const install = (map: MapLibreMap): void => {
+		map.addSource("places", {
+			type: "geojson",
+			data: EMPTY_COLLECTION,
+			cluster: true,
+			clusterRadius: 80,
+			// CLUSTERING_DISABLED_ZOOM is 17; clusterMaxZoom=16 means at z17+ all points unclustered.
+			clusterMaxZoom: CLUSTERING_DISABLED_ZOOM - 1,
+		});
+
+		// Separate non-clustered source for boosted places. Above
+		// BOOSTED_CLUSTERING_MAX_ZOOM, render() routes boosted features here so
+		// they stay visually prominent above cluster discs and never get
+		// absorbed into a cluster icon. At/below that zoom they're routed into
+		// the clustered `places` source instead (see $lib/map/boostedClustering)
+		// — the MapLibre analogue of the legacy /map's dedicated boostedLayer +
+		// BOOSTED_CLUSTERING_MAX_ZOOM swap.
+		map.addSource("places-boosted", {
+			type: "geojson",
+			data: EMPTY_COLLECTION,
+		});
+
+		// Non-clustered source backing the merchant-density heatmap.
+		// Heatmap layers read raw point features, so they can't share the
+		// clustered `places` source — this dedicated source always carries
+		// the full unclustered list (see render). Visibility is toggled via
+		// the tools panel; off by default.
+		map.addSource("places-heatmap", {
+			type: "geojson",
+			data: EMPTY_COLLECTION,
+		});
+
+		// Merchant-density heatmap. Weight is uniform (1) so the gradient
+		// reflects pure point density. Radius and intensity scale up with
+		// zoom so the halo widens as you zoom out to a city/region view and
+		// tightens as pins take over. Opacity stays at full strength through
+		// zoom 14 and fades to zero from zoom 14→17 so the heatmap hands off
+		// cleanly to the individual pins at CLUSTERING_DISABLED_ZOOM.
+		map.addLayer({
+			id: "place-heatmap",
+			type: "heatmap",
+			source: "places-heatmap",
+			maxzoom: CLUSTERING_DISABLED_ZOOM,
+			layout: { visibility: "none" },
+			paint: {
+				"heatmap-weight": 1,
+				"heatmap-intensity": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					0,
+					0.5,
+					CLUSTERING_DISABLED_ZOOM,
+					3,
+				],
+				"heatmap-color": [
+					"interpolate",
+					["linear"],
+					["heatmap-density"],
+					0,
+					"rgba(0, 0, 255, 0)",
+					0.2,
+					"#67e8f9", // cyan-300
+					0.4,
+					"#22d3ee", // cyan-400
+					0.6,
+					"#facc15", // yellow-400
+					0.8,
+					"#facc15", // yellow-400 — yellow holds longer
+					1.0,
+					"#f97316", // orange-500
+					1.2,
+					"#ea580c", // orange-600
+					1.5,
+					"#dc2626", // red-600 — red only at extreme density
+				],
+				"heatmap-radius": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					0,
+					3,
+					CLUSTERING_DISABLED_ZOOM,
+					30,
+				],
+				"heatmap-opacity": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					14,
+					0.9,
+					CLUSTERING_DISABLED_ZOOM,
+					0,
+				],
+			},
+		});
+
+		// Translucent outer ring — green/yellow/orange tiers by point_count
+		// at 0.6 alpha.
+		map.addLayer({
+			id: "clusters-outer",
+			type: "circle",
+			source: "places",
+			filter: ["has", "point_count"],
+			paint: {
+				"circle-color": [
+					"step",
+					["get", "point_count"],
+					"rgba(181, 226, 140, 0.6)",
+					10,
+					"rgba(241, 211, 87, 0.6)",
+					100,
+					"rgba(253, 156, 115, 0.6)",
+				],
+				"circle-radius": 20,
+			},
+		});
+
+		map.addLayer({
+			id: "clusters-inner",
+			type: "circle",
+			source: "places",
+			filter: ["has", "point_count"],
+			paint: {
+				"circle-color": [
+					"step",
+					["get", "point_count"],
+					"rgba(110, 204, 57, 0.6)",
+					10,
+					"rgba(240, 194, 12, 0.6)",
+					100,
+					"rgba(241, 128, 23, 0.6)",
+				],
+				"circle-radius": 15,
+			},
+		});
+
+		map.addLayer({
+			id: "cluster-count",
+			type: "symbol",
+			source: "places",
+			filter: ["has", "point_count"],
+			layout: {
+				"text-field": ["get", "point_count_abbreviated"],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 12,
+				"text-allow-overlap": true,
+				"text-ignore-placement": true,
+				// Keep count upright when the map rotates.
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+			},
+			paint: {
+				"text-color": "#000",
+			},
+		});
+
+		// Symbol layer for unclustered points; boosted places use the orange
+		// pin. Drawn last so pins sit on top of cluster discs at boundaries.
+		map.addLayer({
+			id: "unclustered-point",
+			type: "symbol",
+			source: "places",
+			filter: ["!", ["has", "point_count"]],
+			layout: {
+				// Look up composite sprite (pin shape + baked category icon).
+				// Until the icon's sprite finishes loading, MapLibre logs a
+				// warning and skips the symbol; pins appear as their composite
+				// sprites resolve.
+				"icon-image": [
+					"concat",
+					"pin-",
+					["case", ["coalesce", ["get", "boosted"], false], "b", "r"],
+					"-",
+					["coalesce", ["get", "icon"], "question_mark"],
+				],
+				"icon-size": 1,
+				"icon-anchor": "bottom",
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				// Keep pins upright as the map rotates/pitches.
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		// Boosted pins — drawn from the separate non-clustered source on top
+		// of cluster discs so a paid boost is always visually prominent.
+		map.addLayer({
+			id: "boosted-point",
+			type: "symbol",
+			source: "places-boosted",
+			layout: {
+				"icon-image": [
+					"concat",
+					"pin-b-",
+					["coalesce", ["get", "icon"], "question_mark"],
+				],
+				"icon-size": 1,
+				"icon-anchor": "bottom",
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		// Comment count badge — fixed 16×16 green disc rendered as a
+		// dedicated icon symbol layer. Two layers (disc + text) instead of
+		// one composite symbol so positioning stays simple — both share the
+		// same offset from the pin anchor.
+		// Pin is 32×43, icon-anchor: bottom. Top-right of the pin head is
+		// ~(+10, -36) px from the geographic anchor.
+		map.addLayer({
+			id: "comment-badge",
+			type: "symbol",
+			source: "places",
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				[">", ["get", "comments"], 0],
+			],
+			layout: {
+				"icon-image": "comment-badge-bg",
+				"icon-size": 1,
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+				"icon-offset": [10, -36],
+			},
+		});
+
+		map.addLayer({
+			id: "comment-badge-count",
+			type: "symbol",
+			source: "places",
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				[">", ["get", "comments"], 0],
+			],
+			layout: {
+				"text-field": ["to-string", ["get", "comments"]],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 11,
+				"text-allow-overlap": true,
+				"text-ignore-placement": true,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+				// text-offset is in ems; mirror the disc's pixel offset above.
+				"text-offset": [10 / 11, -36 / 11],
+			},
+			paint: {
+				"text-color": "#fff",
+			},
+		});
+
+		// Saved badge — white disc with bookmark glyph on the pin's
+		// top-left corner. Filter only fires when the feature's `saved`
+		// flag is true (recomputed when $savedPlaceIds size changes).
+		map.addLayer({
+			id: "saved-badge",
+			type: "symbol",
+			source: "places",
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				["==", ["get", "saved"], true],
+			],
+			layout: {
+				"icon-image": "saved-badge",
+				"icon-size": 1,
+				"icon-anchor": "center",
+				// Top-left of the pin head, relative to the bottom-anchored pin.
+				"icon-offset": [-12, -38],
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		// Place name labels — visible at high zoom once the enriched-details
+		// fetch has populated each place's name. Drawn before clusters-hit so
+		// the spiderfy hit-target stays on top for click routing. Colors are
+		// the light palette; the page's applyLabelPalette re-colors for the
+		// active theme right after install.
+		map.addLayer({
+			id: "place-label",
+			type: "symbol",
+			source: "places",
+			minzoom: LABEL_VISIBLE_ZOOM,
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				["!=", ["get", "name"], ""],
+			],
+			layout: {
+				"text-field": ["get", "name"],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 14,
+				"text-anchor": "left",
+				// text-offset is in ems. Pin's right edge sits at ~+16 px from
+				// the geographic anchor (icon-anchor: bottom). Start the label
+				// 6 px past that, vertically centered on the pin head (~ -25 px).
+				"text-offset": [22 / 14, -25 / 14],
+				"text-max-width": 12,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+			},
+			paint: {
+				"text-color": [
+					"case",
+					["get", "boosted"],
+					"#f97316", // orange-500 (boosted)
+					"#0e7490", // cyan-700 (regular)
+				],
+				"text-halo-color": "#fff",
+				"text-halo-width": 1.2,
+				"text-halo-blur": 0,
+			},
+		});
+
+		// Mirrors of comment-badge / comment-badge-count / saved-badge /
+		// place-label for the parallel `places-boosted` source. Without
+		// these a boosted merchant with comments / saved state / a
+		// resolved label rendered as a bare orange pin.
+		map.addLayer({
+			id: "boosted-comment-badge",
+			type: "symbol",
+			source: "places-boosted",
+			filter: [">", ["get", "comments"], 0],
+			layout: {
+				"icon-image": "comment-badge-bg",
+				"icon-size": 1,
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+				"icon-offset": [10, -36],
+			},
+		});
+
+		map.addLayer({
+			id: "boosted-comment-badge-count",
+			type: "symbol",
+			source: "places-boosted",
+			filter: [">", ["get", "comments"], 0],
+			layout: {
+				"text-field": ["to-string", ["get", "comments"]],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 11,
+				"text-allow-overlap": true,
+				"text-ignore-placement": true,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+				"text-offset": [10 / 11, -36 / 11],
+			},
+			paint: {
+				"text-color": "#fff",
+			},
+		});
+
+		map.addLayer({
+			id: "boosted-saved-badge",
+			type: "symbol",
+			source: "places-boosted",
+			filter: ["==", ["get", "saved"], true],
+			layout: {
+				"icon-image": "saved-badge",
+				"icon-size": 1,
+				"icon-anchor": "center",
+				"icon-offset": [-12, -38],
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		map.addLayer({
+			id: "boosted-place-label",
+			type: "symbol",
+			source: "places-boosted",
+			minzoom: LABEL_VISIBLE_ZOOM,
+			filter: ["!=", ["get", "name"], ""],
+			layout: {
+				"text-field": ["get", "name"],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 14,
+				"text-anchor": "left",
+				"text-offset": [22 / 14, -25 / 14],
+				"text-max-width": 12,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+			},
+			paint: {
+				"text-color": "#f97316", // orange-500 (always boosted on this source)
+				"text-halo-color": "#fff",
+				"text-halo-width": 1.2,
+				"text-halo-blur": 0,
+			},
+		});
+
+		// Symbol cluster layer used by spiderfy. Hit-testing on this layer's
+		// near-invisible icon picks up the cluster_id property and routes
+		// through the library, which auto-decides between zoom-on-click and
+		// spiderfying based on getClusterExpansionZoom vs maxZoom.
+		map.addLayer({
+			id: "clusters-hit",
+			type: "symbol",
+			source: "places",
+			filter: ["has", "point_count"],
+			layout: {
+				"icon-image": "cluster-hit",
+				"icon-size": 1,
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+			},
+		});
+	};
+
+	// Renders exactly the list it is given — all visibility policy (search,
+	// category, recency, boosts) lives upstream in selectVisiblePlaces; this
+	// function must never re-filter or accept an unfiltered list.
+	const render = (map: MapLibreMap, list: Place[]): void => {
+		const source = map.getSource("places") as GeoJSONSource | undefined;
+		const boostedSource = map.getSource("places-boosted") as
+			| GeoJSONSource
+			| undefined;
+		const heatmapSource = map.getSource("places-heatmap") as
+			| GeoJSONSource
+			| undefined;
+		if (!source || !boostedSource) return;
+		lastSyncedList = list;
+		boostedAreClustered = shouldClusterBoostedAtZoom(map.getZoom());
+		const { clustered, standalone } = routePlacesByBoostAndZoom(
+			list,
+			map.getZoom(),
+		);
+		source.setData(buildFeatureCollection(clustered));
+		boostedSource.setData(buildFeatureCollection(standalone));
+		// The heatmap reflects overall place density, so it gets the full list
+		// regardless of the boosted-clustering routing decision. Only refresh
+		// it while the layer is actually visible — when off (the default) we
+		// skip the full-list feature-collection build entirely and repopulate
+		// from lastSyncedList on enable (see setHeatmapEnabled).
+		if (heatmapSource && heatmapEnabled) {
+			heatmapSource.setData(buildFeatureCollection(list));
+		}
+		ensureSpritesForPlaces(map, list);
+		deps.onRendered?.(list.length);
+	};
+
+	// Re-route boosted places when zoom crosses BOOSTED_CLUSTERING_MAX_ZOOM —
+	// the MapLibre analogue of the legacy boostedLayer swap. Only re-renders
+	// on an actual flip, so steady-state pans stay cheap.
+	const resyncForZoom = (map: MapLibreMap): void => {
+		if (shouldClusterBoostedAtZoom(map.getZoom()) !== boostedAreClustered) {
+			render(map, lastSyncedList);
+		}
+	};
+
+	const applyHeatmapVisibility = (map: MapLibreMap): void => {
+		const zoom = map.getZoom();
+		// Heatmap layer: visible when enabled regardless of zoom (the layer
+		// itself has maxzoom: CLUSTERING_DISABLED_ZOOM, so it won't render
+		// past that).
+		if (map.getLayer("place-heatmap")) {
+			map.setLayoutProperty(
+				"place-heatmap",
+				"visibility",
+				heatmapEnabled ? "visible" : "none",
+			);
+		}
+		// Conceal all point/cluster/badge/label layers while the heatmap is
+		// visible.  Pins re-appear before the heatmap fully fades out
+		// (zoom 15.5, ~45 % opacity) so individual pins show through the
+		// still-fading heatmap — at the maxzoom boundary (17) the heatmap
+		// instantly removes itself, so waiting until then feels abrupt.
+		const PIN_REVEAL_ZOOM = CLUSTERING_DISABLED_ZOOM - 1.5;
+		const hidePins = heatmapEnabled && zoom < PIN_REVEAL_ZOOM;
+		for (const layerId of HEATMAP_HIDDEN_LAYER_IDS) {
+			if (map.getLayer(layerId)) {
+				map.setLayoutProperty(
+					layerId,
+					"visibility",
+					hidePins ? "none" : "visible",
+				);
+			}
+		}
+	};
+
+	const setHeatmapEnabled = (map: MapLibreMap, enabled: boolean): void => {
+		heatmapEnabled = enabled;
+		// render() skips the heatmap source while it's hidden, so seed it from
+		// the last synced list on enable — otherwise it would stay blank until
+		// the next data sync.
+		if (enabled) {
+			const heatmapSource = map.getSource("places-heatmap") as
+				| GeoJSONSource
+				| undefined;
+			heatmapSource?.setData(buildFeatureCollection(lastSyncedList));
+		}
+		applyHeatmapVisibility(map);
+	};
+
+	// Re-apply the current heatmap on/off state after a style (re)load —
+	// the persisted state can't be applied before the layer exists, and a
+	// basemap swap that fell back to a full style rebuild resets carried
+	// layout properties.
+	const refreshHeatmapAfterStyle = (map: MapLibreMap): void => {
+		setHeatmapEnabled(map, heatmapEnabled);
+	};
+
+	return {
+		loadSprites,
+		install,
+		render,
+		resyncForZoom,
+		applyHeatmapVisibility,
+		setHeatmapEnabled,
+		refreshHeatmapAfterStyle,
+	};
+};

--- a/src/lib/map/placePinSource.ts
+++ b/src/lib/map/placePinSource.ts
@@ -6,7 +6,12 @@ import {
 	shouldClusterBoostedAtZoom,
 } from "$lib/map/boostedClustering";
 import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
-import { ensureSpritesForPlaces, loadSvgImage } from "$lib/map/maplibreSprites";
+import {
+	addRealImage,
+	ensureSpritesForPlaces,
+	hasRealImage,
+	loadSvgImage,
+} from "$lib/map/maplibreSprites";
 import type { Place } from "$lib/types";
 import { isBoosted } from "$lib/utils";
 
@@ -102,11 +107,14 @@ const buildSavedBadgeSvg = (bookmarkSvg: string): string => {
 // alpha keeps pixels effectively invisible while ensuring
 // queryRenderedFeatures registers hits on the icon footprint.
 const loadClusterHitSprite = async (m: MapLibreMap): Promise<void> => {
-	if (m.hasImage("cluster-hit")) return;
+	// Gate on the REAL registration, not hasImage(): the styleimagemissing
+	// placeholder can stub this id if a layer renders before/without the real
+	// sprite, and a hasImage() gate would then block every retry.
+	if (hasRealImage(m, "cluster-hit")) return;
 	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="rgba(0,0,0,0.004)"/></svg>`;
 	const img = await loadSvgImage(svg);
-	if (!m.hasImage("cluster-hit"))
-		m.addImage("cluster-hit", img, { pixelRatio: 1 });
+	if (!hasRealImage(m, "cluster-hit"))
+		addRealImage(m, "cluster-hit", img, { pixelRatio: 1 });
 };
 
 // 16×16 green disc to back the comment count text. Matches /map's
@@ -114,7 +122,7 @@ const loadClusterHitSprite = async (m: MapLibreMap): Promise<void> => {
 // on a canvas — simpler than the SVG → data-URL → <img> roundtrip for
 // a flat shape.
 const loadCommentBadgeSprite = (m: MapLibreMap): void => {
-	if (m.hasImage("comment-badge-bg")) return;
+	if (hasRealImage(m, "comment-badge-bg")) return;
 	// Draw at 2× the logical 16×16 (= 32×32 backing canvas) and register
 	// with pixelRatio: 2 so MapLibre displays at the same logical size
 	// but reads from a higher-density bitmap — keeps the green disc
@@ -136,7 +144,8 @@ const loadCommentBadgeSprite = (m: MapLibreMap): void => {
 		Math.PI * 2,
 	);
 	ctx.fill();
-	m.addImage(
+	addRealImage(
+		m,
 		"comment-badge-bg",
 		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
 		{ pixelRatio: SCALE },
@@ -144,7 +153,7 @@ const loadCommentBadgeSprite = (m: MapLibreMap): void => {
 };
 
 const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
-	if (m.hasImage("saved-badge")) return;
+	if (hasRealImage(m, "saved-badge")) return;
 	const encodedColor = encodeURIComponent(LINK_COLOR);
 	const url = `https://api.iconify.design/ic/baseline-bookmark-added.svg?color=${encodedColor}&width=10&height=10`;
 	const res = await fetch(url);
@@ -154,8 +163,8 @@ const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
 	const bookmarkSvg = await res.text();
 	const composite = buildSavedBadgeSvg(bookmarkSvg);
 	const img = await loadSvgImage(composite);
-	if (!m.hasImage("saved-badge"))
-		m.addImage("saved-badge", img, { pixelRatio: SAVED_BADGE_SCALE });
+	if (!hasRealImage(m, "saved-badge"))
+		addRealImage(m, "saved-badge", img, { pixelRatio: SAVED_BADGE_SCALE });
 	m.triggerRepaint();
 };
 

--- a/src/lib/map/visiblePlaces.test.ts
+++ b/src/lib/map/visiblePlaces.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import { CATEGORIES, placeMatchesCategory } from "$lib/categoryMapping";
+import type { Place } from "$lib/types";
+import { filterPlacesByRecency } from "$lib/verification";
+
+import { computeVisibleSignature, selectVisiblePlaces } from "./visiblePlaces";
+
+const recent = () => new Date(Date.now() - 30 * 86400000).toISOString();
+const old = () => new Date(Date.now() - 2 * 365 * 86400000).toISOString();
+const future = () => new Date(Date.now() + 365 * 86400000).toISOString();
+
+let nextId = 1;
+function place(overrides: Partial<Place> = {}): Place {
+	return { id: nextId++, lat: 0, lon: 0, ...overrides } as Place;
+}
+
+const corpus = () => [
+	place({ icon: "restaurant", verified_at: recent() }),
+	place({ icon: "restaurant", verified_at: old() }),
+	place({ icon: "local_cafe", verified_at: recent(), boosted_until: future() }),
+	place({ icon: "local_cafe" }),
+	place({ icon: "local_atm", verified_at: old() }),
+	place({ icon: "some_unknown", verified_at: recent() }),
+	place({ verified_at: old() }),
+	place({ icon: "restaurant", verified_at: recent(), deleted_at: old() }),
+];
+
+const base = {
+	mode: "nearby" as const,
+	category: "all" as const,
+	recency: null,
+	recencyReady: true,
+	boostsOnly: false,
+};
+
+describe("selectVisiblePlaces", () => {
+	it("drops deleted rows unconditionally", () => {
+		const r = selectVisiblePlaces({ ...base, places: corpus() });
+		expect(r.selection.some((p) => p.deleted_at)).toBe(false);
+		expect(r.selection.length).toBe(7);
+	});
+
+	it("applies the recency window only when the rows carry dates", () => {
+		const rows = corpus();
+		const ready = selectVisiblePlaces({
+			...base,
+			places: rows,
+			recency: 1,
+		});
+		expect(ready.selection.every((p) => p.verified_at)).toBe(true);
+
+		// Provenance gate: bulk-feed rows before enrichment must not all
+		// classify as unverified — the filter stays inert.
+		const notReady = selectVisiblePlaces({
+			...base,
+			places: rows,
+			recency: 1,
+			recencyReady: false,
+		});
+		expect(notReady.selection.length).toBe(7);
+	});
+
+	// The consistency oracle formerly spread across the store tests: counts
+	// must describe exactly what selecting each chip would show, computed on
+	// the recency-filtered PRE-category set.
+	it("counts describe the pre-category selection for every filter mode", () => {
+		const rows = corpus();
+		for (const recency of [null, 1, "outdated"] as const) {
+			const r = selectVisiblePlaces({ ...base, places: rows, recency });
+			const reference = filterPlacesByRecency(
+				rows.filter((p) => !p.deleted_at),
+				recency,
+			);
+			expect(r.counts.all, `recency ${String(recency)}`).toBe(reference.length);
+			for (const category of CATEGORIES) {
+				if (category === "all") continue;
+				expect(r.counts[category], `${String(recency)}/${category}`).toBe(
+					reference.filter((p) => placeMatchesCategory(p, category)).length,
+				);
+			}
+		}
+	});
+
+	it("filters by category with the panel's predicate", () => {
+		const r = selectVisiblePlaces({
+			...base,
+			places: corpus(),
+			category: "coffee",
+		});
+		expect(r.selection.every((p) => placeMatchesCategory(p, "coffee"))).toBe(
+			true,
+		);
+		expect(r.selection.length).toBe(2);
+		expect(r.effectiveCategory).toBe("coffee");
+	});
+
+	it("auto-resets a selected category the current window zeroes", () => {
+		// With a 1-year window the only ATM row (old) disappears.
+		const r = selectVisiblePlaces({
+			...base,
+			places: corpus(),
+			category: "atms",
+			recency: 1,
+		});
+		expect(r.effectiveCategory).toBe("all");
+		expect(r.selection.length).toBeGreaterThan(0);
+	});
+
+	it("keeps a selected category the window still populates", () => {
+		const r = selectVisiblePlaces({
+			...base,
+			places: corpus(),
+			category: "restaurants",
+			recency: 1,
+		});
+		expect(r.effectiveCategory).toBe("restaurants");
+		expect(r.selection.length).toBe(1);
+	});
+
+	it("narrows to boosted places when asked", () => {
+		const r = selectVisiblePlaces({
+			...base,
+			places: corpus(),
+			boostsOnly: true,
+		});
+		expect(r.selection.length).toBe(1);
+		expect(r.selection[0].boosted_until).toBeTruthy();
+	});
+
+	it("composes boosts after category (empty intersections are honest)", () => {
+		const r = selectVisiblePlaces({
+			...base,
+			places: corpus(),
+			category: "restaurants",
+			boostsOnly: true,
+		});
+		expect(r.selection).toEqual([]);
+		// counts still describe the pre-category set so the chips stay usable
+		expect(r.counts.all).toBe(7);
+	});
+});
+
+describe("computeVisibleSignature", () => {
+	const inputs = { ...base };
+
+	it("is stable across unrelated recomputation", () => {
+		expect(computeVisibleSignature(inputs, 7, "")).toBe(
+			computeVisibleSignature(inputs, 7, ""),
+		);
+	});
+
+	it("changes when any visibility input changes", () => {
+		const sig = computeVisibleSignature(inputs, 7, "");
+		expect(
+			computeVisibleSignature({ ...inputs, category: "coffee" }, 7, ""),
+		).not.toBe(sig);
+		expect(computeVisibleSignature({ ...inputs, recency: 1 }, 7, "")).not.toBe(
+			sig,
+		);
+		expect(
+			computeVisibleSignature({ ...inputs, recencyReady: false }, 7, ""),
+		).not.toBe(sig);
+		expect(
+			computeVisibleSignature({ ...inputs, boostsOnly: true }, 7, ""),
+		).not.toBe(sig);
+		expect(
+			computeVisibleSignature({ ...inputs, mode: "search" }, 7, "1,2"),
+		).not.toBe(sig);
+		// the revision covers content changes a shape signature can't see
+		expect(computeVisibleSignature(inputs, 8, "")).not.toBe(sig);
+	});
+});

--- a/src/lib/map/visiblePlaces.test.ts
+++ b/src/lib/map/visiblePlaces.test.ts
@@ -1,10 +1,16 @@
+import { get } from "svelte/store";
 import { describe, expect, it } from "vitest";
 
 import { CATEGORIES, placeMatchesCategory } from "$lib/categoryMapping";
+import { places } from "$lib/store";
 import type { Place } from "$lib/types";
 import { filterPlacesByRecency } from "$lib/verification";
 
-import { computeVisibleSignature, selectVisiblePlaces } from "./visiblePlaces";
+import {
+	computeVisibleSignature,
+	placesRevision,
+	selectVisiblePlaces,
+} from "./visiblePlaces";
 
 const recent = () => new Date(Date.now() - 30 * 86400000).toISOString();
 const old = () => new Date(Date.now() - 2 * 365 * 86400000).toISOString();
@@ -169,5 +175,27 @@ describe("computeVisibleSignature", () => {
 		).not.toBe(sig);
 		// the revision covers content changes a shape signature can't see
 		expect(computeVisibleSignature(inputs, 8, "")).not.toBe(sig);
+	});
+});
+
+describe("placesRevision", () => {
+	it("bumps once per $places publication, including identical re-sets", () => {
+		// This is the load-bearing replacement for the lastUpdatedPlaceId
+		// handshake: ANY publication — boost/comment write-through, enrichment
+		// merge, sync — must change the render signature. Subscribe for the
+		// duration (like the page's $placesRevision) because derived stores
+		// are lazy and only track while subscribed.
+		const seen: number[] = [];
+		const unsubscribe = placesRevision.subscribe((n) => seen.push(n));
+		const before = seen.length;
+
+		places.set([]);
+		// An identical reference still counts as a publication — the sync
+		// layer is responsible for not republishing unchanged data, not us
+		places.set(get(places));
+
+		unsubscribe();
+		expect(seen.length).toBe(before + 2);
+		expect(seen[seen.length - 1]).toBe(seen[before - 1] + 2);
 	});
 });

--- a/src/lib/map/visiblePlaces.ts
+++ b/src/lib/map/visiblePlaces.ts
@@ -1,0 +1,107 @@
+import { derived } from "svelte/store";
+
+import type { CategoryCounts, CategoryKey } from "$lib/categoryMapping";
+import {
+	countMerchantsByCategory,
+	placeMatchesCategory,
+} from "$lib/categoryMapping";
+import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
+import { places } from "$lib/store";
+import type { Place } from "$lib/types";
+import { isBoosted } from "$lib/utils";
+import { filterPlacesByRecency } from "$lib/verification";
+
+// The single decision pipeline for "which places are visible" (#1168). Every
+// consumer — map pins, nearby list, search list, chip counts — derives from
+// selectVisiblePlaces so no pair of sites can disagree again (the #1158-#1162
+// bug class). The category predicate is placeMatchesCategory everywhere; the
+// categoryMapping equivalence tests guard the legacy filterMerchantsByCategory
+// until its remaining callers migrate.
+
+export type VisibleSelectionInputs = {
+	// Candidate rows: the bulk $places, the search results, or API radius rows.
+	places: Place[];
+	mode: "nearby" | "search";
+	category: CategoryKey;
+	recency: VerifiedFilterYears;
+	// Row provenance, stated by the caller: API/search rows carry their own
+	// verified_at, so the recency filter always applies; the bulk feed lacks
+	// dates until enrichment, so its consumers gate on $verifiedDatesLoaded.
+	// When false, the recency filter is deliberately inert rather than
+	// classifying every row as unverified.
+	recencyReady: boolean;
+	// Callers resolve their own boost policy before calling (markers exempt
+	// search mode; the nearby list always filters).
+	boostsOnly: boolean;
+};
+
+export type VisibleSelection = {
+	// The final visible set: recency → category → boosts, deleted rows dropped.
+	selection: Place[];
+	// The recency-filtered, PRE-category set — what chip counts and density
+	// ceilings are computed on (a selected chip must not hide the other
+	// chips' counts).
+	preCategory: Place[];
+	// Counts on preCategory, so chips describe exactly what selecting them
+	// would show.
+	counts: CategoryCounts;
+	// The category after the auto-reset rule: a selected chip whose count
+	// dropped to zero (while other places remain) snaps back to "all".
+	effectiveCategory: CategoryKey;
+};
+
+export function selectVisiblePlaces(
+	inputs: VisibleSelectionInputs,
+): VisibleSelection {
+	const live = inputs.places.filter((p) => !p.deleted_at);
+	const preCategory = inputs.recencyReady
+		? filterPlacesByRecency(live, inputs.recency)
+		: live;
+	const counts = countMerchantsByCategory(preCategory);
+
+	const shouldReset =
+		inputs.category !== "all" &&
+		counts.all > 0 &&
+		counts[inputs.category] === 0;
+	const effectiveCategory = shouldReset ? "all" : inputs.category;
+
+	let selection =
+		effectiveCategory === "all"
+			? preCategory
+			: preCategory.filter((p) => placeMatchesCategory(p, effectiveCategory));
+	if (inputs.boostsOnly) {
+		selection = selection.filter((p) => Boolean(isBoosted(p)));
+	}
+
+	return { selection, preCategory, counts, effectiveCategory };
+}
+
+// Signature of everything that changes WHICH places are visible. String
+// emissions are cheap to compare; consumers recompute the selection only when
+// this changes, never on unrelated store ticks (loading flags, search
+// keystrokes, enrichment merges). `revision` covers the candidate list's
+// content — including in-place mutations a shape signature can't see.
+export function computeVisibleSignature(
+	inputs: Omit<VisibleSelectionInputs, "places">,
+	revision: number,
+	searchResultIds: string,
+): string {
+	return [
+		inputs.mode,
+		inputs.category,
+		inputs.recency ?? "any",
+		inputs.recencyReady,
+		inputs.boostsOnly,
+		revision,
+		searchResultIds,
+	].join("|");
+}
+
+// Bumps on EVERY $places publication — bulk sync, incremental merge, and the
+// single-place mutation flows (boost confirmation, new comment count), whose
+// in-place field changes no length/shape signature can detect. This replaces
+// the lastUpdatedPlaceId handshake and the fragile source-order contract the
+// map page previously needed for the same purpose: derived-store ordering is
+// topological, not source-order.
+let revisionCounter = 0;
+export const placesRevision = derived(places, () => ++revisionCounter);

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -262,13 +262,18 @@ function createMerchantListStore() {
 					preCategory.length > options.hideIfExceeds
 				) {
 					// Too many results - store count but show empty list
-					// The panel will display "zoom in" message, button shows count
+					// The panel will display "zoom in" message, button shows count.
+					// The auto-reset still persists: a selected chip whose count
+					// dropped to zero must snap back to "all" here too, or the chip
+					// state disagrees with the markers (which render the pipeline's
+					// reset selection independently).
 					update((state) => ({
 						...state,
 						merchants: [],
 						totalCount: preCategory.length,
 						isLoadingList: false,
 						categoryCounts: counts,
+						selectedCategory: effectiveCategory,
 					}));
 				} else {
 					const sorted = sortMerchants(

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -6,9 +6,7 @@ import api from "$lib/axios";
 import {
 	type CategoryCounts,
 	type CategoryKey,
-	countMerchantsByCategory,
 	createEmptyCategoryCounts,
-	filterMerchantsByCategory,
 } from "$lib/categoryMapping";
 import { MERCHANT_LIST_MAX_ITEMS } from "$lib/constants";
 import { _ } from "$lib/i18n";
@@ -17,6 +15,7 @@ import {
 	getStoredVerifiedFilter,
 	storeVerifiedFilter,
 } from "$lib/map/verifiedFilter";
+import { selectVisiblePlaces } from "$lib/map/visiblePlaces";
 import { isBoosted } from "$lib/merchantDrawerLogic";
 import { verifiedDatesLoaded } from "$lib/store";
 import type { Place } from "$lib/types";
@@ -74,41 +73,6 @@ const initialState: MerchantListState = {
 // Helper function to reset category state
 function resetCategoryState<T extends MerchantListState>(state: T): T {
 	return { ...state, selectedCategory: "all" };
-}
-
-// The auto-reset rule shared by every counts recompute: a selected chip whose
-// count dropped to zero (while other merchants remain) snaps back to "all".
-function shouldResetCategory(
-	selectedCategory: CategoryKey,
-	categoryCounts: CategoryCounts,
-): boolean {
-	return (
-		selectedCategory !== "all" &&
-		categoryCounts.all > 0 &&
-		categoryCounts[selectedCategory] === 0
-	);
-}
-
-// Helper to apply category filtering with auto-reset when selected category has no matches
-// Returns filtered merchants and the effective category (may be reset to 'all')
-function applyCategoryFilter(
-	merchants: Place[],
-	selectedCategory: CategoryKey,
-	categoryCounts: CategoryCounts,
-): { filtered: Place[]; effectiveCategory: CategoryKey } {
-	const effectiveCategory = shouldResetCategory(
-		selectedCategory,
-		categoryCounts,
-	)
-		? "all"
-		: selectedCategory;
-
-	const filtered =
-		effectiveCategory !== "all"
-			? filterMerchantsByCategory(merchants, effectiveCategory)
-			: merchants;
-
-	return { filtered, effectiveCategory };
 }
 
 // Sort order: boosted merchants first (premium placement), then by distance, then alphabetically
@@ -211,24 +175,21 @@ function createMerchantListStore() {
 			limit: number = MERCHANT_LIST_MAX_ITEMS,
 		) {
 			const { selectedCategory, verifiedWithinYears } = get(store);
-			// Apply the recency filter first so the category counts reflect the
-			// verification window the user is actually seeing. Gate on the dates
-			// being loaded (they're lazy) so we don't blank the list while a
-			// filter is active but enrichment hasn't landed — matches the markers.
-			const recencyReady =
-				verifiedWithinYears == null || get(verifiedDatesLoaded);
-			const recencyPlaces = recencyReady
-				? filterPlacesByRecency(merchants, verifiedWithinYears)
-				: merchants;
-			const categoryCounts = countMerchantsByCategory(recencyPlaces);
-			const { filtered, effectiveCategory } = applyCategoryFilter(
-				recencyPlaces,
-				selectedCategory,
-				categoryCounts,
-			);
+			// The shared pipeline applies the recency window (gated on the lazy
+			// dates being loaded, matching the markers), computes chip counts on
+			// the pre-category set, and applies the auto-reset rule — one
+			// decision path for list, pins, and counts.
+			const { selection, counts, effectiveCategory } = selectVisiblePlaces({
+				places: merchants,
+				mode: "nearby",
+				category: selectedCategory,
+				recency: verifiedWithinYears,
+				recencyReady: verifiedWithinYears == null || get(verifiedDatesLoaded),
+				boostsOnly: false,
+			});
 
 			const sorted = sortMerchants(
-				filtered,
+				selection,
 				centerLat,
 				centerLon,
 				get(userLocation).location,
@@ -238,9 +199,9 @@ function createMerchantListStore() {
 			update((state) => ({
 				...state,
 				merchants: limited,
-				totalCount: filtered.length,
+				totalCount: selection.length,
 				isLoadingList: false,
-				categoryCounts,
+				categoryCounts: counts,
 				selectedCategory: effectiveCategory,
 			}));
 		},
@@ -278,40 +239,40 @@ function createMerchantListStore() {
 				const placeDetailsCache = new Map<number, Place>();
 				validPlaces.forEach((place) => placeDetailsCache.set(place.id, place));
 
-				// Apply the recency filter before the density check (list data is
-				// fetched with verified_at, so no readiness gate is needed): a
-				// narrow window can bring an otherwise-too-dense area under the
-				// ceiling, so the filter stays effective at zoom 10-14.
+				// The shared pipeline applies the recency window before the density
+				// check (API rows carry verified_at, so recencyReady is
+				// unconditionally true here): a narrow window can bring an
+				// otherwise-too-dense area under the ceiling, so the filter stays
+				// effective at zoom 10-14. The density ceiling compares the
+				// PRE-category set — a selected chip must not defeat it.
 				const { selectedCategory, verifiedWithinYears } = get(store);
-				const recencyPlaces = filterPlacesByRecency(
-					validPlaces,
-					verifiedWithinYears,
-				);
-				const categoryCounts = countMerchantsByCategory(recencyPlaces);
+				const { selection, preCategory, counts, effectiveCategory } =
+					selectVisiblePlaces({
+						places: validPlaces,
+						mode: "nearby",
+						category: selectedCategory,
+						recency: verifiedWithinYears,
+						recencyReady: true,
+						boostsOnly: false,
+					});
 
 				// Check if we should hide results (too many at low zoom)
 				if (
 					options?.hideIfExceeds &&
-					recencyPlaces.length > options.hideIfExceeds
+					preCategory.length > options.hideIfExceeds
 				) {
 					// Too many results - store count but show empty list
 					// The panel will display "zoom in" message, button shows count
 					update((state) => ({
 						...state,
 						merchants: [],
-						totalCount: recencyPlaces.length,
+						totalCount: preCategory.length,
 						isLoadingList: false,
-						categoryCounts,
+						categoryCounts: counts,
 					}));
 				} else {
-					const { filtered, effectiveCategory } = applyCategoryFilter(
-						recencyPlaces,
-						selectedCategory,
-						categoryCounts,
-					);
-
 					const sorted = sortMerchants(
-						filtered,
+						selection,
 						center.lat,
 						center.lon,
 						get(userLocation).location,
@@ -320,10 +281,10 @@ function createMerchantListStore() {
 					update((state) => ({
 						...state,
 						merchants: limited,
-						totalCount: filtered.length,
+						totalCount: selection.length,
 						placeDetailsCache,
 						isLoadingList: false,
-						categoryCounts,
+						categoryCounts: counts,
 						selectedCategory: effectiveCategory,
 					}));
 				}
@@ -465,12 +426,18 @@ function createMerchantListStore() {
 				if (!isBoosted(a) && isBoosted(b)) return 1;
 				return 0;
 			});
-			// Counts reflect the recency window; the panel applies the same
-			// recency + category filter to what it renders (filteredSearchResults).
+			// Counts come from the shared pipeline on the recency-filtered set;
+			// the panel renders the same pipeline's selection
+			// (filteredSearchResults), so chips and rows can never disagree.
 			const { verifiedWithinYears } = get(store);
-			const categoryCounts = countMerchantsByCategory(
-				filterPlacesByRecency(sortedResults, verifiedWithinYears),
-			);
+			const { counts: categoryCounts } = selectVisiblePlaces({
+				places: sortedResults,
+				mode: "search",
+				category: "all",
+				recency: verifiedWithinYears,
+				recencyReady: true,
+				boostsOnly: false,
+			});
 			update((state) => ({
 				...resetCategoryState(state),
 				isOpen: true,
@@ -559,30 +526,22 @@ function createMerchantListStore() {
 				// the forced update re-runs setMerchants/fetchAndReplaceList,
 				// which own that recompute.
 				if (state.mode === "search" && state.searchResults.length > 0) {
-					const recencyResults = filterPlacesByRecency(
-						state.searchResults,
-						years,
-					);
-					const categoryCounts = countMerchantsByCategory(recencyResults);
-					// Shared auto-reset rule, counts-only. Deliberately not
-					// applyCategoryFilter: its filtered list is unused here, and
-					// it filters via filterMerchantsByCategory (group icon-list
-					// scan) while the panel renders via placeMatchesCategory
-					// (ICON_TO_CATEGORY lookup) — two implementations that agree
-					// only while the categoryMapping equivalence tests hold, so
-					// this path avoids depending on the one the panel doesn't
-					// use. A window that zeroes the selected chip snaps
-					// selection to "all", exactly as nearby mode does.
+					// The pipeline recomputes counts on the new window and applies
+					// the auto-reset rule — a window that zeroes the selected chip
+					// snaps selection to "all", exactly as nearby mode does.
+					const { counts, effectiveCategory } = selectVisiblePlaces({
+						places: state.searchResults,
+						mode: "search",
+						category: state.selectedCategory,
+						recency: years,
+						recencyReady: true,
+						boostsOnly: false,
+					});
 					return {
 						...state,
 						verifiedWithinYears: years,
-						categoryCounts,
-						selectedCategory: shouldResetCategory(
-							state.selectedCategory,
-							categoryCounts,
-						)
-							? "all"
-							: state.selectedCategory,
+						categoryCounts: counts,
+						selectedCategory: effectiveCategory,
 					};
 				}
 				return { ...state, verifiedWithinYears: years };

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -61,7 +61,6 @@ export const selectedMerchant: Writable<Place | null> = writable(null);
 export const boost: Writable<Boost> = writable();
 export const resetBoost = writable(0);
 export const boostHash: Writable<string> = writable();
-export const lastUpdatedPlaceId: Writable<number | undefined> = writable();
 
 export const showTags: Writable<OSMTags | undefined> = writable();
 export const taggingIssues: Writable<Issue[] | undefined> = writable();

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -356,12 +356,17 @@ export const elementsSync = async () => {
 				// A periodic re-sync that merged nothing must NOT republish:
 				// places.set notifies every subscriber (and bumps placesRevision)
 				// even when the array is unchanged, sending ~50k rows back through
-				// the map pipeline once per sync interval for no reason. The first
+				// the map pipeline once per sync interval for no reason. Applies
+				// ONLY to cache-based re-syncs: a CDN baseline download (no local
+				// cache — e.g. after a failed persist) always publishes, since the
+				// in-memory data may be older than the fresh baseline. The first
 				// publication of the session (empty store) always goes through —
 				// hydrating from the cache IS a change. The synced_at watermark
 				// still advances so the update window stays minimal.
 				const nothingChanged =
-					mergedUpdateCount === 0 && get(places).length > 0;
+					cachedPlaces != null &&
+					mergedUpdateCount === 0 &&
+					get(places).length > 0;
 				if (nothingChanged) {
 					if (apiSucceeded) {
 						await localforage.setItem(

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -292,6 +292,7 @@ export const elementsSync = async () => {
 					: await getStaticFileDate();
 
 				let apiSucceeded = false;
+				let mergedUpdateCount = 0;
 
 				try {
 					const apiResponse = await api.get<Place[]>(
@@ -315,6 +316,7 @@ export const elementsSync = async () => {
 					);
 
 					if (recentUpdates.length > 0) {
+						mergedUpdateCount = recentUpdates.length;
 						placesLoadingStatus.set("Merging updates...");
 						placesLoadingProgress.set(
 							cachedPlaces
@@ -351,7 +353,25 @@ export const elementsSync = async () => {
 				placesLoadingStatus.set("Finalizing...");
 				placesLoadingProgress.set(PROGRESS_RANGES.FINALIZE);
 
-				if (placesData.length > 0) {
+				// A periodic re-sync that merged nothing must NOT republish:
+				// places.set notifies every subscriber (and bumps placesRevision)
+				// even when the array is unchanged, sending ~50k rows back through
+				// the map pipeline once per sync interval for no reason. The first
+				// publication of the session (empty store) always goes through —
+				// hydrating from the cache IS a change. The synced_at watermark
+				// still advances so the update window stays minimal.
+				const nothingChanged =
+					mergedUpdateCount === 0 && get(places).length > 0;
+				if (nothingChanged) {
+					if (apiSucceeded) {
+						await localforage.setItem(
+							"places_v4_synced_at",
+							new Date().toISOString(),
+						);
+					}
+					placesLoadingStatus.set("Complete!");
+					placesLoadingProgress.set(PROGRESS_RANGES.COMPLETE);
+				} else if (placesData.length > 0) {
 					localforage
 						.setItem("places_v4", placesData)
 						.then(async () => {

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -4,7 +4,6 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import Spiderfy from "@nazka/map-gl-js-spiderfy";
 import type {
 	FilterSpecification,
-	GeoJSONSource,
 	LngLatBounds,
 	MapGeoJSONFeature,
 	MapLayerMouseEvent,
@@ -40,11 +39,7 @@ import {
 	SUPPORT_ATTR,
 	styleForBasemap,
 } from "$lib/map/basemaps";
-import {
-	routePlacesByBoostAndZoom,
-	shouldClusterBoostedAtZoom,
-} from "$lib/map/boostedClustering";
-import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
+import { shouldClusterBoostedAtZoom } from "$lib/map/boostedClustering";
 import {
 	type HashCoords,
 	parseHashCoords,
@@ -53,10 +48,14 @@ import {
 import {
 	ensureSpritesForPlaces,
 	installPlaceholderHandler,
-	loadSvgImage,
 	PIN_FILL_BOOSTED,
 	PIN_FILL_REGULAR,
 } from "$lib/map/maplibreSprites";
+import {
+	CUSTOM_LAYER_IDS,
+	CUSTOM_SOURCE_IDS,
+	createPlacePinSource,
+} from "$lib/map/placePinSource";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
 import { ensureRtlTextPlugin } from "$lib/map/rtl";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
@@ -128,24 +127,6 @@ if (outdatedOnly) {
 	merchantList.setVerifiedFilter("outdated", { persist: false });
 }
 
-type PlaceFeature = {
-	type: "Feature";
-	geometry: { type: "Point"; coordinates: [number, number] };
-	properties: {
-		id: number;
-		boosted: boolean;
-		icon: string;
-		comments: number;
-		saved: boolean;
-		name: string;
-	};
-};
-
-type PlaceFeatureCollection = {
-	type: "FeatureCollection";
-	features: PlaceFeature[];
-};
-
 let mapContainer: HTMLDivElement;
 let map: MapLibreMap | undefined;
 let destroyed = false;
@@ -159,12 +140,26 @@ let lastAppliedLabelTheme: "light" | "dark" | undefined;
 // size, enriched-cache size, locale). Empty string forces a sync.
 let lastRenderSig = "";
 
-// Last place list fed to the sources, kept so the boosted-clustering boundary
-// re-sync (on zoom crossing BOOSTED_CLUSTERING_MAX_ZOOM) can rebuild without a
-// $places change. `boostedAreClustered` mirrors the routing decision of the
-// most recent sync so the moveend handler only re-syncs when it actually flips.
-let lastSyncedList: Place[] = [];
-let boostedAreClustered = false;
+// The pin/cluster/badge/label/heatmap rendering facade (#1170). Owns the
+// sources, layers, sprites, feature building, boosted routing, and heatmap
+// visibility; this page keeps interactions, spiderfy, camera, and the label
+// palette. The deps are read as snapshots on every render — saved state and
+// enriched names arrive lazily.
+const pinSource = createPlacePinSource({
+	getSavedIds: () => get(savedPlaceIds),
+	getEnrichedCache: () => get(merchantList).placeDetailsCache,
+	getDisplayLang: () => getDisplayLang(get(locale)),
+	onRendered: (count) => {
+		if (count > 0) elementsLoaded = true;
+		// E2E test hook: Playwright can't probe WebGL canvas pins like it
+		// could probe Leaflet's DOM markers, so we expose the count for
+		// `waitForMarkersToLoad` to gate on. No-op outside tests.
+		if (typeof window !== "undefined") {
+			(window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount =
+				count;
+		}
+	},
+});
 
 // Place-label colors. MapLibre paint expressions can't read CSS custom
 // properties, so the values are inlined here.
@@ -687,173 +682,12 @@ const handleHashChange = () => {
 	merchantDrawer.syncFromHash();
 };
 
-const EMPTY_COLLECTION: PlaceFeatureCollection = {
-	type: "FeatureCollection",
-	features: [],
-};
-
-// Boosted places ride a separate non-clustered source so they stay
-// individually visible above cluster discs — but only above
-// BOOSTED_CLUSTERING_MAX_ZOOM. At/below it they fold into the clustered
-// `places` source (matching the legacy /map's dedicated boostedLayer +
-// BOOSTED_CLUSTERING_MAX_ZOOM behavior) so the zoomed-out world view isn't
-// littered with overlapping orange pins. Routing lives in
-// $lib/map/boostedClustering; see syncPlacesToSource for the wiring.
-
-const buildFeatureCollectionFor = (list: Place[]): PlaceFeatureCollection => {
-	const saved = get(savedPlaceIds);
-	// Snapshot the enriched cache once per build — names arrive lazily as
-	// the viewport-bound /v4/places/search fetch resolves.
-	const enrichedCache = get(merchantList).placeDetailsCache;
-	const displayLang = getDisplayLang(get(locale));
-	const resolveName = (p: Place): string => {
-		const enriched = enrichedCache.get(p.id);
-		// Priority: enriched localized name → enriched plain name →
-		// $places localized name → $places plain name → OSM amenity fallback.
-		return (
-			enriched?.localized_name?.[displayLang] ??
-			enriched?.name ??
-			p.localized_name?.[displayLang] ??
-			p.name ??
-			p["osm:amenity"] ??
-			""
-		);
-	};
-	return {
-		type: "FeatureCollection",
-		features: list.map((p) => ({
-			type: "Feature",
-			geometry: { type: "Point", coordinates: [p.lon, p.lat] },
-			properties: {
-				id: p.id,
-				// Per-place so a boosted marker folded into the clustered source at
-				// low zoom still renders its orange pin when it sits unclustered.
-				boosted: !!isBoosted(p),
-				icon: p.icon ?? "question_mark",
-				comments: p.comments ?? 0,
-				saved: saved.has(p.id),
-				name: resolveName(p),
-			},
-		})),
-	};
-};
-
-// Tailwind `text-link` color (tailwind.config.js → colors.link).
-const LINK_COLOR = "#0099AF";
-
-// Composite saved-badge SVG. Outer SVG is rasterized at 2× its declared
-// dimensions (viewBox stays the same) and registered with pixelRatio: 2
-// so it draws crisp at the same logical 16×16 — same trick as
-// PIN_RENDER_SCALE for the main pin sprite.
-const SAVED_BADGE_SCALE = 2;
-const buildSavedBadgeSvg = (bookmarkSvg: string): string => {
-	const w = 16 * SAVED_BADGE_SCALE;
-	const h = 16 * SAVED_BADGE_SCALE;
-	return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" fill="#fff" stroke="${LINK_COLOR}" stroke-width="1"/><g transform="translate(3, 3)">${bookmarkSvg}</g></svg>`;
-};
-
-// Near-invisible circular hit-target sprite used as the icon for the
-// symbol cluster layer that spiderfy hooks into. We render the visible
-// cluster discs as circle layers (not symbols), so this symbol layer
-// exists purely so the spiderfy library can register click handlers
-// targeting it. 1/255 alpha keeps pixels effectively invisible while
-// ensuring queryRenderedFeatures registers hits on the icon footprint.
-const loadClusterHitSprite = async (m: MapLibreMap): Promise<void> => {
-	if (m.hasImage("cluster-hit")) return;
-	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="rgba(0,0,0,0.004)"/></svg>`;
-	const img = await loadSvgImage(svg);
-	if (!m.hasImage("cluster-hit"))
-		m.addImage("cluster-hit", img, { pixelRatio: 1 });
-};
-
-// 16×16 green disc to back the comment count text. Matches /map's
-// Tailwind `bg-green-600 w-4 h-4 rounded-full` exactly. Drawn directly
-// on a canvas — simpler than the SVG → data-URL → <img> roundtrip for
-// a flat shape.
-const loadCommentBadgeSprite = (m: MapLibreMap): void => {
-	if (m.hasImage("comment-badge-bg")) return;
-	// Draw at 2× the logical 16×16 (= 32×32 backing canvas) and register
-	// with pixelRatio: 2 so MapLibre displays at the same logical size
-	// but reads from a higher-density bitmap — keeps the green disc
-	// crisp on retina/phone DPRs instead of upscaling 16×16 bitmap pixels.
-	const SIZE = 16;
-	const SCALE = 2;
-	const canvas = document.createElement("canvas");
-	canvas.width = SIZE * SCALE;
-	canvas.height = SIZE * SCALE;
-	const ctx = canvas.getContext("2d");
-	if (!ctx) return;
-	ctx.fillStyle = "#16A34A";
-	ctx.beginPath();
-	ctx.arc(
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		0,
-		Math.PI * 2,
-	);
-	ctx.fill();
-	m.addImage(
-		"comment-badge-bg",
-		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
-		{ pixelRatio: SCALE },
-	);
-};
-
-const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
-	if (m.hasImage("saved-badge")) return;
-	const encodedColor = encodeURIComponent(LINK_COLOR);
-	const url = `https://api.iconify.design/ic/baseline-bookmark-added.svg?color=${encodedColor}&width=10&height=10`;
-	const res = await fetch(url);
-	if (!res.ok) {
-		throw new Error(`saved-badge bookmark fetch failed: ${res.status} ${url}`);
-	}
-	const bookmarkSvg = await res.text();
-	const composite = buildSavedBadgeSvg(bookmarkSvg);
-	const img = await loadSvgImage(composite);
-	if (!m.hasImage("saved-badge"))
-		m.addImage("saved-badge", img, { pixelRatio: SAVED_BADGE_SCALE });
-	m.triggerRepaint();
-};
-
 // Renders exactly the list it is given — all visibility policy (search,
-// category, recency, boosts) lives upstream in selectVisiblePlaces; this
-// function must never re-filter or accept an unfiltered list.
+// category, recency, boosts) lives upstream in selectVisiblePlaces; the
+// facade must never receive an unfiltered list.
 const syncPlacesToSource = (list: Place[]) => {
 	if (!map || !styleLoaded) return;
-	const source = map.getSource("places") as GeoJSONSource | undefined;
-	const boostedSource = map.getSource("places-boosted") as
-		| GeoJSONSource
-		| undefined;
-	const heatmapSource = map.getSource("places-heatmap") as
-		| GeoJSONSource
-		| undefined;
-	if (!source || !boostedSource) return;
-	lastSyncedList = list;
-	boostedAreClustered = shouldClusterBoostedAtZoom(map.getZoom());
-	const { clustered, standalone } = routePlacesByBoostAndZoom(
-		list,
-		map.getZoom(),
-	);
-	source.setData(buildFeatureCollectionFor(clustered));
-	boostedSource.setData(buildFeatureCollectionFor(standalone));
-	// The heatmap reflects overall place density, so it gets the full list
-	// regardless of the boosted-clustering routing decision. Only refresh it
-	// while the layer is actually visible — when off (the default) we skip
-	// the full-list feature-collection build entirely and repopulate from
-	// lastSyncedList on enable (see setHeatmapEnabled).
-	if (heatmapSource && heatmapEnabled) {
-		heatmapSource.setData(buildFeatureCollectionFor(list));
-	}
-	ensureSpritesForPlaces(map, list);
-	if (list.length > 0) elementsLoaded = true;
-	// E2E test hook: Playwright can't probe WebGL canvas pins like it
-	// could probe Leaflet's DOM markers, so we expose the count for
-	// `waitForMarkersToLoad` to gate on. No-op outside tests.
-	if (typeof window !== "undefined") {
-		(window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount =
-			list.length;
-	}
+	pinSource.render(map, list);
 };
 
 // Debounced enrichment trigger — fires on moveend when zoomed in enough
@@ -964,105 +798,11 @@ $: if (
 	void ensureVerifiedDates().then(() => updateMerchantList({ force: true }));
 }
 
-// The custom sources + layers we add on top of whatever basemap is
-// active. applyBasemap() carries these across a setStyle() so the pins,
-// clusters, and labels survive a basemap/theme swap untouched (MapLibre's
-// style differ leaves byte-identical layers in place — only the basemap
-// layers below them get swapped).
-const CUSTOM_SOURCE_IDS = ["places", "places-boosted", "places-heatmap"];
-const CUSTOM_LAYER_IDS = [
-	"place-heatmap",
-	"clusters-outer",
-	"clusters-inner",
-	"cluster-count",
-	"unclustered-point",
-	"boosted-point",
-	"comment-badge",
-	"comment-badge-count",
-	"saved-badge",
-	"place-label",
-	"boosted-comment-badge",
-	"boosted-comment-badge-count",
-	"boosted-saved-badge",
-	"boosted-place-label",
-	"clusters-hit",
-];
-// All point/cluster/badge/label layers that the heatmap conceals while
-// active below CLUSTERING_DISABLED_ZOOM (17).  At zoom 17+ the heatmap
-// layer naturally disappears (its maxzoom), so these layers are revealed
-// again without the user having to toggle heatmap off.
-const HEATMAP_HIDDEN_LAYER_IDS = [
-	"clusters-outer",
-	"clusters-inner",
-	"cluster-count",
-	"clusters-hit",
-	"unclustered-point",
-	"boosted-point",
-	"comment-badge",
-	"comment-badge-count",
-	"saved-badge",
-	"place-label",
-	"boosted-comment-badge",
-	"boosted-comment-badge-count",
-	"boosted-saved-badge",
-	"boosted-place-label",
-];
-
-// Toggle the merchant-density heatmap layer. Off by default unless the
-// user previously enabled it (persisted in localStorage by the control).
-let heatmapEnabled = false;
-if (typeof window !== "undefined") {
-	try {
-		heatmapEnabled = localStorage.getItem(HEATMAP_STORAGE_KEY) === "true";
-	} catch {
-		// localStorage may be unavailable (private mode)
-	}
-}
-
-const applyHeatmapVisibility = () => {
-	if (!map) return;
-	const zoom = map.getZoom();
-	// Heatmap layer: visible when enabled regardless of zoom (the layer
-	// itself has maxzoom: CLUSTERING_DISABLED_ZOOM, so it won't render
-	// past that).
-	if (map.getLayer("place-heatmap")) {
-		map.setLayoutProperty(
-			"place-heatmap",
-			"visibility",
-			heatmapEnabled ? "visible" : "none",
-		);
-	}
-	// Conceal all point/cluster/badge/label layers while the heatmap is
-	// visible.  Pins re-appear before the heatmap fully fades out
-	// (zoom 15.5, ~45 % opacity) so individual pins show through the
-	// still-fading heatmap — at the maxzoom boundary (17) the heatmap
-	// instantly removes itself, so waiting until then feels abrupt.
-	const PIN_REVEAL_ZOOM = CLUSTERING_DISABLED_ZOOM - 1.5;
-	const hidePins = heatmapEnabled && zoom < PIN_REVEAL_ZOOM;
-	for (const layerId of HEATMAP_HIDDEN_LAYER_IDS) {
-		if (map.getLayer(layerId)) {
-			map.setLayoutProperty(
-				layerId,
-				"visibility",
-				hidePins ? "none" : "visible",
-			);
-		}
-	}
-};
-
+// Heatmap on/off state and layer-visibility juggling live in the facade;
+// this wrapper is the shape <MapControls> expects.
 const setHeatmapEnabled = (enabled: boolean) => {
 	if (!map) return;
-	heatmapEnabled = enabled;
-	// syncPlacesToSource skips the heatmap source while it's hidden, so seed
-	// it from the last synced list on enable — otherwise it would stay blank
-	// until the next data sync.
-	if (enabled) {
-		const heatmapSource = map.getSource("places-heatmap") as
-			| GeoJSONSource
-			| undefined;
-		heatmapSource?.setData(buildFeatureCollectionFor(lastSyncedList));
-	}
-	applyHeatmapVisibility();
+	pinSource.setHeatmapEnabled(map, enabled);
 };
 
 // Switch the basemap without tearing down our pin/cluster/label layers.
@@ -1089,14 +829,12 @@ const applyBasemap = (id: BasemapId) => {
 	map.once("style.load", () => {
 		if (!map) return;
 		applyLabelPalette(map, get(theme));
-		loadClusterHitSprite(map).catch(() => {});
-		loadCommentBadgeSprite(map);
-		loadSavedBadgeSprite(map).catch(() => {});
+		pinSource.loadSprites(map);
 		ensureSpritesForPlaces(map, get(places));
 		spiderfier?.applyTo("clusters-hit");
 		// Re-apply heatmap/cluster visibility in case the style diff fell
 		// back to a full rebuild and reset carried layout properties.
-		setHeatmapEnabled(heatmapEnabled);
+		pinSource.refreshHeatmapAfterStyle(map);
 	});
 	map.setStyle(styleForBasemap(id), {
 		transformStyle: (previous, next) => {
@@ -1305,20 +1043,12 @@ onMount(async () => {
 	map.on("load", async () => {
 		if (!map || destroyed) return;
 
-		// Critical sprites must succeed; the saved-badge fetch goes to a
-		// third-party CDN and should NOT block the rest of map init if
-		// it fails. Wrap it with a catch so a transient Iconify outage
-		// just degrades the saved-state badge.
-		// The pin and pin-boosted plain sprites are NOT loaded here —
-		// every pin layer references the composite `pin-r-{icon}` /
-		// `pin-b-{icon}` names produced lazily by ensureSpritesForPlaces.
-		await Promise.all([
-			loadSavedBadgeSprite(map).catch((err) => {
-				console.warn("Saved-badge sprite failed to load:", err);
-			}),
-			loadCommentBadgeSprite(map),
-			loadClusterHitSprite(map),
-		]);
+		// The saved-badge fetch goes to a third-party CDN and must NOT block
+		// map init — the facade catches sprite failures and degrades. The pin
+		// and pin-boosted plain sprites are NOT loaded here — every pin layer
+		// references the composite `pin-r-{icon}` / `pin-b-{icon}` names
+		// produced lazily by ensureSpritesForPlaces.
+		await pinSource.loadSprites(map);
 
 		// Component may have been destroyed while sprites were loading
 		// (user navigated away within ~1s of mount). Without this check
@@ -1328,425 +1058,8 @@ onMount(async () => {
 		// destroyed instance, so a plain `!map` check doesn't catch this.
 		if (destroyed) return;
 
-		map.addSource("places", {
-			type: "geojson",
-			data: EMPTY_COLLECTION,
-			cluster: true,
-			clusterRadius: 80,
-			// CLUSTERING_DISABLED_ZOOM is 17; clusterMaxZoom=16 means at z17+ all points unclustered.
-			clusterMaxZoom: CLUSTERING_DISABLED_ZOOM - 1,
-		});
-
-		// Separate non-clustered source for boosted places. Above
-		// BOOSTED_CLUSTERING_MAX_ZOOM, syncPlacesToSource routes boosted
-		// features here so they stay visually prominent above cluster discs and
-		// never get absorbed into a cluster icon. At/below that zoom they're
-		// routed into the clustered `places` source instead (see
-		// $lib/map/boostedClustering) — the MapLibre analogue of the legacy
-		// /map's dedicated boostedLayer + BOOSTED_CLUSTERING_MAX_ZOOM swap.
-		map.addSource("places-boosted", {
-			type: "geojson",
-			data: EMPTY_COLLECTION,
-		});
-
-		// Non-clustered source backing the merchant-density heatmap.
-		// Heatmap layers read raw point features, so they can't share the
-		// clustered `places` source — this dedicated source always carries
-		// the full unclustered list (see syncPlacesToSource). Visibility is
-		// toggled via the tools panel; off by default.
-		map.addSource("places-heatmap", {
-			type: "geojson",
-			data: EMPTY_COLLECTION,
-		});
-
-		// Merchant-density heatmap. Weight is uniform (1) so the gradient
-		// reflects pure point density. Radius and intensity scale up with
-		// zoom so the halo widens as you zoom out to a city/region view and
-		// tightens as pins take over. Opacity stays at full strength through
-		// zoom 14 and fades to zero from zoom 14→17 so the heatmap hands off
-		// cleanly to the individual pins at
-		// CLUSTERING_DISABLED_ZOOM.
-		map.addLayer({
-			id: "place-heatmap",
-			type: "heatmap",
-			source: "places-heatmap",
-			maxzoom: CLUSTERING_DISABLED_ZOOM,
-			layout: { visibility: "none" },
-			paint: {
-				"heatmap-weight": 1,
-				"heatmap-intensity": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					0,
-					0.5,
-					CLUSTERING_DISABLED_ZOOM,
-					3,
-				],
-				"heatmap-color": [
-					"interpolate",
-					["linear"],
-					["heatmap-density"],
-					0,
-					"rgba(0, 0, 255, 0)",
-					0.2,
-					"#67e8f9", // cyan-300
-					0.4,
-					"#22d3ee", // cyan-400
-					0.6,
-					"#facc15", // yellow-400
-					0.8,
-					"#facc15", // yellow-400 — yellow holds longer
-					1.0,
-					"#f97316", // orange-500
-					1.2,
-					"#ea580c", // orange-600
-					1.5,
-					"#dc2626", // red-600 — red only at extreme density
-				],
-				"heatmap-radius": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					0,
-					3,
-					CLUSTERING_DISABLED_ZOOM,
-					30,
-				],
-				"heatmap-opacity": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					14,
-					0.9,
-					CLUSTERING_DISABLED_ZOOM,
-					0,
-				],
-			},
-		});
-
-		// Translucent outer ring — green/yellow/orange tiers by point_count
-		// at 0.6 alpha.
-		map.addLayer({
-			id: "clusters-outer",
-			type: "circle",
-			source: "places",
-			filter: ["has", "point_count"],
-			paint: {
-				"circle-color": [
-					"step",
-					["get", "point_count"],
-					"rgba(181, 226, 140, 0.6)",
-					10,
-					"rgba(241, 211, 87, 0.6)",
-					100,
-					"rgba(253, 156, 115, 0.6)",
-				],
-				"circle-radius": 20,
-			},
-		});
-
-		map.addLayer({
-			id: "clusters-inner",
-			type: "circle",
-			source: "places",
-			filter: ["has", "point_count"],
-			paint: {
-				"circle-color": [
-					"step",
-					["get", "point_count"],
-					"rgba(110, 204, 57, 0.6)",
-					10,
-					"rgba(240, 194, 12, 0.6)",
-					100,
-					"rgba(241, 128, 23, 0.6)",
-				],
-				"circle-radius": 15,
-			},
-		});
-
-		map.addLayer({
-			id: "cluster-count",
-			type: "symbol",
-			source: "places",
-			filter: ["has", "point_count"],
-			layout: {
-				"text-field": ["get", "point_count_abbreviated"],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 12,
-				"text-allow-overlap": true,
-				"text-ignore-placement": true,
-				// Keep count upright when the map rotates.
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-			},
-			paint: {
-				"text-color": "#000",
-			},
-		});
-
-		// Symbol layer for unclustered points; boosted places use the orange pin.
-		// Drawn last so pins sit on top of cluster discs at boundaries.
-		map.addLayer({
-			id: "unclustered-point",
-			type: "symbol",
-			source: "places",
-			filter: ["!", ["has", "point_count"]],
-			layout: {
-				// Look up composite sprite (pin shape + baked category icon). Until
-				// the icon's sprite finishes loading, MapLibre logs a warning and
-				// skips the symbol; pins appear as their composite sprites resolve.
-				"icon-image": [
-					"concat",
-					"pin-",
-					["case", ["coalesce", ["get", "boosted"], false], "b", "r"],
-					"-",
-					["coalesce", ["get", "icon"], "question_mark"],
-				],
-				"icon-size": 1,
-				"icon-anchor": "bottom",
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				// Keep pins upright as the map rotates/pitches.
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		// Boosted pins — drawn from the separate non-clustered source on top
-		// of cluster discs so a paid boost is always visually prominent.
-		map.addLayer({
-			id: "boosted-point",
-			type: "symbol",
-			source: "places-boosted",
-			layout: {
-				"icon-image": [
-					"concat",
-					"pin-b-",
-					["coalesce", ["get", "icon"], "question_mark"],
-				],
-				"icon-size": 1,
-				"icon-anchor": "bottom",
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		// Comment count badge — green disc on the pin's top-right corner.
-		// Comment count badge — fixed 16×16 green disc rendered as a
-		// dedicated icon symbol layer. Two layers (disc + text) instead of
-		// one composite symbol so positioning stays simple — both share the
-		// same offset from the pin anchor.
-		// Pin is 32×43, icon-anchor: bottom. Top-right of the pin head is
-		// ~(+10, -36) px from the geographic anchor.
-		map.addLayer({
-			id: "comment-badge",
-			type: "symbol",
-			source: "places",
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				[">", ["get", "comments"], 0],
-			],
-			layout: {
-				"icon-image": "comment-badge-bg",
-				"icon-size": 1,
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-				"icon-offset": [10, -36],
-			},
-		});
-
-		map.addLayer({
-			id: "comment-badge-count",
-			type: "symbol",
-			source: "places",
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				[">", ["get", "comments"], 0],
-			],
-			layout: {
-				"text-field": ["to-string", ["get", "comments"]],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 11,
-				"text-allow-overlap": true,
-				"text-ignore-placement": true,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-				// text-offset is in ems; mirror the disc's pixel offset above.
-				"text-offset": [10 / 11, -36 / 11],
-			},
-			paint: {
-				"text-color": "#fff",
-			},
-		});
-
-		// Saved badge — white disc with bookmark glyph on the pin's
-		// top-left corner. Filter only fires when the feature's `saved`
-		// flag is true (recomputed when $savedPlaceIds size changes).
-		map.addLayer({
-			id: "saved-badge",
-			type: "symbol",
-			source: "places",
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				["==", ["get", "saved"], true],
-			],
-			layout: {
-				"icon-image": "saved-badge",
-				"icon-size": 1,
-				"icon-anchor": "center",
-				// Top-left of the pin head, relative to the bottom-anchored pin.
-				"icon-offset": [-12, -38],
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		// Place name labels — visible at high zoom once the enriched-details
-		// fetch has populated each place's name. Drawn before clusters-hit so
-		// the spiderfy hit-target stays on top for click routing.
-		map.addLayer({
-			id: "place-label",
-			type: "symbol",
-			source: "places",
-			minzoom: LABEL_VISIBLE_ZOOM,
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				["!=", ["get", "name"], ""],
-			],
-			layout: {
-				"text-field": ["get", "name"],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 14,
-				"text-anchor": "left",
-				// text-offset is in ems. Pin's right edge sits at ~+16 px from
-				// the geographic anchor (icon-anchor: bottom). Start the label
-				// 6 px past that, vertically centered on the pin head (~ -25 px).
-				"text-offset": [22 / 14, -25 / 14],
-				"text-max-width": 12,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-			},
-			paint: {
-				"text-color": [
-					"case",
-					["get", "boosted"],
-					"#f97316", // orange-500 (boosted)
-					"#0e7490", // cyan-700 (regular)
-				],
-				"text-halo-color": "#fff",
-				"text-halo-width": 1.2,
-				"text-halo-blur": 0,
-			},
-		});
-
-		// Mirrors of comment-badge / comment-badge-count / saved-badge /
-		// place-label for the parallel `places-boosted` source. Without
-		// these a boosted merchant with comments / saved state / a
-		// resolved label rendered as a bare orange pin.
-		map.addLayer({
-			id: "boosted-comment-badge",
-			type: "symbol",
-			source: "places-boosted",
-			filter: [">", ["get", "comments"], 0],
-			layout: {
-				"icon-image": "comment-badge-bg",
-				"icon-size": 1,
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-				"icon-offset": [10, -36],
-			},
-		});
-
-		map.addLayer({
-			id: "boosted-comment-badge-count",
-			type: "symbol",
-			source: "places-boosted",
-			filter: [">", ["get", "comments"], 0],
-			layout: {
-				"text-field": ["to-string", ["get", "comments"]],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 11,
-				"text-allow-overlap": true,
-				"text-ignore-placement": true,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-				"text-offset": [10 / 11, -36 / 11],
-			},
-			paint: {
-				"text-color": "#fff",
-			},
-		});
-
-		map.addLayer({
-			id: "boosted-saved-badge",
-			type: "symbol",
-			source: "places-boosted",
-			filter: ["==", ["get", "saved"], true],
-			layout: {
-				"icon-image": "saved-badge",
-				"icon-size": 1,
-				"icon-anchor": "center",
-				"icon-offset": [-12, -38],
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		map.addLayer({
-			id: "boosted-place-label",
-			type: "symbol",
-			source: "places-boosted",
-			minzoom: LABEL_VISIBLE_ZOOM,
-			filter: ["!=", ["get", "name"], ""],
-			layout: {
-				"text-field": ["get", "name"],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 14,
-				"text-anchor": "left",
-				"text-offset": [22 / 14, -25 / 14],
-				"text-max-width": 12,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-			},
-			paint: {
-				"text-color": "#f97316", // orange-500 (always boosted on this source)
-				"text-halo-color": "#fff",
-				"text-halo-width": 1.2,
-				"text-halo-blur": 0,
-			},
-		});
-
-		// Symbol cluster layer used by spiderfy. Hit-testing on this layer's
-		// near-invisible icon picks up the cluster_id property and routes
-		// through the library, which auto-decides between zoom-on-click and
-		// spiderfying based on getClusterExpansionZoom vs maxZoom.
-		map.addLayer({
-			id: "clusters-hit",
-			type: "symbol",
-			source: "places",
-			filter: ["has", "point_count"],
-			layout: {
-				"icon-image": "cluster-hit",
-				"icon-size": 1,
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-			},
-		});
+		// Sources + fifteen layers (pins, clusters, badges, labels, heatmap).
+		pinSource.install(map);
 
 		// Spiderfy hooks the clusters-hit symbol layer. The library's
 		// internal decision is: if expansionZoom > forceSpiderifyMinZoom OR
@@ -1852,15 +1165,15 @@ onMount(async () => {
 			currentLat = c.lat;
 			currentLon = c.lng;
 			// Re-route boosted places when zoom crosses BOOSTED_CLUSTERING_MAX_ZOOM
-			// — the MapLibre analogue of the legacy boostedLayer swap. Only re-syncs
-			// on an actual flip, so steady-state pans stay cheap.
-			if (shouldClusterBoostedAtZoom(currentZoom) !== boostedAreClustered) {
-				syncPlacesToSource(lastSyncedList);
+			// — the MapLibre analogue of the legacy boostedLayer swap. The facade
+			// only re-renders on an actual flip, so steady-state pans stay cheap.
+			if (styleLoaded) {
+				pinSource.resyncForZoom(map);
 			}
 			// When the heatmap is active, zooming past CLUSTERING_DISABLED_ZOOM
 			// naturally removes the heatmap layer (its maxzoom), so re-show
 			// all the point/cluster/badge layers that were concealed.
-			applyHeatmapVisibility();
+			pinSource.applyHeatmapVisibility(map);
 			debouncedUpdateMerchantList();
 		});
 
@@ -1979,7 +1292,7 @@ onMount(async () => {
 		// exists. The toggle control can't do this itself — it's added
 		// before 'load' fires, so the layer isn't present at addControl
 		// time.
-		setHeatmapEnabled(heatmapEnabled);
+		pinSource.refreshHeatmapAfterStyle(map);
 		// Kick once on load — if the user lands above the threshold, labels
 		// should appear without requiring a move.
 		triggerEnrichmentIfNeeded();

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -893,8 +893,13 @@ $: if (map && styleLoaded && $places) {
 		recency: $merchantList.verifiedWithinYears,
 		// Search rows carry verified_at natively (LIST_ITEM); the bulk feed
 		// only after enrichment — the pipeline keeps the filter inert until
-		// the dates land rather than hiding every pin.
-		recencyReady: inSearch || $verifiedDatesLoaded,
+		// the dates land rather than hiding every pin. Trivially ready when
+		// no window is selected (matching setMerchants in the list store), so
+		// the dates landing can't change the signature while the filter is off.
+		recencyReady:
+			$merchantList.verifiedWithinYears == null ||
+			inSearch ||
+			$verifiedDatesLoaded,
 		// Markers exempt search mode from the boosted-only narrowing: an
 		// explicit query should surface all matches on the map.
 		boostsOnly: boostsOnly && !inSearch,

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -19,10 +19,6 @@ import MapLoadingMain from "$components/MapLoadingMain.svelte";
 import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import { trackEvent } from "$lib/analytics";
 import {
-	filterMerchantsByCategory,
-	placeMatchesCategory,
-} from "$lib/categoryMapping";
-import {
 	BREAKPOINTS,
 	CLUSTERING_DISABLED_ZOOM,
 	DEFAULT_MAP_LAT,
@@ -69,6 +65,11 @@ import {
 	getZoomBehavior,
 } from "$lib/map/viewport";
 import { loadCachedView, saveCachedView } from "$lib/map/viewportCache";
+import {
+	computeVisibleSignature,
+	placesRevision,
+	selectVisiblePlaces,
+} from "$lib/map/visiblePlaces";
 import { hasWebGL } from "$lib/map/webgl";
 import {
 	MERCHANT_URL_CHANGE_EVENT,
@@ -78,7 +79,6 @@ import { merchantDrawer } from "$lib/merchantDrawerStore";
 import { merchantList } from "$lib/merchantListStore";
 import { savedPlaceIds } from "$lib/session";
 import {
-	lastUpdatedPlaceId,
 	places,
 	placesById,
 	placesError,
@@ -91,7 +91,6 @@ import { theme } from "$lib/theme";
 import type { Place } from "$lib/types";
 import { userLocation } from "$lib/userLocationStore";
 import { debounce, errToast, isBoosted } from "$lib/utils";
-import { filterPlacesByRecency } from "$lib/verification";
 
 import type { PageData } from "./$types";
 import MapControls from "./components/MapControls.svelte";
@@ -153,18 +152,12 @@ let destroyed = false;
 let spiderfier: Spiderfy | undefined;
 let styleLoaded = false;
 let webglUnsupported = false;
-let lastPlacesLength = -1;
-let lastSavedIdsSize = -1;
-let lastEnrichedCacheSize = -1;
-let lastLocale: string | null | undefined;
 let lastAppliedLabelTheme: "light" | "dark" | undefined;
-// Signature of the mode-dependent visible set. Empty string forces an
-// initial sync; "n" = nearby (all places); "c:<category>" = nearby
-// narrowed by a chip; "s:<category>:<id>,<id>,…" = a search-result list
-// (optionally narrowed by a chip); the sync guard appends "|v:<years>"
-// for the verified-recency window. Distinct from lastPlacesLength
-// because a fresh search or chip switch may leave the count unchanged.
-let lastSearchModeSig = "";
+// The one render signature gating syncPlacesToSource: the visibility
+// signature (computeVisibleSignature — mode/category/recency/gate/boosts/
+// $placesRevision/search ids) joined with the render-only inputs (saved-ids
+// size, enriched-cache size, locale). Empty string forces a sync.
+let lastRenderSig = "";
 
 // Last place list fed to the sources, kept so the boosted-clustering boundary
 // re-sync (on zoom crossing BOOSTED_CLUSTERING_MAX_ZOOM) can rebuild without a
@@ -823,15 +816,11 @@ const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
 	m.triggerRepaint();
 };
 
-const syncPlacesToSource = (rawList: Place[]) => {
+// Renders exactly the list it is given — all visibility policy (search,
+// category, recency, boosts) lives upstream in selectVisiblePlaces; this
+// function must never re-filter or accept an unfiltered list.
+const syncPlacesToSource = (list: Place[]) => {
 	if (!map || !styleLoaded) return;
-	// "Boosted locations only" narrows every sync path (markers, the boosted
-	// source and the heatmap) to currently-boosted places — except in search
-	// mode, where an explicit query should surface all matches on the map.
-	const list =
-		boostsOnly && get(merchantList).mode !== "search"
-			? rawList.filter(isBoosted)
-			: rawList;
 	const source = map.getSource("places") as GeoJSONSource | undefined;
 	const boostedSource = map.getSource("places-boosted") as
 		| GeoJSONSource
@@ -885,87 +874,48 @@ const triggerEnrichmentIfNeeded = debounce(() => {
 	);
 }, ENRICHMENT_DEBOUNCE_DELAY);
 
-// In-place mutations to a place (boost confirmation, new comment count)
-// don't change array length or any of the size counters below, so the marker
-// block's guard wouldn't repaint the pin. lastUpdatedPlaceId is set by the
-// boost/comment flows (BoostContent, CommentAdd) right after they await
-// updateSinglePlace() in $lib/sync/places.ts — invalidate the memo so the
-// marker block re-runs with the current search/category/recency filters and
-// re-syncs (same idiom as the style-load reset). Never sync raw $places here:
-// that bypasses every filter and poisons lastSyncedList for the heatmap and
-// zoom-crossing paths. ORDERING MATTERS: this block must stay ABOVE the
-// marker block. Svelte 4 excludes self-assigned variables when ordering
-// reactive blocks, so the marker block (which also assigns lastPlacesLength)
-// is not sorted after this one — only source order guarantees the marker
-// block's dirty check sees the bit this assignment sets within the same
-// update pass. Note: in search mode pins render from searchResults, which
-// updateSinglePlace doesn't refresh, so the re-sync repaints only data the
-// store already holds.
-$: if (map && styleLoaded && $lastUpdatedPlaceId !== undefined) {
-	lastPlacesLength = -1;
-	lastUpdatedPlaceId.set(undefined);
-}
-
-// Rebuild only when the count changes meaningfully (and always on first load),
-// to avoid jank on incremental store updates with ~50k places worldwide.
-// Also rebuild when $savedPlaceIds size changes so the saved badge appears/
-// disappears as the user toggles saves, and when the enriched details cache
-// grows so place-name labels appear as their data arrives. Tracking size
-// catches add/remove but misses the swap case (e.g. save A + unsave B with
-// no net size change) — accepted tradeoff for now.
+// The visible set comes from the shared pipeline (selectVisiblePlaces) so the
+// pins can never disagree with the list, counts, or camera again — the
+// #1158-#1162 bug class. The render signature gates the expensive
+// syncPlacesToSource: visibility inputs via computeVisibleSignature (with
+// $placesRevision covering bulk turnover AND in-place mutations from the
+// boost/comment flows — this replaces the old lastUpdatedPlaceId handshake
+// and its source-order contract), plus render-only inputs: $savedPlaceIds
+// size (saved badges), enriched-cache size (name labels), and locale. Size
+// tracking misses the swap case (save A + unsave B, no net change) —
+// accepted tradeoff carried over from the memo it replaces.
 $: if (map && styleLoaded && $places) {
 	const inSearch =
 		$merchantList.mode === "search" && $merchantList.searchResults.length > 0;
-	const category = $merchantList.selectedCategory;
-	let effective: Place[];
-	if (inSearch) {
-		// Apply the category chips to search pins with the panel's exact
-		// predicate (placeMatchesCategory, see filteredSearchResults) so the
-		// list and the map always show the same set.
-		effective =
-			category === "all"
-				? $merchantList.searchResults
-				: $merchantList.searchResults.filter((p) =>
-						placeMatchesCategory(p, category),
-					);
-	} else if (category !== "all") {
-		effective = filterMerchantsByCategory($places, category);
-	} else {
-		effective = $places;
-	}
-	// Verified-recency filter. Search results carry verified_at natively
-	// (LIST_ITEM), so filter them regardless of the bulk-enrichment flag —
-	// matching the panel's filteredSearchResults. The $places-derived branches
-	// gate on the flag: the bulk feed has no verified_at until enrichment lands,
-	// so until then treat the filter as inert rather than hiding every pin.
-	const verifiedYears = $merchantList.verifiedWithinYears;
-	const datesReady = verifiedYears == null || inSearch || $verifiedDatesLoaded;
-	if (datesReady) {
-		effective = filterPlacesByRecency(effective, verifiedYears);
-	}
-	const placesLen = effective.length;
-	const savedSize = $savedPlaceIds.size;
-	const cacheSize = $merchantList.placeDetailsCache.size;
-	const currentLocale = $locale;
-	const modeSig = inSearch
-		? `s:${category}:${$merchantList.searchResults.map((p) => p.id).join(",")}`
-		: category !== "all"
-			? `c:${category}`
-			: "n";
-	const searchSig = `${modeSig}|v:${verifiedYears ?? "any"}`;
-	if (
-		placesLen !== lastPlacesLength ||
-		savedSize !== lastSavedIdsSize ||
-		cacheSize !== lastEnrichedCacheSize ||
-		currentLocale !== lastLocale ||
-		searchSig !== lastSearchModeSig
-	) {
-		lastPlacesLength = placesLen;
-		lastSavedIdsSize = savedSize;
-		lastEnrichedCacheSize = cacheSize;
-		lastLocale = currentLocale;
-		lastSearchModeSig = searchSig;
-		syncPlacesToSource(effective);
+	const inputs = {
+		mode: (inSearch ? "search" : "nearby") as "search" | "nearby",
+		category: $merchantList.selectedCategory,
+		recency: $merchantList.verifiedWithinYears,
+		// Search rows carry verified_at natively (LIST_ITEM); the bulk feed
+		// only after enrichment — the pipeline keeps the filter inert until
+		// the dates land rather than hiding every pin.
+		recencyReady: inSearch || $verifiedDatesLoaded,
+		// Markers exempt search mode from the boosted-only narrowing: an
+		// explicit query should surface all matches on the map.
+		boostsOnly: boostsOnly && !inSearch,
+	};
+	const renderSig = [
+		computeVisibleSignature(
+			inputs,
+			$placesRevision,
+			inSearch ? $merchantList.searchResults.map((p) => p.id).join(",") : "",
+		),
+		$savedPlaceIds.size,
+		$merchantList.placeDetailsCache.size,
+		$locale,
+	].join("~");
+	if (renderSig !== lastRenderSig) {
+		lastRenderSig = renderSig;
+		const { selection } = selectVisiblePlaces({
+			...inputs,
+			places: inSearch ? $merchantList.searchResults : $places,
+		});
+		syncPlacesToSource(selection);
 	}
 }
 
@@ -2012,14 +1962,14 @@ onMount(async () => {
 		}
 
 		styleLoaded = true;
-		lastPlacesLength = -1;
-		lastSavedIdsSize = -1;
-		lastEnrichedCacheSize = -1;
-		lastSearchModeSig = "";
+		// Invalidate the render signature: setting styleLoaded re-runs the
+		// marker block, which recomputes the filtered selection and syncs it.
+		// Never sync raw $places here — syncPlacesToSource renders exactly
+		// what it is given and all filtering lives upstream in the pipeline.
+		lastRenderSig = "";
 		// Apply theme-dependent label palette now that the layer exists.
 		applyLabelPalette(map, get(theme));
 		lastAppliedLabelTheme = get(theme);
-		syncPlacesToSource($places);
 		// Apply the persisted heatmap on/off state now that the layer
 		// exists. The toggle control can't do this itself — it's added
 		// before 'load' fires, so the layer isn't present at addControl

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -12,18 +12,17 @@ import {
 	CATEGORY_ENTRIES,
 	type CategoryCounts,
 	type CategoryKey,
-	placeMatchesCategory,
 } from "$lib/categoryMapping";
 import { MERCHANT_LIST_LOW_ZOOM } from "$lib/constants";
 import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
 import { createDrawerGestureController } from "$lib/drawerGestureController";
 import { _ } from "$lib/i18n";
+import { selectVisiblePlaces } from "$lib/map/visiblePlaces";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import { merchantList } from "$lib/merchantListStore";
 import type { Place } from "$lib/types";
 import { userLocation } from "$lib/userLocationStore";
 import { errToast, formatNearbyPillCount } from "$lib/utils";
-import { filterPlacesByRecency } from "$lib/verification";
 
 import MerchantListItem from "./MerchantListItem.svelte";
 import NearbyCountPill from "./NearbyCountPill.svelte";
@@ -356,13 +355,17 @@ function handleDismissLocation() {
 	locationRequestDismissed = true;
 }
 
-// Filter search results by category and verification recency
-$: filteredSearchResults = filterPlacesByRecency(
-	selectedCategory === "all"
-		? searchResults
-		: searchResults.filter((p) => placeMatchesCategory(p, selectedCategory)),
-	verifiedWithinYears,
-);
+// The rendered search rows come from the same pipeline as the pins and the
+// chip counts (selectVisiblePlaces), so the list can never disagree with
+// either again.
+$: filteredSearchResults = selectVisiblePlaces({
+	places: searchResults,
+	mode: "search",
+	category: selectedCategory,
+	recency: verifiedWithinYears,
+	recencyReady: true,
+	boostsOnly: false,
+}).selection;
 
 // Helper function to check if a category has matching merchants
 // Note: counts param required for Svelte reactivity (indirect deps aren't tracked)

--- a/src/routes/merchant/[id]/components/CommentAdd.svelte
+++ b/src/routes/merchant/[id]/components/CommentAdd.svelte
@@ -8,7 +8,6 @@ import Icon from "$components/Icon.svelte";
 import InvoicePaymentStage from "$components/InvoicePaymentStage.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
 import { _ } from "$lib/i18n";
-import { lastUpdatedPlaceId } from "$lib/store";
 import { updateSinglePlace } from "$lib/sync/places";
 import type { MerchantPageData } from "$lib/types.js";
 import { errToast } from "$lib/utils";
@@ -35,7 +34,6 @@ const closeModal = () => {
 	invoiceId = "";
 	loading = false;
 	commentComplete = false;
-	$lastUpdatedPlaceId = undefined;
 };
 
 const handleOutClick = () => {
@@ -75,8 +73,6 @@ const handlePaymentSuccess = async () => {
 	// Update the place in localforage and store immediately
 	if (elementId) {
 		await updateSinglePlace(elementId);
-		// Signal map to update marker icon
-		lastUpdatedPlaceId.set(Number(elementId));
 	}
 };
 


### PR DESCRIPTION
Fixes #1168, implementing the **re-scoped** design from the adversarial re-review (see the issue's correction comment) — not the original sketch.

## What
- **`src/lib/map/visiblePlaces.ts`** — the pure pipeline: `selectVisiblePlaces(inputs)` → `{ selection, preCategory, counts, effectiveCategory }`. Recency with a caller-stated **provenance gate** (API/search rows carry `verified_at` natively; the bulk feed only after enrichment — the documented deliberate divergence, now modeled instead of smeared). Counts on the pre-category set. The auto-reset rule. Category via `placeMatchesCategory` everywhere — **unifying the two predicates** the #1182 equivalence tests were built to guard.
- **`computeVisibleSignature`** — string-gated recomputation, so consumers never rebuild ~50k-place GeoJSON on unrelated store ticks (search keystrokes, enrichment merges, loading flags). This was the re-review's headline hazard with a naive derived store, and the design answers it.
- **`placesRevision`** — bumps on every `$places` publication, covering bulk turnover *and* the in-place mutations no shape signature can see. This **replaces the `lastUpdatedPlaceId` handshake and the #1177 source-order contract entirely** — the fragile ordering comment is gone because the mechanism it protected is gone.

## Consumers routed through the pipeline
Marker block (five memo vars → one render signature), `setMerchants`, `fetchAndReplaceList` (density ceiling now explicitly on the pre-category set), `openWithSearchResults`, `setVerifiedFilter`'s search-mode recompute, and the panel's `filteredSearchResults`. `syncPlacesToSource` now renders exactly what it is given — all policy upstream (boosts moved out, keeping the marker path's search-mode exemption; the style-load path invalidates the signature instead of syncing raw `$places`). The store's `applyCategoryFilter`/`shouldResetCategory` dissolve into the pipeline. Net **−88 lines** with the new module included.

**Deliberately untouched:** `fetchCountOnly` (its recency-only policy is a documented, test-pinned invariant with its own boundary semantics), the nearby list's viewport/boost composition in `updateMerchantList`, and `?boosts` stays page-injected (it's a session constant read from the URL — a $lib store would freeze the wrong value; the re-review's injection point).

## Why now (with #1158-#1162 fixed)
Five patches in one week each hand-re-aligned a pair of decision sites; #921's `?issues` filter would have threaded through all of them like `?outdated` did. It now lands in one function. The consistency oracles built during those fixes become the pipeline's spec.

## Verification
- **Every oracle from #1177-#1182 passes unchanged** — the agreement test, the rendered-selection oracle, the equivalence guard, all 506 unit tests. 10 new pipeline tests (provenance gate, counts oracle, auto-reset both ways, boost composition, signature stability).
- Live: boot 29,080 pins → "coffee" 100 → Coffee chip **84 pins** with the panel reading "84 of 100 result(s)" — pins ≡ list through one code path; zero console errors.
- e2e in CI covers the `?outdated` deep link and search-chip narrowing end to end.

## Review follow-up (second commit)

AI review caught a real regression in the first cut: the layout's 10-minute `dataSync` republishes `$places` even when zero updates merged, and `placesRevision` (correctly) treats every publication as a content change — so each idle tick re-ran the whole pipeline over ~50k rows, which main's length-memo used to absorb. Fixed at the source: `elementsSync` now skips the blob write and the publish when a re-sync merged nothing (the synced_at watermark still advances; the session's first publication always goes through). This also covers stacked #1198 with no change there.

Also in the follow-up: `lastUpdatedPlaceId` became write-only dead state once this PR removed its map-page reader — the store and its three writers (Boost, BoostContent, CommentAdd) are deleted; and a new test pins `placesRevision`'s bump-per-publication semantics, the load-bearing replacement for that handshake.

## Sequencing
#1170 (placePinSource) stacks on this branch — its facade consumes this signature. #1173 stays parked behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

