### PR TITLE
refactor: one radius-search fetcher behind the three merchant-list reducers (#1171)

### DIFF
--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -676,22 +676,27 @@ describe("merchantListStore", () => {
 		});
 
 		it("should leave the cache untouched on a non-array response", async () => {
+			// try/finally: a failing assertion must not leave console.warn
+			// mocked for later tests (beforeEach clears, but doesn't restore)
 			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-			// Seed the cache through the list path
-			const initialPlace = createMockPlace({ id: 1 });
-			(api.get as Mock).mockResolvedValueOnce({ data: [initialPlace] });
-			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+			try {
+				// Seed the cache through the list path
+				const initialPlace = createMockPlace({ id: 1 });
+				(api.get as Mock).mockResolvedValueOnce({ data: [initialPlace] });
+				await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
 
-			// An HTML error page served with 200 must not poison the cache
-			(api.get as Mock).mockResolvedValueOnce({ data: "<html>oops</html>" });
-			await merchantList.fetchEnrichedDetails({ lat: 0, lon: 0 }, 10);
+				// An HTML error page served with 200 must not poison the cache
+				(api.get as Mock).mockResolvedValueOnce({ data: "<html>oops</html>" });
+				await merchantList.fetchEnrichedDetails({ lat: 0, lon: 0 }, 10);
 
-			const state = get(merchantList);
-			expect(state.placeDetailsCache.has(1)).toBe(true);
-			expect(state.placeDetailsCache.size).toBe(1);
-			expect(state.isEnrichingDetails).toBe(false);
-			expect(warnSpy).toHaveBeenCalled();
-			warnSpy.mockRestore();
+				const state = get(merchantList);
+				expect(state.placeDetailsCache.has(1)).toBe(true);
+				expect(state.placeDetailsCache.size).toBe(1);
+				expect(state.isEnrichingDetails).toBe(false);
+				expect(warnSpy).toHaveBeenCalled();
+			} finally {
+				warnSpy.mockRestore();
+			}
 		});
 	});
 

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -674,6 +674,25 @@ describe("merchantListStore", () => {
 
 			await fetchPromise;
 		});
+
+		it("should leave the cache untouched on a non-array response", async () => {
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			// Seed the cache through the list path
+			const initialPlace = createMockPlace({ id: 1 });
+			(api.get as Mock).mockResolvedValueOnce({ data: [initialPlace] });
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+
+			// An HTML error page served with 200 must not poison the cache
+			(api.get as Mock).mockResolvedValueOnce({ data: "<html>oops</html>" });
+			await merchantList.fetchEnrichedDetails({ lat: 0, lon: 0 }, 10);
+
+			const state = get(merchantList);
+			expect(state.placeDetailsCache.has(1)).toBe(true);
+			expect(state.placeDetailsCache.size).toBe(1);
+			expect(state.isEnrichingDetails).toBe(false);
+			expect(warnSpy).toHaveBeenCalled();
+			warnSpy.mockRestore();
+		});
 	});
 
 	describe("request cancellation", () => {

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -145,7 +145,9 @@ async function searchPlacesInRadius<T extends { id?: unknown }>(
 		{ timeout: 10000, signal },
 	);
 	if (!Array.isArray(response.data)) {
-		throw new Error("API returned invalid data format");
+		throw new Error(
+			`Radius search returned invalid data: expected an array, got ${typeof response.data}`,
+		);
 	}
 	return filterValidPlaces(response.data);
 }

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -128,6 +128,28 @@ function filterValidPlaces<T extends { id?: unknown }>(items: T[]): T[] {
 	return items.filter((item): item is T => typeof item?.id === "number");
 }
 
+// The one radius-search fetcher behind the three list reducers
+// (fetchAndReplaceList, fetchCountOnly, fetchEnrichedDetails). Owns the URL
+// shape, the 10s transport policy, the array-shape validation (the API can
+// return an HTML error page), and the dropping of rows without a numeric id.
+// What each reducer does with the rows — and how loudly it fails — stays
+// that reducer's own policy.
+async function searchPlacesInRadius<T extends { id?: unknown }>(
+	center: { lat: number; lon: number },
+	radiusKm: number,
+	fields: string,
+	signal: AbortSignal,
+): Promise<T[]> {
+	const response = await api.get<T[]>(
+		`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`,
+		{ timeout: 10000, signal },
+	);
+	if (!Array.isArray(response.data)) {
+		throw new Error("API returned invalid data format");
+	}
+	return filterValidPlaces(response.data);
+}
+
 function createMerchantListStore() {
 	const store = writable<MerchantListState>(initialState);
 	const { subscribe, set, update } = store;
@@ -229,19 +251,12 @@ function createMerchantListStore() {
 			update((state) => ({ ...state, isLoadingList: true }));
 
 			try {
-				const fields = buildFieldsParam(PLACE_FIELD_SETS.LIST_ITEM);
-				const response = await api.get<Place[]>(
-					`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`,
-					{ timeout: 10000, signal: listAbortController.signal },
+				const validPlaces = await searchPlacesInRadius<Place>(
+					center,
+					radiusKm,
+					buildFieldsParam(PLACE_FIELD_SETS.LIST_ITEM),
+					listAbortController.signal,
 				);
-
-				// Validate response is an array (API may return HTML error page)
-				if (!Array.isArray(response.data)) {
-					throw new Error("API returned invalid data format");
-				}
-
-				// Filter out invalid items missing required id field
-				const validPlaces = filterValidPlaces(response.data);
 
 				// Build cache for enriched display (icons, addresses, etc.)
 				const placeDetailsCache = new Map<number, Place>();
@@ -342,18 +357,9 @@ function createMerchantListStore() {
 			try {
 				// Typed to the payload actually requested — these rows are not
 				// full Places and must not be handed to anything expecting one.
-				const response = await api.get<Pick<Place, "id" | "verified_at">[]>(
-					`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`,
-					{ timeout: 10000, signal: listAbortController.signal },
-				);
-
-				// Validate response is an array (API may return HTML error page)
-				if (!Array.isArray(response.data)) {
-					throw new Error("API returned invalid data format");
-				}
-
-				// Filter out invalid items missing required id field
-				const validItems = filterValidPlaces(response.data);
+				const validItems = await searchPlacesInRadius<
+					Pick<Place, "id" | "verified_at">
+				>(center, radiusKm, fields, listAbortController.signal);
 				const recencyPlaces = filterPlacesByRecency(
 					validItems,
 					verifiedWithinYears,
@@ -397,14 +403,14 @@ function createMerchantListStore() {
 			update((state) => ({ ...state, isEnrichingDetails: true }));
 
 			try {
-				const fields = buildFieldsParam(PLACE_FIELD_SETS.LIST_ITEM);
-				const response = await api.get<Place[]>(
-					`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`,
-					{ timeout: 10000, signal: detailsAbortController.signal },
+				const validPlaces = await searchPlacesInRadius<Place>(
+					center,
+					radiusKm,
+					buildFieldsParam(PLACE_FIELD_SETS.LIST_ITEM),
+					detailsAbortController.signal,
 				);
 
-				// Filter out invalid items and merge into existing cache
-				const validPlaces = filterValidPlaces(response.data);
+				// Merge into existing cache
 				update((state) => {
 					const mergedCache = new Map(state.placeDetailsCache);
 					validPlaces.forEach((place) => mergedCache.set(place.id, place));


### PR DESCRIPTION
## Summary

The fetcher half of #1171, re-scoped per the re-review on that issue (the original nearbyList module was demoted: its motivation was half-consumed by #1180, and the three reducers' policies are deliberately distinct and test-pinned). **Refs #1171.**

**Stacked on #1192** (`fix/cancelled-fetch-toast`) — it builds on the `isCancellation` classification introduced there. GitHub will retarget to `main` when #1192 merges; only the last commit is new here.

**What changed**
- A private `searchPlacesInRadius(center, radiusKm, fields, signal)` in `merchantListStore.ts` now owns the previously triplicated `/v4/places/search/` URL, the 10s timeout, the array-shape validation, and the invalid-row drop (`filterValidPlaces`).
- The three reducers — `fetchAndReplaceList`, `fetchCountOnly`, `fetchEnrichedDetails` — keep their distinct, test-pinned policies: what to do with the rows, which abort controller to use, and how loudly to fail (only the visible-list path toasts).
- `fetchCountOnly`'s lean `id`/`id,verified_at` payload stays typed as `Pick<Place, ...>` through the generic.

**Invariant made explicit** (review clarified this is not a behavior change): `fetchEnrichedDetails` was the only one of the three without the explicit array-shape check — a non-array response there failed only via an incidental `TypeError` inside `filterValidPlaces`, with the same observable outcome (caught, warned, cache untouched). The shared fetcher makes the invariant explicit with a clear error message, and a new test pins the behavior instead of relying on the accident.

**Deliberately excluded** (per the re-review): the status-enum unification — it needs a behavior override plus live-zoom input and is not a mechanical extraction.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean
- [x] 500/500 unit tests green (1 new: non-array enrichment response leaves the cache untouched)
- [ ] CI (build, e2e, type-checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

