### PR TITLE
refactor: createBtcmapMap — shared embedded-map bring-up (#1169 phase 1)

### DIFF
--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -291,6 +291,13 @@ const initializeMap = async () => {
 		return;
 	}
 	if (outcome.status === "cancelled") return;
+	// Teardown can interleave with the await above (SvelteKit navigation runs
+	// in microtask continuations) — destroy the just-created map instead of
+	// leaking a WebGL context onDestroy already missed.
+	if (destroyed) {
+		outcome.handle.destroy();
+		return;
+	}
 	mapHandle = outcome.handle;
 	map = outcome.handle.map;
 };

--- a/src/components/MultiPlaceMap.svelte
+++ b/src/components/MultiPlaceMap.svelte
@@ -13,12 +13,9 @@ import MapLoadingEmbed from "$components/MapLoadingEmbed.svelte";
 import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import { CLUSTERING_DISABLED_ZOOM } from "$lib/constants";
 import { computeBbox } from "$lib/map/bbox";
-import {
-	ensureSprite,
-	installPlaceholderHandler,
-} from "$lib/map/maplibreSprites";
-import { ensureRtlTextPlugin } from "$lib/map/rtl";
-import { hasWebGL } from "$lib/map/webgl";
+import type { BtcmapMapHandle } from "$lib/map/createMap";
+import { createBtcmapMap } from "$lib/map/createMap";
+import { ensureSprite } from "$lib/map/maplibreSprites";
 import { theme } from "$lib/theme";
 import type { SavedPlace } from "$lib/types";
 
@@ -45,9 +42,6 @@ const EMPTY_COLLECTION: PlaceFeatureCollection = {
 	features: [],
 };
 
-const STYLE_LIGHT = "https://tiles.openfreemap.org/styles/liberty";
-const STYLE_DARK = "https://static.btcmap.org/map-styles/dark.json";
-
 let selectedMerchantId: number | null = null;
 
 const openDrawer = (id: number) => {
@@ -60,9 +54,9 @@ const closeDrawer = () => {
 
 let mapContainer: HTMLDivElement;
 let map: MapLibreMap | undefined;
+let mapHandle: BtcmapMapHandle | undefined;
 let mapLoaded = false;
 let styleLoaded = false;
-let lastAppliedTheme: "light" | "dark" | undefined;
 
 // Saved places are always rendered with the bitcoin icon — mirrors the legacy
 // Leaflet MultiPlaceMap which hardcodes generateIcon(..., "currency_bitcoin").
@@ -250,9 +244,6 @@ const attachInteractions = (m: MapLibreMap) => {
 	});
 };
 
-const styleUrlForTheme = (t: "light" | "dark" | undefined): string =>
-	t === "dark" ? STYLE_DARK : STYLE_LIGHT;
-
 let initialRenderComplete = false;
 let dataInitialized = false;
 let destroyed = false;
@@ -266,85 +257,42 @@ onMount(() => {
 
 onDestroy(() => {
 	destroyed = true;
-	map?.remove();
+	mapHandle?.destroy();
+	mapHandle = undefined;
 	map = undefined;
 });
 
+// The bring-up (WebGL check, dynamic import, controls, theme-swap state
+// machine) lives in createBtcmapMap; this component supplies the places
+// overlay and the first-load camera/interaction wiring. The shared sprite
+// cache evicts resolved promises on completion, so any sprites that didn't
+// survive a theme swap regenerate lazily against the new style.
 const initializeMap = async () => {
 	if (dataInitialized) return;
 	dataInitialized = true;
 
-	if (!hasWebGL()) {
+	const outcome = await createBtcmapMap({
+		container: mapContainer,
+		theme: $theme,
+		isCancelled: () => destroyed,
+		registerOverlays: (m) => initializeMapContents(m),
+		onFirstLoad: (m) => {
+			fitToPlaces(m);
+			attachInteractions(m);
+			mapLoaded = true;
+		},
+		onStyleReadyChange: (ready) => {
+			styleLoaded = ready;
+		},
+	});
+
+	if (outcome.status === "unsupported") {
 		webglUnsupported = true;
 		return;
 	}
-	const maplibre = await import("maplibre-gl");
-	ensureRtlTextPlugin(maplibre);
-	// Component may have been destroyed while the dynamic import was in
-	// flight (fast navigation away). Bail before binding to a stale
-	// container — otherwise we leak a Map instance that onDestroy can't
-	// clean up because it already ran with `map` undefined.
-	if (destroyed) return;
-
-	lastAppliedTheme = $theme;
-
-	map = new maplibre.Map({
-		container: mapContainer,
-		style: styleUrlForTheme($theme),
-		maxZoom: 21,
-		dragRotate: true,
-		touchZoomRotate: true,
-		pitchWithRotate: false,
-		attributionControl: { compact: true },
-	});
-
-	map.addControl(
-		new maplibre.NavigationControl({
-			showCompass: true,
-			showZoom: true,
-			visualizePitch: false,
-		}),
-		"top-right",
-	);
-
-	const geolocate = new maplibre.GeolocateControl({
-		positionOptions: { enableHighAccuracy: true },
-		trackUserLocation: true,
-		showUserLocation: true,
-		showAccuracyCircle: true,
-		fitBoundsOptions: { maxZoom: 15, linear: true },
-	});
-	map.addControl(geolocate, "top-right");
-
-	installPlaceholderHandler(map);
-
-	map.on("load", () => {
-		if (!map) return;
-		initializeMapContents(map);
-		fitToPlaces(map);
-		attachInteractions(map);
-		styleLoaded = true;
-		mapLoaded = true;
-	});
-};
-
-// Theme reactivity — swap the basemap, then re-register places overlay on the
-// resulting style.load event. The shared sprite cache evicts resolved promises
-// on completion, so any sprites that didn't survive the style swap regenerate
-// lazily on first render against the new style.
-const applyTheme = (next: "light" | "dark" | undefined) => {
-	if (!map) return;
-	if (!styleLoaded) return;
-	if (next === lastAppliedTheme) return;
-	lastAppliedTheme = next;
-	styleLoaded = false;
-	const onStyleLoad = () => {
-		if (!map) return;
-		initializeMapContents(map);
-		styleLoaded = true;
-	};
-	map.once("style.load", onStyleLoad);
-	map.setStyle(styleUrlForTheme(next));
+	if (outcome.status === "cancelled") return;
+	mapHandle = outcome.handle;
+	map = outcome.handle.map;
 };
 
 $: if (initialRenderComplete && places && !dataInitialized) {
@@ -361,7 +309,7 @@ $: if (initialRenderComplete && places && !dataInitialized) {
 }
 
 $: if (map && styleLoaded) {
-	applyTheme($theme);
+	mapHandle?.setTheme($theme);
 }
 </script>
 

--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -18,12 +18,9 @@ import ShowTags from "$components/ShowTags.svelte";
 import TaggingIssues from "$components/TaggingIssues.svelte";
 import { CLUSTERING_DISABLED_ZOOM, GradeTable } from "$lib/constants";
 import { computeBbox } from "$lib/map/bbox";
-import {
-	ensureSpritesForPlaces,
-	installPlaceholderHandler,
-} from "$lib/map/maplibreSprites";
-import { ensureRtlTextPlugin } from "$lib/map/rtl";
-import { hasWebGL } from "$lib/map/webgl";
+import type { BtcmapMapHandle } from "$lib/map/createMap";
+import { createBtcmapMap } from "$lib/map/createMap";
+import { ensureSpritesForPlaces } from "$lib/map/maplibreSprites";
 import { theme } from "$lib/theme";
 import type { Grade, Place } from "$lib/types";
 import { getGrade, isBoosted } from "$lib/utils";
@@ -59,9 +56,6 @@ const EMPTY_COLLECTION: PlaceFeatureCollection = {
 	features: [],
 };
 
-const STYLE_LIGHT = "https://tiles.openfreemap.org/styles/liberty";
-const STYLE_DARK = "https://static.btcmap.org/map-styles/dark.json";
-
 const AREA_OUTLINE_COLOR = "#0E95AF";
 
 // Local drawer state — mirrors the legacy Leaflet AreaMap component.
@@ -94,9 +88,9 @@ $: gradeTooltip &&
 
 let mapContainer: HTMLDivElement;
 let map: MapLibreMap | undefined;
+let mapHandle: BtcmapMapHandle | undefined;
 let mapLoaded = false;
 let styleLoaded = false;
-let lastAppliedTheme: "light" | "dark" | undefined;
 // Track last-applied props by reference so the area-change reactive only
 // fires on genuine prop turnover, not on theme-swap styleLoaded toggles.
 let lastAppliedGeoJSON: GeoJSON | undefined;
@@ -395,9 +389,6 @@ const attachInteractions = (m: MapLibreMap) => {
 	});
 };
 
-const styleUrlForTheme = (t: "light" | "dark" | undefined): string =>
-	t === "dark" ? STYLE_DARK : STYLE_LIGHT;
-
 let initialRenderComplete = false;
 let dataInitialized = false;
 let destroyed = false;
@@ -411,92 +402,44 @@ onMount(() => {
 
 onDestroy(() => {
 	destroyed = true;
-	map?.remove();
+	mapHandle?.destroy();
+	mapHandle = undefined;
 	map = undefined;
 });
 
+// The bring-up (WebGL check, dynamic import, controls, theme-swap state
+// machine) lives in createBtcmapMap; this component supplies the area
+// overlays and the first-load camera/interaction wiring. The shared sprite
+// cache evicts resolved promises on completion, so any sprites that didn't
+// survive a theme swap regenerate lazily against the new style.
 const initializeMap = async () => {
 	if (dataInitialized) return;
 	dataInitialized = true;
 
-	if (!hasWebGL()) {
+	const outcome = await createBtcmapMap({
+		container: mapContainer,
+		theme: $theme,
+		isCancelled: () => destroyed,
+		registerOverlays: (m) => initializeMapContents(m),
+		onFirstLoad: (m) => {
+			fitToArea(m);
+			attachInteractions(m);
+			mapLoaded = true;
+			lastAppliedGeoJSON = geoJSON;
+			lastAppliedFilteredPlaces = filteredPlaces;
+		},
+		onStyleReadyChange: (ready) => {
+			styleLoaded = ready;
+		},
+	});
+
+	if (outcome.status === "unsupported") {
 		webglUnsupported = true;
 		return;
 	}
-	const maplibre = await import("maplibre-gl");
-	ensureRtlTextPlugin(maplibre);
-	// Component may have been destroyed while the dynamic import was in
-	// flight (fast navigation away). Bail before binding to a stale
-	// container — otherwise we leak a Map instance that onDestroy can't
-	// clean up because it already ran with `map` undefined.
-	if (destroyed) return;
-
-	lastAppliedTheme = $theme;
-
-	map = new maplibre.Map({
-		container: mapContainer,
-		style: styleUrlForTheme($theme),
-		maxZoom: 21,
-		dragRotate: true,
-		touchZoomRotate: true,
-		pitchWithRotate: false,
-		attributionControl: { compact: true },
-	});
-
-	map.addControl(
-		new maplibre.NavigationControl({
-			showCompass: true,
-			showZoom: true,
-			visualizePitch: false,
-		}),
-		"top-right",
-	);
-
-	const geolocate = new maplibre.GeolocateControl({
-		positionOptions: { enableHighAccuracy: true },
-		trackUserLocation: true,
-		showUserLocation: true,
-		showAccuracyCircle: true,
-		fitBoundsOptions: { maxZoom: 15, linear: true },
-	});
-	map.addControl(geolocate, "top-right");
-
-	// MapLibre logs a "image missing" warning whenever a symbol references an
-	// icon id that hasn't been registered yet. Composite pin sprites resolve
-	// async; registering a transparent stub for any missing id keeps the
-	// console quiet and prevents flicker until the real sprite lands.
-	installPlaceholderHandler(map);
-
-	// First load — register everything and mark mapLoaded once stable.
-	map.on("load", () => {
-		if (!map) return;
-		initializeMapContents(map);
-		fitToArea(map);
-		attachInteractions(map);
-		styleLoaded = true;
-		mapLoaded = true;
-		lastAppliedGeoJSON = geoJSON;
-		lastAppliedFilteredPlaces = filteredPlaces;
-	});
-};
-
-// Theme reactivity — swap the basemap, then re-register area + places overlays
-// on the resulting style.load event. The shared sprite cache evicts resolved
-// promises on completion, so any sprites that didn't survive the style swap
-// regenerate lazily on first render against the new style.
-const applyTheme = (next: "light" | "dark" | undefined) => {
-	if (!map) return;
-	if (!styleLoaded) return;
-	if (next === lastAppliedTheme) return;
-	lastAppliedTheme = next;
-	styleLoaded = false;
-	const onStyleLoad = () => {
-		if (!map) return;
-		initializeMapContents(map);
-		styleLoaded = true;
-	};
-	map.once("style.load", onStyleLoad);
-	map.setStyle(styleUrlForTheme(next));
+	if (outcome.status === "cancelled") return;
+	mapHandle = outcome.handle;
+	map = outcome.handle.map;
 };
 
 $: if (initialRenderComplete && geoJSON && filteredPlaces && !dataInitialized) {
@@ -538,7 +481,7 @@ $: if (
 }
 
 $: if (map && styleLoaded) {
-	applyTheme($theme);
+	mapHandle?.setTheme($theme);
 }
 </script>
 

--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -438,6 +438,13 @@ const initializeMap = async () => {
 		return;
 	}
 	if (outcome.status === "cancelled") return;
+	// Teardown can interleave with the await above (SvelteKit navigation runs
+	// in microtask continuations) — destroy the just-created map instead of
+	// leaking a WebGL context onDestroy already missed.
+	if (destroyed) {
+		outcome.handle.destroy();
+		return;
+	}
 	mapHandle = outcome.handle;
 	map = outcome.handle.map;
 };

--- a/src/lib/map/createMap.test.ts
+++ b/src/lib/map/createMap.test.ts
@@ -159,6 +159,19 @@ describe("createBtcmapMap", () => {
 		expect(fake.setStyleCalls).toEqual([]);
 	});
 
+	it("treats undefined and light as the same theme — no restyle on resolve", async () => {
+		// Callers may construct before the theme store resolves; undefined and
+		// "light" map to the same style, so resolving must not restyle.
+		const { handle, fake } = await readyOutcome({ theme: undefined });
+		fake.fire("load");
+
+		handle.setTheme("light");
+		expect(fake.setStyleCalls).toEqual([]);
+
+		handle.setTheme("dark");
+		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
+	});
+
 	it("ignores setTheme while a previous swap's style is still loading", async () => {
 		const { handle, fake } = await readyOutcome();
 		fake.fire("load");

--- a/src/lib/map/createMap.test.ts
+++ b/src/lib/map/createMap.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { hasWebGLMock } = vi.hoisted(() => ({ hasWebGLMock: vi.fn() }));
+
+vi.mock("$lib/map/webgl", () => ({ hasWebGL: hasWebGLMock }));
+vi.mock("$lib/map/rtl", () => ({ ensureRtlTextPlugin: vi.fn() }));
+vi.mock("$lib/map/maplibreSprites", () => ({
+	installPlaceholderHandler: vi.fn(),
+}));
+
+// Minimal stand-in for maplibre's Map: enough event plumbing to drive the
+// load / style.load lifecycle the theme-swap state machine depends on.
+class FakeMap {
+	static instances: FakeMap[] = [];
+	styleUrl: string;
+	removed = false;
+	setStyleCalls: string[] = [];
+	private handlers = new Map<string, ((...args: unknown[]) => void)[]>();
+	private onceHandlers = new Map<string, ((...args: unknown[]) => void)[]>();
+
+	constructor(opts: { style: string }) {
+		this.styleUrl = opts.style;
+		FakeMap.instances.push(this);
+	}
+	on(event: string, cb: (...args: unknown[]) => void) {
+		const list = this.handlers.get(event) ?? [];
+		list.push(cb);
+		this.handlers.set(event, list);
+	}
+	once(event: string, cb: (...args: unknown[]) => void) {
+		const list = this.onceHandlers.get(event) ?? [];
+		list.push(cb);
+		this.onceHandlers.set(event, list);
+	}
+	addControl() {}
+	setStyle(url: string) {
+		this.setStyleCalls.push(url);
+		this.styleUrl = url;
+	}
+	remove() {
+		this.removed = true;
+	}
+	fire(event: string) {
+		for (const cb of this.handlers.get(event) ?? []) cb();
+		const once = this.onceHandlers.get(event) ?? [];
+		this.onceHandlers.delete(event);
+		for (const cb of once) cb();
+	}
+}
+
+vi.mock("maplibre-gl", () => ({
+	Map: FakeMap,
+	NavigationControl: class {},
+	GeolocateControl: class {},
+}));
+
+import { createBtcmapMap, styleUrlForTheme } from "./createMap";
+
+const container = {} as HTMLElement;
+
+const readyOutcome = async (
+	overrides: Partial<Parameters<typeof createBtcmapMap>[0]> = {},
+) => {
+	const registerOverlays = vi.fn();
+	const onFirstLoad = vi.fn();
+	const onStyleReadyChange = vi.fn();
+	const outcome = await createBtcmapMap({
+		container,
+		theme: "light",
+		registerOverlays,
+		onFirstLoad,
+		onStyleReadyChange,
+		...overrides,
+	});
+	if (outcome.status !== "ready") throw new Error("expected ready");
+	const fake = FakeMap.instances[FakeMap.instances.length - 1];
+	return {
+		handle: outcome.handle,
+		fake,
+		registerOverlays,
+		onFirstLoad,
+		onStyleReadyChange,
+	};
+};
+
+beforeEach(() => {
+	FakeMap.instances = [];
+	hasWebGLMock.mockReturnValue(true);
+});
+
+describe("styleUrlForTheme", () => {
+	it("maps dark to the dark style and everything else to light", () => {
+		expect(styleUrlForTheme("dark")).toContain("dark");
+		expect(styleUrlForTheme("light")).not.toContain("dark");
+		expect(styleUrlForTheme(undefined)).toBe(styleUrlForTheme("light"));
+	});
+});
+
+describe("createBtcmapMap", () => {
+	it("returns unsupported without constructing a Map when WebGL is missing", async () => {
+		hasWebGLMock.mockReturnValue(false);
+		const outcome = await createBtcmapMap({
+			container,
+			theme: "light",
+			registerOverlays: vi.fn(),
+		});
+		expect(outcome.status).toBe("unsupported");
+		expect(FakeMap.instances.length).toBe(0);
+	});
+
+	it("returns cancelled without constructing a Map when the component died mid-import", async () => {
+		const outcome = await createBtcmapMap({
+			container,
+			theme: "light",
+			registerOverlays: vi.fn(),
+			isCancelled: () => true,
+		});
+		expect(outcome.status).toBe("cancelled");
+		expect(FakeMap.instances.length).toBe(0);
+	});
+
+	it("runs overlays, first-load wiring, and the ready signal on load", async () => {
+		const { fake, registerOverlays, onFirstLoad, onStyleReadyChange } =
+			await readyOutcome();
+		expect(registerOverlays).not.toHaveBeenCalled();
+
+		fake.fire("load");
+
+		expect(registerOverlays).toHaveBeenCalledTimes(1);
+		expect(onFirstLoad).toHaveBeenCalledTimes(1);
+		expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
+	});
+
+	it("swaps the style on a theme change and re-registers overlays on style.load", async () => {
+		const { handle, fake, registerOverlays, onFirstLoad, onStyleReadyChange } =
+			await readyOutcome();
+		fake.fire("load");
+
+		handle.setTheme("dark");
+		expect(onStyleReadyChange).toHaveBeenLastCalledWith(false);
+		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
+
+		fake.fire("style.load");
+		expect(registerOverlays).toHaveBeenCalledTimes(2);
+		// First-load wiring must NOT re-run on a theme swap
+		expect(onFirstLoad).toHaveBeenCalledTimes(1);
+		expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
+	});
+
+	it("ignores setTheme before the first load and for an unchanged theme", async () => {
+		const { handle, fake } = await readyOutcome();
+
+		// Not ready yet — a swap now would race the initial style load
+		handle.setTheme("dark");
+		expect(fake.setStyleCalls).toEqual([]);
+
+		fake.fire("load");
+		handle.setTheme("light");
+		expect(fake.setStyleCalls).toEqual([]);
+	});
+
+	it("ignores setTheme while a previous swap's style is still loading", async () => {
+		const { handle, fake } = await readyOutcome();
+		fake.fire("load");
+
+		handle.setTheme("dark");
+		handle.setTheme("light");
+		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
+
+		// Once the swap settles, the component's readiness reactive re-invokes
+		fake.fire("style.load");
+		handle.setTheme("light");
+		expect(fake.setStyleCalls).toEqual([
+			styleUrlForTheme("dark"),
+			styleUrlForTheme("light"),
+		]);
+	});
+
+	it("destroy removes the map and inert-s the handle", async () => {
+		const { handle, fake, registerOverlays } = await readyOutcome();
+		fake.fire("load");
+
+		handle.destroy();
+		expect(fake.removed).toBe(true);
+
+		handle.setTheme("dark");
+		expect(fake.setStyleCalls).toEqual([]);
+
+		// A straggling event after teardown must not touch callbacks
+		fake.fire("style.load");
+		expect(registerOverlays).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -1,16 +1,16 @@
 import type { Map as MapLibreMap } from "maplibre-gl";
 
+import { styleForBasemap } from "$lib/map/basemaps";
 import { installPlaceholderHandler } from "$lib/map/maplibreSprites";
 import { ensureRtlTextPlugin } from "$lib/map/rtl";
 import { hasWebGL } from "$lib/map/webgl";
 
 export type MapThemeName = "light" | "dark" | undefined;
 
-const STYLE_LIGHT = "https://tiles.openfreemap.org/styles/liberty";
-const STYLE_DARK = "https://static.btcmap.org/map-styles/dark.json";
-
-export const styleUrlForTheme = (t: MapThemeName): string =>
-	t === "dark" ? STYLE_DARK : STYLE_LIGHT;
+// The embedded maps pin their two basemaps to the same styles the /map
+// picker exposes — basemaps.ts stays the single source of truth for the URLs.
+export const styleUrlForTheme = (t: MapThemeName) =>
+	styleForBasemap(t === "dark" ? "ofm-dark" : "liberty");
 
 export type BtcmapMapHandle = {
 	map: MapLibreMap;

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -55,7 +55,13 @@ export const createBtcmapMap = async (opts: {
 	ensureRtlTextPlugin(maplibre);
 	if (opts.isCancelled?.()) return { status: "cancelled" };
 
-	let appliedTheme = opts.theme;
+	// Normalize so undefined ≡ "light" (they resolve to the same style):
+	// otherwise a caller that initializes with an unresolved theme and later
+	// passes "light" would trigger a full setStyle round-trip for nothing.
+	const normalizeTheme = (t: MapThemeName): "light" | "dark" =>
+		t === "dark" ? "dark" : "light";
+
+	let appliedTheme = normalizeTheme(opts.theme);
 	let ready = false;
 	let disposed = false;
 
@@ -110,15 +116,16 @@ export const createBtcmapMap = async (opts: {
 	const setTheme = (next: MapThemeName) => {
 		if (disposed) return;
 		if (!ready) return;
-		if (next === appliedTheme) return;
-		appliedTheme = next;
+		const normalized = normalizeTheme(next);
+		if (normalized === appliedTheme) return;
+		appliedTheme = normalized;
 		setReady(false);
 		map.once("style.load", () => {
 			if (disposed) return;
 			opts.registerOverlays(map);
 			setReady(true);
 		});
-		map.setStyle(styleUrlForTheme(next));
+		map.setStyle(styleUrlForTheme(normalized));
 	};
 
 	const destroy = () => {

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -1,0 +1,131 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+import { installPlaceholderHandler } from "$lib/map/maplibreSprites";
+import { ensureRtlTextPlugin } from "$lib/map/rtl";
+import { hasWebGL } from "$lib/map/webgl";
+
+export type MapThemeName = "light" | "dark" | undefined;
+
+const STYLE_LIGHT = "https://tiles.openfreemap.org/styles/liberty";
+const STYLE_DARK = "https://static.btcmap.org/map-styles/dark.json";
+
+export const styleUrlForTheme = (t: MapThemeName): string =>
+	t === "dark" ? STYLE_DARK : STYLE_LIGHT;
+
+export type BtcmapMapHandle = {
+	map: MapLibreMap;
+	// Swap the basemap for a theme change. No-ops while a previous swap's
+	// style is still loading — the component's readiness reactive re-invokes
+	// once it settles — and when the theme didn't actually change.
+	setTheme: (next: MapThemeName) => void;
+	destroy: () => void;
+};
+
+export type CreateBtcmapMapOutcome =
+	| { status: "ready"; handle: BtcmapMapHandle }
+	| { status: "unsupported" }
+	| { status: "cancelled" };
+
+// The shared bring-up for embedded maps (AreaMap, MultiPlaceMap): WebGL
+// support check, dynamic maplibre import, RTL plugin, Map construction,
+// navigation + geolocate controls, sprite placeholder handler, and the
+// theme-swap state machine. Overlay content stays with the caller:
+// registerOverlays re-runs after every style (re)load because setStyle()
+// strips custom sprites, sources, and layers.
+export const createBtcmapMap = async (opts: {
+	container: HTMLElement;
+	theme: MapThemeName;
+	// Sprites + sources + layers + data. Runs on the initial load and again
+	// after every theme swap's style.load.
+	registerOverlays: (map: MapLibreMap) => void;
+	// Runs once, after the first registerOverlays: camera + interactions.
+	onFirstLoad?: (map: MapLibreMap) => void;
+	// Style readiness — false while a swap's style is loading. Components
+	// gate reactive source writes on this.
+	onStyleReadyChange?: (ready: boolean) => void;
+	// The dynamic import may outlive the component (fast navigation away);
+	// return true to abandon initialization before a Map binds to the
+	// container — otherwise we'd leak an instance the component's onDestroy
+	// can't clean up because it already ran.
+	isCancelled?: () => boolean;
+}): Promise<CreateBtcmapMapOutcome> => {
+	if (!hasWebGL()) return { status: "unsupported" };
+
+	const maplibre = await import("maplibre-gl");
+	ensureRtlTextPlugin(maplibre);
+	if (opts.isCancelled?.()) return { status: "cancelled" };
+
+	let appliedTheme = opts.theme;
+	let ready = false;
+	let disposed = false;
+
+	const setReady = (value: boolean) => {
+		ready = value;
+		opts.onStyleReadyChange?.(value);
+	};
+
+	const map = new maplibre.Map({
+		container: opts.container,
+		style: styleUrlForTheme(opts.theme),
+		maxZoom: 21,
+		dragRotate: true,
+		touchZoomRotate: true,
+		pitchWithRotate: false,
+		attributionControl: { compact: true },
+	});
+
+	map.addControl(
+		new maplibre.NavigationControl({
+			showCompass: true,
+			showZoom: true,
+			visualizePitch: false,
+		}),
+		"top-right",
+	);
+
+	map.addControl(
+		new maplibre.GeolocateControl({
+			positionOptions: { enableHighAccuracy: true },
+			trackUserLocation: true,
+			showUserLocation: true,
+			showAccuracyCircle: true,
+			fitBoundsOptions: { maxZoom: 15, linear: true },
+		}),
+		"top-right",
+	);
+
+	// MapLibre logs an "image missing" warning whenever a symbol references
+	// an icon id that hasn't been registered yet. Composite pin sprites
+	// resolve async; registering a transparent stub for any missing id keeps
+	// the console quiet and prevents flicker until the real sprite lands.
+	installPlaceholderHandler(map);
+
+	map.on("load", () => {
+		if (disposed) return;
+		opts.registerOverlays(map);
+		opts.onFirstLoad?.(map);
+		setReady(true);
+	});
+
+	const setTheme = (next: MapThemeName) => {
+		if (disposed) return;
+		if (!ready) return;
+		if (next === appliedTheme) return;
+		appliedTheme = next;
+		setReady(false);
+		map.once("style.load", () => {
+			if (disposed) return;
+			opts.registerOverlays(map);
+			setReady(true);
+		});
+		map.setStyle(styleUrlForTheme(next));
+	};
+
+	const destroy = () => {
+		if (disposed) return;
+		disposed = true;
+		map.remove();
+	};
+
+	return { status: "ready", handle: { map, setTheme, destroy } };
+};


### PR DESCRIPTION
## Summary

Phase 1 of #1169, per the re-review on that issue: extract the embedded-map bring-up into `src/lib/map/createMap.ts` and adopt it in the two components whose duplication is byte-identical today — `AreaMap` and `MultiPlaceMap`. **Refs #1169.**

**Deliberately NOT adopted yet** (the re-review's sequencing): `/map` and `/communities/map` wait until the MapLibre v6 migration (PR #1144) lands — adopting there now would create a rebase collision with the v6 branch for no user benefit. `add-location`/`MerchantStaticMap` are the phase-2 follow-up.

**What the module owns** (one call, `createBtcmapMap({...})`):
- WebGL support check → `{status: "unsupported"}` outcome (component shows its fallback)
- dynamic `maplibre-gl` import + RTL text plugin + the destroyed-mid-import guard (`isCancelled` callback → `{status: "cancelled"}`)
- `Map` construction with the shared options, NavigationControl + GeolocateControl, sprite placeholder handler
- the theme-swap state machine: `handle.setTheme(next)` no-ops on unchanged theme or while a previous swap's style is still loading, and re-runs the caller's `registerOverlays` on each `style.load`
- `handle.destroy()` — removes the map and inert-s the handle (straggling `style.load` events can't touch callbacks)

**What stays with each component**: overlays (`registerOverlays`), first-load camera + interactions (`onFirstLoad`), and the `styleLoaded` gating via `onStyleReadyChange` — the parts that genuinely differ.

Net: −166 lines across the two components, +134-line module, and the state machine is now unit-testable (7 new tests pin swap-re-registers-overlays, first-load-never-re-runs, swap-ignored-while-loading, destroy-inert semantics — none of which had any coverage before).

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean
- [x] 504/504 unit tests green (7 new in `createMap.test.ts`)
- [x] Live-verified on the dev server (`/community/free-madeira`): area outline + clusters render, dark→light theme swap keeps overlays and camera, light→dark back, no new console errors
- [ ] CI (build, e2e, type-checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)