### PR TITLE
refactor: placePinSource — the /map pin rendering facade (#1170)

### DIFF
--- a/src/lib/map/placePinSource.test.ts
+++ b/src/lib/map/placePinSource.test.ts
@@ -1,6 +1,7 @@
 import type { Map as MapLibreMap } from "maplibre-gl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
 import type { Place } from "$lib/types";
 
 const { ensureSpritesMock } = vi.hoisted(() => ({
@@ -190,7 +191,7 @@ describe("heatmap", () => {
 	});
 
 	it("reads the persisted on state and re-applies it after a style load", () => {
-		localStorage.setItem("btcmap:heatmap-layer", "true");
+		localStorage.setItem(HEATMAP_STORAGE_KEY, "true");
 		const fake = makeFakeMap(10);
 		const pin = makeSource();
 		pin.refreshHeatmapAfterStyle(fake.map);

--- a/src/lib/map/placePinSource.test.ts
+++ b/src/lib/map/placePinSource.test.ts
@@ -1,0 +1,200 @@
+import type { Map as MapLibreMap } from "maplibre-gl";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Place } from "$lib/types";
+
+const { ensureSpritesMock } = vi.hoisted(() => ({
+	ensureSpritesMock: vi.fn(),
+}));
+
+vi.mock("$lib/map/maplibreSprites", () => ({
+	ensureSpritesForPlaces: ensureSpritesMock,
+	loadSvgImage: vi.fn(),
+}));
+
+import { createPlacePinSource } from "./placePinSource";
+
+// BOOSTED_CLUSTERING_MAX_ZOOM is 5: boosted places fold into the clustered
+// source at integer zoom ≤ 5 and ride the standalone source above it.
+const CLUSTERED_ZOOM = 3;
+const STANDALONE_ZOOM = 12;
+
+type FakeSource = { setData: ReturnType<typeof vi.fn> };
+
+const makeFakeMap = (zoom: number) => {
+	const sources: Record<string, FakeSource> = {
+		places: { setData: vi.fn() },
+		"places-boosted": { setData: vi.fn() },
+		"places-heatmap": { setData: vi.fn() },
+	};
+	const layoutCalls: [string, string, string][] = [];
+	let currentZoom = zoom;
+	return {
+		sources,
+		layoutCalls,
+		setZoom: (z: number) => {
+			currentZoom = z;
+		},
+		map: {
+			getZoom: () => currentZoom,
+			getSource: (id: string) => sources[id],
+			getLayer: (_id: string) => true,
+			setLayoutProperty: (layer: string, prop: string, value: string) => {
+				layoutCalls.push([layer, prop, value]);
+			},
+		} as unknown as MapLibreMap,
+	};
+};
+
+const makePlace = (overrides: Partial<Place> = {}): Place =>
+	({
+		id: 1,
+		lat: 10,
+		lon: 20,
+		icon: "cafe",
+		...overrides,
+	}) as Place;
+
+const boostedPlace = (id: number): Place =>
+	makePlace({
+		id,
+		boosted_until: new Date(Date.now() + 86_400_000).toISOString(),
+	});
+
+const makeSource = (onRendered?: (count: number) => void) =>
+	createPlacePinSource({
+		getSavedIds: () => new Set<number>([1]),
+		getEnrichedCache: () => new Map<number, Place>(),
+		getDisplayLang: () => "en",
+		onRendered,
+	});
+
+const featuresOf = (source: FakeSource) =>
+	source.setData.mock.calls[source.setData.mock.calls.length - 1][0].features;
+
+beforeEach(() => {
+	ensureSpritesMock.mockClear();
+	localStorage.clear();
+});
+
+describe("render", () => {
+	it("routes boosted places to the standalone source above the clustering zoom", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const pin = makeSource();
+		pin.render(map, [makePlace({ id: 1 }), boostedPlace(2)]);
+
+		expect(
+			featuresOf(sources.places).map(
+				(f: { properties: { id: number } }) => f.properties.id,
+			),
+		).toEqual([1]);
+		expect(
+			featuresOf(sources["places-boosted"]).map(
+				(f: { properties: { id: number } }) => f.properties.id,
+			),
+		).toEqual([2]);
+	});
+
+	it("folds boosted places into the clustered source at low zoom", () => {
+		const { map, sources } = makeFakeMap(CLUSTERED_ZOOM);
+		const pin = makeSource();
+		pin.render(map, [makePlace({ id: 1 }), boostedPlace(2)]);
+
+		expect(featuresOf(sources.places)).toHaveLength(2);
+		expect(featuresOf(sources["places-boosted"])).toHaveLength(0);
+	});
+
+	it("skips the heatmap source while the heatmap is off, reports the count, loads sprites", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const counts: number[] = [];
+		const pin = makeSource((count) => counts.push(count));
+		const list = [makePlace({ id: 1 }), makePlace({ id: 2 })];
+		pin.render(map, list);
+
+		expect(sources["places-heatmap"].setData).not.toHaveBeenCalled();
+		expect(counts).toEqual([2]);
+		expect(ensureSpritesMock).toHaveBeenCalledWith(map, list);
+	});
+
+	it("builds feature properties from the injected deps", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const enriched = new Map<number, Place>([
+			[1, { localized_name: { de: "Café Eins" } } as unknown as Place],
+		]);
+		const pin = createPlacePinSource({
+			getSavedIds: () => new Set([1]),
+			getEnrichedCache: () => enriched,
+			getDisplayLang: () => "de",
+		});
+		pin.render(map, [makePlace({ id: 1, name: "Cafe One" })]);
+
+		const [feature] = featuresOf(sources.places);
+		expect(feature.properties.name).toBe("Café Eins");
+		expect(feature.properties.saved).toBe(true);
+		expect(feature.properties.boosted).toBe(false);
+	});
+});
+
+describe("resyncForZoom", () => {
+	it("re-renders only when the zoom crossing actually flips the routing", () => {
+		const fake = makeFakeMap(CLUSTERED_ZOOM);
+		const pin = makeSource();
+		pin.render(fake.map, [makePlace({ id: 1 }), boostedPlace(2)]);
+		expect(fake.sources.places.setData).toHaveBeenCalledTimes(1);
+
+		// Same side of the boundary — no re-render
+		fake.setZoom(CLUSTERED_ZOOM + 1);
+		pin.resyncForZoom(fake.map);
+		expect(fake.sources.places.setData).toHaveBeenCalledTimes(1);
+
+		// Crossing the boundary re-renders from the remembered list
+		fake.setZoom(STANDALONE_ZOOM);
+		pin.resyncForZoom(fake.map);
+		expect(fake.sources.places.setData).toHaveBeenCalledTimes(2);
+		expect(featuresOf(fake.sources["places-boosted"])).toHaveLength(1);
+	});
+});
+
+describe("heatmap", () => {
+	it("seeds the heatmap source from the last synced list on enable", () => {
+		const { map, sources } = makeFakeMap(STANDALONE_ZOOM);
+		const pin = makeSource();
+		pin.render(map, [makePlace({ id: 1 }), makePlace({ id: 2 })]);
+		expect(sources["places-heatmap"].setData).not.toHaveBeenCalled();
+
+		pin.setHeatmapEnabled(map, true);
+		expect(featuresOf(sources["places-heatmap"])).toHaveLength(2);
+
+		// While enabled, render refreshes the heatmap with the full list
+		pin.render(map, [makePlace({ id: 3 })]);
+		expect(featuresOf(sources["places-heatmap"])).toHaveLength(1);
+	});
+
+	it("conceals pin layers below the reveal zoom and shows them above it", () => {
+		const fake = makeFakeMap(10);
+		const pin = makeSource();
+		pin.setHeatmapEnabled(fake.map, true);
+		const heatmapVis = fake.layoutCalls.find(([l]) => l === "place-heatmap");
+		expect(heatmapVis?.[2]).toBe("visible");
+		const pinVis = fake.layoutCalls.find(([l]) => l === "unclustered-point");
+		expect(pinVis?.[2]).toBe("none");
+
+		// Past the reveal zoom (15.5) pins show through the fading heatmap
+		fake.layoutCalls.length = 0;
+		fake.setZoom(16);
+		pin.applyHeatmapVisibility(fake.map);
+		const pinVisHigh = fake.layoutCalls.find(
+			([l]) => l === "unclustered-point",
+		);
+		expect(pinVisHigh?.[2]).toBe("visible");
+	});
+
+	it("reads the persisted on state and re-applies it after a style load", () => {
+		localStorage.setItem("btcmap:heatmap-layer", "true");
+		const fake = makeFakeMap(10);
+		const pin = makeSource();
+		pin.refreshHeatmapAfterStyle(fake.map);
+		const heatmapVis = fake.layoutCalls.find(([l]) => l === "place-heatmap");
+		expect(heatmapVis?.[2]).toBe("visible");
+	});
+});

--- a/src/lib/map/placePinSource.ts
+++ b/src/lib/map/placePinSource.ts
@@ -1,0 +1,779 @@
+import type { GeoJSONSource, Map as MapLibreMap } from "maplibre-gl";
+
+import { CLUSTERING_DISABLED_ZOOM, LABEL_VISIBLE_ZOOM } from "$lib/constants";
+import {
+	routePlacesByBoostAndZoom,
+	shouldClusterBoostedAtZoom,
+} from "$lib/map/boostedClustering";
+import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
+import { ensureSpritesForPlaces, loadSvgImage } from "$lib/map/maplibreSprites";
+import type { Place } from "$lib/types";
+import { isBoosted } from "$lib/utils";
+
+export type PlaceFeature = {
+	type: "Feature";
+	geometry: { type: "Point"; coordinates: [number, number] };
+	properties: {
+		id: number;
+		boosted: boolean;
+		icon: string;
+		comments: number;
+		saved: boolean;
+		name: string;
+	};
+};
+
+export type PlaceFeatureCollection = {
+	type: "FeatureCollection";
+	features: PlaceFeature[];
+};
+
+const EMPTY_COLLECTION: PlaceFeatureCollection = {
+	type: "FeatureCollection",
+	features: [],
+};
+
+// The custom sources + layers this module adds on top of whatever basemap is
+// active. The /map page's applyBasemap() carries these across a setStyle() so
+// the pins, clusters, and labels survive a basemap/theme swap untouched
+// (MapLibre's style differ leaves byte-identical layers in place — only the
+// basemap layers below them get swapped).
+export const CUSTOM_SOURCE_IDS = ["places", "places-boosted", "places-heatmap"];
+export const CUSTOM_LAYER_IDS = [
+	"place-heatmap",
+	"clusters-outer",
+	"clusters-inner",
+	"cluster-count",
+	"unclustered-point",
+	"boosted-point",
+	"comment-badge",
+	"comment-badge-count",
+	"saved-badge",
+	"place-label",
+	"boosted-comment-badge",
+	"boosted-comment-badge-count",
+	"boosted-saved-badge",
+	"boosted-place-label",
+	"clusters-hit",
+];
+// All point/cluster/badge/label layers that the heatmap conceals while
+// active below CLUSTERING_DISABLED_ZOOM (17).  At zoom 17+ the heatmap
+// layer naturally disappears (its maxzoom), so these layers are revealed
+// again without the user having to toggle heatmap off.
+const HEATMAP_HIDDEN_LAYER_IDS = [
+	"clusters-outer",
+	"clusters-inner",
+	"cluster-count",
+	"clusters-hit",
+	"unclustered-point",
+	"boosted-point",
+	"comment-badge",
+	"comment-badge-count",
+	"saved-badge",
+	"place-label",
+	"boosted-comment-badge",
+	"boosted-comment-badge-count",
+	"boosted-saved-badge",
+	"boosted-place-label",
+];
+
+// Tailwind `text-link` color (tailwind.config.js → colors.link).
+const LINK_COLOR = "#0099AF";
+
+// Composite saved-badge SVG. Outer SVG is rasterized at 2× its declared
+// dimensions (viewBox stays the same) and registered with pixelRatio: 2
+// so it draws crisp at the same logical 16×16 — same trick as
+// PIN_RENDER_SCALE for the main pin sprite.
+const SAVED_BADGE_SCALE = 2;
+const buildSavedBadgeSvg = (bookmarkSvg: string): string => {
+	const w = 16 * SAVED_BADGE_SCALE;
+	const h = 16 * SAVED_BADGE_SCALE;
+	return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" fill="#fff" stroke="${LINK_COLOR}" stroke-width="1"/><g transform="translate(3, 3)">${bookmarkSvg}</g></svg>`;
+};
+
+// Near-invisible circular hit-target sprite used as the icon for the
+// symbol cluster layer that spiderfy hooks into. The visible cluster discs
+// render as circle layers (not symbols), so this symbol layer exists purely
+// so the spiderfy library can register click handlers targeting it. 1/255
+// alpha keeps pixels effectively invisible while ensuring
+// queryRenderedFeatures registers hits on the icon footprint.
+const loadClusterHitSprite = async (m: MapLibreMap): Promise<void> => {
+	if (m.hasImage("cluster-hit")) return;
+	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="rgba(0,0,0,0.004)"/></svg>`;
+	const img = await loadSvgImage(svg);
+	if (!m.hasImage("cluster-hit"))
+		m.addImage("cluster-hit", img, { pixelRatio: 1 });
+};
+
+// 16×16 green disc to back the comment count text. Matches /map's
+// Tailwind `bg-green-600 w-4 h-4 rounded-full` exactly. Drawn directly
+// on a canvas — simpler than the SVG → data-URL → <img> roundtrip for
+// a flat shape.
+const loadCommentBadgeSprite = (m: MapLibreMap): void => {
+	if (m.hasImage("comment-badge-bg")) return;
+	// Draw at 2× the logical 16×16 (= 32×32 backing canvas) and register
+	// with pixelRatio: 2 so MapLibre displays at the same logical size
+	// but reads from a higher-density bitmap — keeps the green disc
+	// crisp on retina/phone DPRs instead of upscaling 16×16 bitmap pixels.
+	const SIZE = 16;
+	const SCALE = 2;
+	const canvas = document.createElement("canvas");
+	canvas.width = SIZE * SCALE;
+	canvas.height = SIZE * SCALE;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return;
+	ctx.fillStyle = "#16A34A";
+	ctx.beginPath();
+	ctx.arc(
+		(SIZE * SCALE) / 2,
+		(SIZE * SCALE) / 2,
+		(SIZE * SCALE) / 2,
+		0,
+		Math.PI * 2,
+	);
+	ctx.fill();
+	m.addImage(
+		"comment-badge-bg",
+		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
+		{ pixelRatio: SCALE },
+	);
+};
+
+const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
+	if (m.hasImage("saved-badge")) return;
+	const encodedColor = encodeURIComponent(LINK_COLOR);
+	const url = `https://api.iconify.design/ic/baseline-bookmark-added.svg?color=${encodedColor}&width=10&height=10`;
+	const res = await fetch(url);
+	if (!res.ok) {
+		throw new Error(`saved-badge bookmark fetch failed: ${res.status} ${url}`);
+	}
+	const bookmarkSvg = await res.text();
+	const composite = buildSavedBadgeSvg(bookmarkSvg);
+	const img = await loadSvgImage(composite);
+	if (!m.hasImage("saved-badge"))
+		m.addImage("saved-badge", img, { pixelRatio: SAVED_BADGE_SCALE });
+	m.triggerRepaint();
+};
+
+export type PlacePinSourceDeps = {
+	// Snapshots read once per feature-collection build — saved state and
+	// enriched names arrive lazily and are re-read on every render.
+	getSavedIds: () => Set<number>;
+	getEnrichedCache: () => Map<number, Place>;
+	getDisplayLang: () => string;
+	// Fired after each render with the rendered count. The /map page uses it
+	// for the loading-screen gate and the e2e __mapPlacesCount hook.
+	onRendered?: (count: number) => void;
+};
+
+export type PlacePinSource = ReturnType<typeof createPlacePinSource>;
+
+// The pin/cluster/badge/label/heatmap rendering facade for the main /map.
+// Owns: the three GeoJSON sources and fifteen layers, the badge sprites, the
+// Place → feature-collection build (with lazy name resolution), the
+// boosted-routing render path, the zoom-boundary re-sync, and heatmap
+// visibility. Does NOT own: interactions, spiderfy, camera, label palette,
+// or any visibility policy — callers must pass the already-filtered list
+// (selectVisiblePlaces upstream) and render() renders exactly what it gets.
+export const createPlacePinSource = (deps: PlacePinSourceDeps) => {
+	// Last place list fed to the sources, kept so the boosted-clustering
+	// boundary re-sync (on zoom crossing BOOSTED_CLUSTERING_MAX_ZOOM) can
+	// rebuild without a $places change. `boostedAreClustered` mirrors the
+	// routing decision of the most recent render so the moveend handler only
+	// re-syncs when it actually flips.
+	let lastSyncedList: Place[] = [];
+	let boostedAreClustered = false;
+
+	// Merchant-density heatmap on/off. Off by default unless the user
+	// previously enabled it (persisted in localStorage by the toggle control).
+	let heatmapEnabled = false;
+	if (typeof window !== "undefined") {
+		try {
+			heatmapEnabled = localStorage.getItem(HEATMAP_STORAGE_KEY) === "true";
+		} catch {
+			// localStorage may be unavailable (private mode)
+		}
+	}
+
+	const buildFeatureCollection = (list: Place[]): PlaceFeatureCollection => {
+		const saved = deps.getSavedIds();
+		// Snapshot the enriched cache once per build — names arrive lazily as
+		// the viewport-bound /v4/places/search fetch resolves.
+		const enrichedCache = deps.getEnrichedCache();
+		const displayLang = deps.getDisplayLang();
+		const resolveName = (p: Place): string => {
+			const enriched = enrichedCache.get(p.id);
+			// Priority: enriched localized name → enriched plain name →
+			// $places localized name → $places plain name → OSM amenity fallback.
+			return (
+				enriched?.localized_name?.[displayLang] ??
+				enriched?.name ??
+				p.localized_name?.[displayLang] ??
+				p.name ??
+				p["osm:amenity"] ??
+				""
+			);
+		};
+		return {
+			type: "FeatureCollection",
+			features: list.map((p) => ({
+				type: "Feature",
+				geometry: { type: "Point", coordinates: [p.lon, p.lat] },
+				properties: {
+					id: p.id,
+					// Per-place so a boosted marker folded into the clustered source
+					// at low zoom still renders its orange pin when it sits
+					// unclustered.
+					boosted: !!isBoosted(p),
+					icon: p.icon ?? "question_mark",
+					comments: p.comments ?? 0,
+					saved: saved.has(p.id),
+					name: resolveName(p),
+				},
+			})),
+		};
+	};
+
+	// Badge + cluster-hit sprites. The saved-badge fetch goes to a
+	// third-party CDN and must NOT block or fail map init — a transient
+	// Iconify outage just degrades the saved-state badge. All loaders are
+	// hasImage-guarded, so re-running after a basemap swap is a cheap no-op
+	// on the normal (style-diff) path.
+	const loadSprites = async (map: MapLibreMap): Promise<void> => {
+		await Promise.all([
+			loadSavedBadgeSprite(map).catch((err) => {
+				console.warn("Saved-badge sprite failed to load:", err);
+			}),
+			loadCommentBadgeSprite(map),
+			loadClusterHitSprite(map).catch((err) => {
+				console.warn("Cluster-hit sprite failed to load:", err);
+			}),
+		]);
+	};
+
+	const install = (map: MapLibreMap): void => {
+		map.addSource("places", {
+			type: "geojson",
+			data: EMPTY_COLLECTION,
+			cluster: true,
+			clusterRadius: 80,
+			// CLUSTERING_DISABLED_ZOOM is 17; clusterMaxZoom=16 means at z17+ all points unclustered.
+			clusterMaxZoom: CLUSTERING_DISABLED_ZOOM - 1,
+		});
+
+		// Separate non-clustered source for boosted places. Above
+		// BOOSTED_CLUSTERING_MAX_ZOOM, render() routes boosted features here so
+		// they stay visually prominent above cluster discs and never get
+		// absorbed into a cluster icon. At/below that zoom they're routed into
+		// the clustered `places` source instead (see $lib/map/boostedClustering)
+		// — the MapLibre analogue of the legacy /map's dedicated boostedLayer +
+		// BOOSTED_CLUSTERING_MAX_ZOOM swap.
+		map.addSource("places-boosted", {
+			type: "geojson",
+			data: EMPTY_COLLECTION,
+		});
+
+		// Non-clustered source backing the merchant-density heatmap.
+		// Heatmap layers read raw point features, so they can't share the
+		// clustered `places` source — this dedicated source always carries
+		// the full unclustered list (see render). Visibility is toggled via
+		// the tools panel; off by default.
+		map.addSource("places-heatmap", {
+			type: "geojson",
+			data: EMPTY_COLLECTION,
+		});
+
+		// Merchant-density heatmap. Weight is uniform (1) so the gradient
+		// reflects pure point density. Radius and intensity scale up with
+		// zoom so the halo widens as you zoom out to a city/region view and
+		// tightens as pins take over. Opacity stays at full strength through
+		// zoom 14 and fades to zero from zoom 14→17 so the heatmap hands off
+		// cleanly to the individual pins at CLUSTERING_DISABLED_ZOOM.
+		map.addLayer({
+			id: "place-heatmap",
+			type: "heatmap",
+			source: "places-heatmap",
+			maxzoom: CLUSTERING_DISABLED_ZOOM,
+			layout: { visibility: "none" },
+			paint: {
+				"heatmap-weight": 1,
+				"heatmap-intensity": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					0,
+					0.5,
+					CLUSTERING_DISABLED_ZOOM,
+					3,
+				],
+				"heatmap-color": [
+					"interpolate",
+					["linear"],
+					["heatmap-density"],
+					0,
+					"rgba(0, 0, 255, 0)",
+					0.2,
+					"#67e8f9", // cyan-300
+					0.4,
+					"#22d3ee", // cyan-400
+					0.6,
+					"#facc15", // yellow-400
+					0.8,
+					"#facc15", // yellow-400 — yellow holds longer
+					1.0,
+					"#f97316", // orange-500
+					1.2,
+					"#ea580c", // orange-600
+					1.5,
+					"#dc2626", // red-600 — red only at extreme density
+				],
+				"heatmap-radius": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					0,
+					3,
+					CLUSTERING_DISABLED_ZOOM,
+					30,
+				],
+				"heatmap-opacity": [
+					"interpolate",
+					["linear"],
+					["zoom"],
+					14,
+					0.9,
+					CLUSTERING_DISABLED_ZOOM,
+					0,
+				],
+			},
+		});
+
+		// Translucent outer ring — green/yellow/orange tiers by point_count
+		// at 0.6 alpha.
+		map.addLayer({
+			id: "clusters-outer",
+			type: "circle",
+			source: "places",
+			filter: ["has", "point_count"],
+			paint: {
+				"circle-color": [
+					"step",
+					["get", "point_count"],
+					"rgba(181, 226, 140, 0.6)",
+					10,
+					"rgba(241, 211, 87, 0.6)",
+					100,
+					"rgba(253, 156, 115, 0.6)",
+				],
+				"circle-radius": 20,
+			},
+		});
+
+		map.addLayer({
+			id: "clusters-inner",
+			type: "circle",
+			source: "places",
+			filter: ["has", "point_count"],
+			paint: {
+				"circle-color": [
+					"step",
+					["get", "point_count"],
+					"rgba(110, 204, 57, 0.6)",
+					10,
+					"rgba(240, 194, 12, 0.6)",
+					100,
+					"rgba(241, 128, 23, 0.6)",
+				],
+				"circle-radius": 15,
+			},
+		});
+
+		map.addLayer({
+			id: "cluster-count",
+			type: "symbol",
+			source: "places",
+			filter: ["has", "point_count"],
+			layout: {
+				"text-field": ["get", "point_count_abbreviated"],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 12,
+				"text-allow-overlap": true,
+				"text-ignore-placement": true,
+				// Keep count upright when the map rotates.
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+			},
+			paint: {
+				"text-color": "#000",
+			},
+		});
+
+		// Symbol layer for unclustered points; boosted places use the orange
+		// pin. Drawn last so pins sit on top of cluster discs at boundaries.
+		map.addLayer({
+			id: "unclustered-point",
+			type: "symbol",
+			source: "places",
+			filter: ["!", ["has", "point_count"]],
+			layout: {
+				// Look up composite sprite (pin shape + baked category icon).
+				// Until the icon's sprite finishes loading, MapLibre logs a
+				// warning and skips the symbol; pins appear as their composite
+				// sprites resolve.
+				"icon-image": [
+					"concat",
+					"pin-",
+					["case", ["coalesce", ["get", "boosted"], false], "b", "r"],
+					"-",
+					["coalesce", ["get", "icon"], "question_mark"],
+				],
+				"icon-size": 1,
+				"icon-anchor": "bottom",
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				// Keep pins upright as the map rotates/pitches.
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		// Boosted pins — drawn from the separate non-clustered source on top
+		// of cluster discs so a paid boost is always visually prominent.
+		map.addLayer({
+			id: "boosted-point",
+			type: "symbol",
+			source: "places-boosted",
+			layout: {
+				"icon-image": [
+					"concat",
+					"pin-b-",
+					["coalesce", ["get", "icon"], "question_mark"],
+				],
+				"icon-size": 1,
+				"icon-anchor": "bottom",
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		// Comment count badge — fixed 16×16 green disc rendered as a
+		// dedicated icon symbol layer. Two layers (disc + text) instead of
+		// one composite symbol so positioning stays simple — both share the
+		// same offset from the pin anchor.
+		// Pin is 32×43, icon-anchor: bottom. Top-right of the pin head is
+		// ~(+10, -36) px from the geographic anchor.
+		map.addLayer({
+			id: "comment-badge",
+			type: "symbol",
+			source: "places",
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				[">", ["get", "comments"], 0],
+			],
+			layout: {
+				"icon-image": "comment-badge-bg",
+				"icon-size": 1,
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+				"icon-offset": [10, -36],
+			},
+		});
+
+		map.addLayer({
+			id: "comment-badge-count",
+			type: "symbol",
+			source: "places",
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				[">", ["get", "comments"], 0],
+			],
+			layout: {
+				"text-field": ["to-string", ["get", "comments"]],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 11,
+				"text-allow-overlap": true,
+				"text-ignore-placement": true,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+				// text-offset is in ems; mirror the disc's pixel offset above.
+				"text-offset": [10 / 11, -36 / 11],
+			},
+			paint: {
+				"text-color": "#fff",
+			},
+		});
+
+		// Saved badge — white disc with bookmark glyph on the pin's
+		// top-left corner. Filter only fires when the feature's `saved`
+		// flag is true (recomputed when $savedPlaceIds size changes).
+		map.addLayer({
+			id: "saved-badge",
+			type: "symbol",
+			source: "places",
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				["==", ["get", "saved"], true],
+			],
+			layout: {
+				"icon-image": "saved-badge",
+				"icon-size": 1,
+				"icon-anchor": "center",
+				// Top-left of the pin head, relative to the bottom-anchored pin.
+				"icon-offset": [-12, -38],
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		// Place name labels — visible at high zoom once the enriched-details
+		// fetch has populated each place's name. Drawn before clusters-hit so
+		// the spiderfy hit-target stays on top for click routing. Colors are
+		// the light palette; the page's applyLabelPalette re-colors for the
+		// active theme right after install.
+		map.addLayer({
+			id: "place-label",
+			type: "symbol",
+			source: "places",
+			minzoom: LABEL_VISIBLE_ZOOM,
+			filter: [
+				"all",
+				["!", ["has", "point_count"]],
+				["!=", ["get", "name"], ""],
+			],
+			layout: {
+				"text-field": ["get", "name"],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 14,
+				"text-anchor": "left",
+				// text-offset is in ems. Pin's right edge sits at ~+16 px from
+				// the geographic anchor (icon-anchor: bottom). Start the label
+				// 6 px past that, vertically centered on the pin head (~ -25 px).
+				"text-offset": [22 / 14, -25 / 14],
+				"text-max-width": 12,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+			},
+			paint: {
+				"text-color": [
+					"case",
+					["get", "boosted"],
+					"#f97316", // orange-500 (boosted)
+					"#0e7490", // cyan-700 (regular)
+				],
+				"text-halo-color": "#fff",
+				"text-halo-width": 1.2,
+				"text-halo-blur": 0,
+			},
+		});
+
+		// Mirrors of comment-badge / comment-badge-count / saved-badge /
+		// place-label for the parallel `places-boosted` source. Without
+		// these a boosted merchant with comments / saved state / a
+		// resolved label rendered as a bare orange pin.
+		map.addLayer({
+			id: "boosted-comment-badge",
+			type: "symbol",
+			source: "places-boosted",
+			filter: [">", ["get", "comments"], 0],
+			layout: {
+				"icon-image": "comment-badge-bg",
+				"icon-size": 1,
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+				"icon-offset": [10, -36],
+			},
+		});
+
+		map.addLayer({
+			id: "boosted-comment-badge-count",
+			type: "symbol",
+			source: "places-boosted",
+			filter: [">", ["get", "comments"], 0],
+			layout: {
+				"text-field": ["to-string", ["get", "comments"]],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 11,
+				"text-allow-overlap": true,
+				"text-ignore-placement": true,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+				"text-offset": [10 / 11, -36 / 11],
+			},
+			paint: {
+				"text-color": "#fff",
+			},
+		});
+
+		map.addLayer({
+			id: "boosted-saved-badge",
+			type: "symbol",
+			source: "places-boosted",
+			filter: ["==", ["get", "saved"], true],
+			layout: {
+				"icon-image": "saved-badge",
+				"icon-size": 1,
+				"icon-anchor": "center",
+				"icon-offset": [-12, -38],
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+				"icon-rotation-alignment": "viewport",
+				"icon-pitch-alignment": "viewport",
+			},
+		});
+
+		map.addLayer({
+			id: "boosted-place-label",
+			type: "symbol",
+			source: "places-boosted",
+			minzoom: LABEL_VISIBLE_ZOOM,
+			filter: ["!=", ["get", "name"], ""],
+			layout: {
+				"text-field": ["get", "name"],
+				"text-font": ["Noto Sans Bold"],
+				"text-size": 14,
+				"text-anchor": "left",
+				"text-offset": [22 / 14, -25 / 14],
+				"text-max-width": 12,
+				"text-rotation-alignment": "viewport",
+				"text-pitch-alignment": "viewport",
+			},
+			paint: {
+				"text-color": "#f97316", // orange-500 (always boosted on this source)
+				"text-halo-color": "#fff",
+				"text-halo-width": 1.2,
+				"text-halo-blur": 0,
+			},
+		});
+
+		// Symbol cluster layer used by spiderfy. Hit-testing on this layer's
+		// near-invisible icon picks up the cluster_id property and routes
+		// through the library, which auto-decides between zoom-on-click and
+		// spiderfying based on getClusterExpansionZoom vs maxZoom.
+		map.addLayer({
+			id: "clusters-hit",
+			type: "symbol",
+			source: "places",
+			filter: ["has", "point_count"],
+			layout: {
+				"icon-image": "cluster-hit",
+				"icon-size": 1,
+				"icon-allow-overlap": true,
+				"icon-ignore-placement": true,
+			},
+		});
+	};
+
+	// Renders exactly the list it is given — all visibility policy (search,
+	// category, recency, boosts) lives upstream in selectVisiblePlaces; this
+	// function must never re-filter or accept an unfiltered list.
+	const render = (map: MapLibreMap, list: Place[]): void => {
+		const source = map.getSource("places") as GeoJSONSource | undefined;
+		const boostedSource = map.getSource("places-boosted") as
+			| GeoJSONSource
+			| undefined;
+		const heatmapSource = map.getSource("places-heatmap") as
+			| GeoJSONSource
+			| undefined;
+		if (!source || !boostedSource) return;
+		lastSyncedList = list;
+		boostedAreClustered = shouldClusterBoostedAtZoom(map.getZoom());
+		const { clustered, standalone } = routePlacesByBoostAndZoom(
+			list,
+			map.getZoom(),
+		);
+		source.setData(buildFeatureCollection(clustered));
+		boostedSource.setData(buildFeatureCollection(standalone));
+		// The heatmap reflects overall place density, so it gets the full list
+		// regardless of the boosted-clustering routing decision. Only refresh
+		// it while the layer is actually visible — when off (the default) we
+		// skip the full-list feature-collection build entirely and repopulate
+		// from lastSyncedList on enable (see setHeatmapEnabled).
+		if (heatmapSource && heatmapEnabled) {
+			heatmapSource.setData(buildFeatureCollection(list));
+		}
+		ensureSpritesForPlaces(map, list);
+		deps.onRendered?.(list.length);
+	};
+
+	// Re-route boosted places when zoom crosses BOOSTED_CLUSTERING_MAX_ZOOM —
+	// the MapLibre analogue of the legacy boostedLayer swap. Only re-renders
+	// on an actual flip, so steady-state pans stay cheap.
+	const resyncForZoom = (map: MapLibreMap): void => {
+		if (shouldClusterBoostedAtZoom(map.getZoom()) !== boostedAreClustered) {
+			render(map, lastSyncedList);
+		}
+	};
+
+	const applyHeatmapVisibility = (map: MapLibreMap): void => {
+		const zoom = map.getZoom();
+		// Heatmap layer: visible when enabled regardless of zoom (the layer
+		// itself has maxzoom: CLUSTERING_DISABLED_ZOOM, so it won't render
+		// past that).
+		if (map.getLayer("place-heatmap")) {
+			map.setLayoutProperty(
+				"place-heatmap",
+				"visibility",
+				heatmapEnabled ? "visible" : "none",
+			);
+		}
+		// Conceal all point/cluster/badge/label layers while the heatmap is
+		// visible.  Pins re-appear before the heatmap fully fades out
+		// (zoom 15.5, ~45 % opacity) so individual pins show through the
+		// still-fading heatmap — at the maxzoom boundary (17) the heatmap
+		// instantly removes itself, so waiting until then feels abrupt.
+		const PIN_REVEAL_ZOOM = CLUSTERING_DISABLED_ZOOM - 1.5;
+		const hidePins = heatmapEnabled && zoom < PIN_REVEAL_ZOOM;
+		for (const layerId of HEATMAP_HIDDEN_LAYER_IDS) {
+			if (map.getLayer(layerId)) {
+				map.setLayoutProperty(
+					layerId,
+					"visibility",
+					hidePins ? "none" : "visible",
+				);
+			}
+		}
+	};
+
+	const setHeatmapEnabled = (map: MapLibreMap, enabled: boolean): void => {
+		heatmapEnabled = enabled;
+		// render() skips the heatmap source while it's hidden, so seed it from
+		// the last synced list on enable — otherwise it would stay blank until
+		// the next data sync.
+		if (enabled) {
+			const heatmapSource = map.getSource("places-heatmap") as
+				| GeoJSONSource
+				| undefined;
+			heatmapSource?.setData(buildFeatureCollection(lastSyncedList));
+		}
+		applyHeatmapVisibility(map);
+	};
+
+	// Re-apply the current heatmap on/off state after a style (re)load —
+	// the persisted state can't be applied before the layer exists, and a
+	// basemap swap that fell back to a full style rebuild resets carried
+	// layout properties.
+	const refreshHeatmapAfterStyle = (map: MapLibreMap): void => {
+		setHeatmapEnabled(map, heatmapEnabled);
+	};
+
+	return {
+		loadSprites,
+		install,
+		render,
+		resyncForZoom,
+		applyHeatmapVisibility,
+		setHeatmapEnabled,
+		refreshHeatmapAfterStyle,
+	};
+};

--- a/src/lib/map/placePinSource.ts
+++ b/src/lib/map/placePinSource.ts
@@ -38,8 +38,12 @@ const EMPTY_COLLECTION: PlaceFeatureCollection = {
 // the pins, clusters, and labels survive a basemap/theme swap untouched
 // (MapLibre's style differ leaves byte-identical layers in place — only the
 // basemap layers below them get swapped).
-export const CUSTOM_SOURCE_IDS = ["places", "places-boosted", "places-heatmap"];
-export const CUSTOM_LAYER_IDS = [
+export const CUSTOM_SOURCE_IDS: readonly string[] = [
+	"places",
+	"places-boosted",
+	"places-heatmap",
+];
+export const CUSTOM_LAYER_IDS: readonly string[] = [
 	"place-heatmap",
 	"clusters-outer",
 	"clusters-inner",

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -4,7 +4,6 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import Spiderfy from "@nazka/map-gl-js-spiderfy";
 import type {
 	FilterSpecification,
-	GeoJSONSource,
 	LngLatBounds,
 	MapGeoJSONFeature,
 	MapLayerMouseEvent,

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -40,11 +40,7 @@ import {
 	SUPPORT_ATTR,
 	styleForBasemap,
 } from "$lib/map/basemaps";
-import {
-	routePlacesByBoostAndZoom,
-	shouldClusterBoostedAtZoom,
-} from "$lib/map/boostedClustering";
-import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
+import { shouldClusterBoostedAtZoom } from "$lib/map/boostedClustering";
 import {
 	type HashCoords,
 	parseHashCoords,
@@ -53,10 +49,14 @@ import {
 import {
 	ensureSpritesForPlaces,
 	installPlaceholderHandler,
-	loadSvgImage,
 	PIN_FILL_BOOSTED,
 	PIN_FILL_REGULAR,
 } from "$lib/map/maplibreSprites";
+import {
+	CUSTOM_LAYER_IDS,
+	CUSTOM_SOURCE_IDS,
+	createPlacePinSource,
+} from "$lib/map/placePinSource";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
 import { ensureRtlTextPlugin } from "$lib/map/rtl";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
@@ -128,24 +128,6 @@ if (outdatedOnly) {
 	merchantList.setVerifiedFilter("outdated", { persist: false });
 }
 
-type PlaceFeature = {
-	type: "Feature";
-	geometry: { type: "Point"; coordinates: [number, number] };
-	properties: {
-		id: number;
-		boosted: boolean;
-		icon: string;
-		comments: number;
-		saved: boolean;
-		name: string;
-	};
-};
-
-type PlaceFeatureCollection = {
-	type: "FeatureCollection";
-	features: PlaceFeature[];
-};
-
 let mapContainer: HTMLDivElement;
 let map: MapLibreMap | undefined;
 let destroyed = false;
@@ -159,12 +141,26 @@ let lastAppliedLabelTheme: "light" | "dark" | undefined;
 // size, enriched-cache size, locale). Empty string forces a sync.
 let lastRenderSig = "";
 
-// Last place list fed to the sources, kept so the boosted-clustering boundary
-// re-sync (on zoom crossing BOOSTED_CLUSTERING_MAX_ZOOM) can rebuild without a
-// $places change. `boostedAreClustered` mirrors the routing decision of the
-// most recent sync so the moveend handler only re-syncs when it actually flips.
-let lastSyncedList: Place[] = [];
-let boostedAreClustered = false;
+// The pin/cluster/badge/label/heatmap rendering facade (#1170). Owns the
+// sources, layers, sprites, feature building, boosted routing, and heatmap
+// visibility; this page keeps interactions, spiderfy, camera, and the label
+// palette. The deps are read as snapshots on every render — saved state and
+// enriched names arrive lazily.
+const pinSource = createPlacePinSource({
+	getSavedIds: () => get(savedPlaceIds),
+	getEnrichedCache: () => get(merchantList).placeDetailsCache,
+	getDisplayLang: () => getDisplayLang(get(locale)),
+	onRendered: (count) => {
+		if (count > 0) elementsLoaded = true;
+		// E2E test hook: Playwright can't probe WebGL canvas pins like it
+		// could probe Leaflet's DOM markers, so we expose the count for
+		// `waitForMarkersToLoad` to gate on. No-op outside tests.
+		if (typeof window !== "undefined") {
+			(window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount =
+				count;
+		}
+	},
+});
 
 // Place-label colors. MapLibre paint expressions can't read CSS custom
 // properties, so the values are inlined here.
@@ -687,173 +683,12 @@ const handleHashChange = () => {
 	merchantDrawer.syncFromHash();
 };
 
-const EMPTY_COLLECTION: PlaceFeatureCollection = {
-	type: "FeatureCollection",
-	features: [],
-};
-
-// Boosted places ride a separate non-clustered source so they stay
-// individually visible above cluster discs — but only above
-// BOOSTED_CLUSTERING_MAX_ZOOM. At/below it they fold into the clustered
-// `places` source (matching the legacy /map's dedicated boostedLayer +
-// BOOSTED_CLUSTERING_MAX_ZOOM behavior) so the zoomed-out world view isn't
-// littered with overlapping orange pins. Routing lives in
-// $lib/map/boostedClustering; see syncPlacesToSource for the wiring.
-
-const buildFeatureCollectionFor = (list: Place[]): PlaceFeatureCollection => {
-	const saved = get(savedPlaceIds);
-	// Snapshot the enriched cache once per build — names arrive lazily as
-	// the viewport-bound /v4/places/search fetch resolves.
-	const enrichedCache = get(merchantList).placeDetailsCache;
-	const displayLang = getDisplayLang(get(locale));
-	const resolveName = (p: Place): string => {
-		const enriched = enrichedCache.get(p.id);
-		// Priority: enriched localized name → enriched plain name →
-		// $places localized name → $places plain name → OSM amenity fallback.
-		return (
-			enriched?.localized_name?.[displayLang] ??
-			enriched?.name ??
-			p.localized_name?.[displayLang] ??
-			p.name ??
-			p["osm:amenity"] ??
-			""
-		);
-	};
-	return {
-		type: "FeatureCollection",
-		features: list.map((p) => ({
-			type: "Feature",
-			geometry: { type: "Point", coordinates: [p.lon, p.lat] },
-			properties: {
-				id: p.id,
-				// Per-place so a boosted marker folded into the clustered source at
-				// low zoom still renders its orange pin when it sits unclustered.
-				boosted: !!isBoosted(p),
-				icon: p.icon ?? "question_mark",
-				comments: p.comments ?? 0,
-				saved: saved.has(p.id),
-				name: resolveName(p),
-			},
-		})),
-	};
-};
-
-// Tailwind `text-link` color (tailwind.config.js → colors.link).
-const LINK_COLOR = "#0099AF";
-
-// Composite saved-badge SVG. Outer SVG is rasterized at 2× its declared
-// dimensions (viewBox stays the same) and registered with pixelRatio: 2
-// so it draws crisp at the same logical 16×16 — same trick as
-// PIN_RENDER_SCALE for the main pin sprite.
-const SAVED_BADGE_SCALE = 2;
-const buildSavedBadgeSvg = (bookmarkSvg: string): string => {
-	const w = 16 * SAVED_BADGE_SCALE;
-	const h = 16 * SAVED_BADGE_SCALE;
-	return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 16 16"><circle cx="8" cy="8" r="7" fill="#fff" stroke="${LINK_COLOR}" stroke-width="1"/><g transform="translate(3, 3)">${bookmarkSvg}</g></svg>`;
-};
-
-// Near-invisible circular hit-target sprite used as the icon for the
-// symbol cluster layer that spiderfy hooks into. We render the visible
-// cluster discs as circle layers (not symbols), so this symbol layer
-// exists purely so the spiderfy library can register click handlers
-// targeting it. 1/255 alpha keeps pixels effectively invisible while
-// ensuring queryRenderedFeatures registers hits on the icon footprint.
-const loadClusterHitSprite = async (m: MapLibreMap): Promise<void> => {
-	if (m.hasImage("cluster-hit")) return;
-	const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40"><circle cx="20" cy="20" r="20" fill="rgba(0,0,0,0.004)"/></svg>`;
-	const img = await loadSvgImage(svg);
-	if (!m.hasImage("cluster-hit"))
-		m.addImage("cluster-hit", img, { pixelRatio: 1 });
-};
-
-// 16×16 green disc to back the comment count text. Matches /map's
-// Tailwind `bg-green-600 w-4 h-4 rounded-full` exactly. Drawn directly
-// on a canvas — simpler than the SVG → data-URL → <img> roundtrip for
-// a flat shape.
-const loadCommentBadgeSprite = (m: MapLibreMap): void => {
-	if (m.hasImage("comment-badge-bg")) return;
-	// Draw at 2× the logical 16×16 (= 32×32 backing canvas) and register
-	// with pixelRatio: 2 so MapLibre displays at the same logical size
-	// but reads from a higher-density bitmap — keeps the green disc
-	// crisp on retina/phone DPRs instead of upscaling 16×16 bitmap pixels.
-	const SIZE = 16;
-	const SCALE = 2;
-	const canvas = document.createElement("canvas");
-	canvas.width = SIZE * SCALE;
-	canvas.height = SIZE * SCALE;
-	const ctx = canvas.getContext("2d");
-	if (!ctx) return;
-	ctx.fillStyle = "#16A34A";
-	ctx.beginPath();
-	ctx.arc(
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		0,
-		Math.PI * 2,
-	);
-	ctx.fill();
-	m.addImage(
-		"comment-badge-bg",
-		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
-		{ pixelRatio: SCALE },
-	);
-};
-
-const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
-	if (m.hasImage("saved-badge")) return;
-	const encodedColor = encodeURIComponent(LINK_COLOR);
-	const url = `https://api.iconify.design/ic/baseline-bookmark-added.svg?color=${encodedColor}&width=10&height=10`;
-	const res = await fetch(url);
-	if (!res.ok) {
-		throw new Error(`saved-badge bookmark fetch failed: ${res.status} ${url}`);
-	}
-	const bookmarkSvg = await res.text();
-	const composite = buildSavedBadgeSvg(bookmarkSvg);
-	const img = await loadSvgImage(composite);
-	if (!m.hasImage("saved-badge"))
-		m.addImage("saved-badge", img, { pixelRatio: SAVED_BADGE_SCALE });
-	m.triggerRepaint();
-};
-
 // Renders exactly the list it is given — all visibility policy (search,
-// category, recency, boosts) lives upstream in selectVisiblePlaces; this
-// function must never re-filter or accept an unfiltered list.
+// category, recency, boosts) lives upstream in selectVisiblePlaces; the
+// facade must never receive an unfiltered list.
 const syncPlacesToSource = (list: Place[]) => {
 	if (!map || !styleLoaded) return;
-	const source = map.getSource("places") as GeoJSONSource | undefined;
-	const boostedSource = map.getSource("places-boosted") as
-		| GeoJSONSource
-		| undefined;
-	const heatmapSource = map.getSource("places-heatmap") as
-		| GeoJSONSource
-		| undefined;
-	if (!source || !boostedSource) return;
-	lastSyncedList = list;
-	boostedAreClustered = shouldClusterBoostedAtZoom(map.getZoom());
-	const { clustered, standalone } = routePlacesByBoostAndZoom(
-		list,
-		map.getZoom(),
-	);
-	source.setData(buildFeatureCollectionFor(clustered));
-	boostedSource.setData(buildFeatureCollectionFor(standalone));
-	// The heatmap reflects overall place density, so it gets the full list
-	// regardless of the boosted-clustering routing decision. Only refresh it
-	// while the layer is actually visible — when off (the default) we skip
-	// the full-list feature-collection build entirely and repopulate from
-	// lastSyncedList on enable (see setHeatmapEnabled).
-	if (heatmapSource && heatmapEnabled) {
-		heatmapSource.setData(buildFeatureCollectionFor(list));
-	}
-	ensureSpritesForPlaces(map, list);
-	if (list.length > 0) elementsLoaded = true;
-	// E2E test hook: Playwright can't probe WebGL canvas pins like it
-	// could probe Leaflet's DOM markers, so we expose the count for
-	// `waitForMarkersToLoad` to gate on. No-op outside tests.
-	if (typeof window !== "undefined") {
-		(window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount =
-			list.length;
-	}
+	pinSource.render(map, list);
 };
 
 // Debounced enrichment trigger — fires on moveend when zoomed in enough
@@ -959,105 +794,11 @@ $: if (
 	void ensureVerifiedDates().then(() => updateMerchantList({ force: true }));
 }
 
-// The custom sources + layers we add on top of whatever basemap is
-// active. applyBasemap() carries these across a setStyle() so the pins,
-// clusters, and labels survive a basemap/theme swap untouched (MapLibre's
-// style differ leaves byte-identical layers in place — only the basemap
-// layers below them get swapped).
-const CUSTOM_SOURCE_IDS = ["places", "places-boosted", "places-heatmap"];
-const CUSTOM_LAYER_IDS = [
-	"place-heatmap",
-	"clusters-outer",
-	"clusters-inner",
-	"cluster-count",
-	"unclustered-point",
-	"boosted-point",
-	"comment-badge",
-	"comment-badge-count",
-	"saved-badge",
-	"place-label",
-	"boosted-comment-badge",
-	"boosted-comment-badge-count",
-	"boosted-saved-badge",
-	"boosted-place-label",
-	"clusters-hit",
-];
-// All point/cluster/badge/label layers that the heatmap conceals while
-// active below CLUSTERING_DISABLED_ZOOM (17).  At zoom 17+ the heatmap
-// layer naturally disappears (its maxzoom), so these layers are revealed
-// again without the user having to toggle heatmap off.
-const HEATMAP_HIDDEN_LAYER_IDS = [
-	"clusters-outer",
-	"clusters-inner",
-	"cluster-count",
-	"clusters-hit",
-	"unclustered-point",
-	"boosted-point",
-	"comment-badge",
-	"comment-badge-count",
-	"saved-badge",
-	"place-label",
-	"boosted-comment-badge",
-	"boosted-comment-badge-count",
-	"boosted-saved-badge",
-	"boosted-place-label",
-];
-
-// Toggle the merchant-density heatmap layer. Off by default unless the
-// user previously enabled it (persisted in localStorage by the control).
-let heatmapEnabled = false;
-if (typeof window !== "undefined") {
-	try {
-		heatmapEnabled = localStorage.getItem(HEATMAP_STORAGE_KEY) === "true";
-	} catch {
-		// localStorage may be unavailable (private mode)
-	}
-}
-
-const applyHeatmapVisibility = () => {
-	if (!map) return;
-	const zoom = map.getZoom();
-	// Heatmap layer: visible when enabled regardless of zoom (the layer
-	// itself has maxzoom: CLUSTERING_DISABLED_ZOOM, so it won't render
-	// past that).
-	if (map.getLayer("place-heatmap")) {
-		map.setLayoutProperty(
-			"place-heatmap",
-			"visibility",
-			heatmapEnabled ? "visible" : "none",
-		);
-	}
-	// Conceal all point/cluster/badge/label layers while the heatmap is
-	// visible.  Pins re-appear before the heatmap fully fades out
-	// (zoom 15.5, ~45 % opacity) so individual pins show through the
-	// still-fading heatmap — at the maxzoom boundary (17) the heatmap
-	// instantly removes itself, so waiting until then feels abrupt.
-	const PIN_REVEAL_ZOOM = CLUSTERING_DISABLED_ZOOM - 1.5;
-	const hidePins = heatmapEnabled && zoom < PIN_REVEAL_ZOOM;
-	for (const layerId of HEATMAP_HIDDEN_LAYER_IDS) {
-		if (map.getLayer(layerId)) {
-			map.setLayoutProperty(
-				layerId,
-				"visibility",
-				hidePins ? "none" : "visible",
-			);
-		}
-	}
-};
-
+// Heatmap on/off state and layer-visibility juggling live in the facade;
+// this wrapper is the shape <MapControls> expects.
 const setHeatmapEnabled = (enabled: boolean) => {
 	if (!map) return;
-	heatmapEnabled = enabled;
-	// syncPlacesToSource skips the heatmap source while it's hidden, so seed
-	// it from the last synced list on enable — otherwise it would stay blank
-	// until the next data sync.
-	if (enabled) {
-		const heatmapSource = map.getSource("places-heatmap") as
-			| GeoJSONSource
-			| undefined;
-		heatmapSource?.setData(buildFeatureCollectionFor(lastSyncedList));
-	}
-	applyHeatmapVisibility();
+	pinSource.setHeatmapEnabled(map, enabled);
 };
 
 // Switch the basemap without tearing down our pin/cluster/label layers.
@@ -1084,14 +825,12 @@ const applyBasemap = (id: BasemapId) => {
 	map.once("style.load", () => {
 		if (!map) return;
 		applyLabelPalette(map, get(theme));
-		loadClusterHitSprite(map).catch(() => {});
-		loadCommentBadgeSprite(map);
-		loadSavedBadgeSprite(map).catch(() => {});
+		pinSource.loadSprites(map);
 		ensureSpritesForPlaces(map, get(places));
 		spiderfier?.applyTo("clusters-hit");
 		// Re-apply heatmap/cluster visibility in case the style diff fell
 		// back to a full rebuild and reset carried layout properties.
-		setHeatmapEnabled(heatmapEnabled);
+		pinSource.refreshHeatmapAfterStyle(map);
 	});
 	map.setStyle(styleForBasemap(id), {
 		transformStyle: (previous, next) => {
@@ -1300,20 +1039,12 @@ onMount(async () => {
 	map.on("load", async () => {
 		if (!map || destroyed) return;
 
-		// Critical sprites must succeed; the saved-badge fetch goes to a
-		// third-party CDN and should NOT block the rest of map init if
-		// it fails. Wrap it with a catch so a transient Iconify outage
-		// just degrades the saved-state badge.
-		// The pin and pin-boosted plain sprites are NOT loaded here —
-		// every pin layer references the composite `pin-r-{icon}` /
-		// `pin-b-{icon}` names produced lazily by ensureSpritesForPlaces.
-		await Promise.all([
-			loadSavedBadgeSprite(map).catch((err) => {
-				console.warn("Saved-badge sprite failed to load:", err);
-			}),
-			loadCommentBadgeSprite(map),
-			loadClusterHitSprite(map),
-		]);
+		// The saved-badge fetch goes to a third-party CDN and must NOT block
+		// map init — the facade catches sprite failures and degrades. The pin
+		// and pin-boosted plain sprites are NOT loaded here — every pin layer
+		// references the composite `pin-r-{icon}` / `pin-b-{icon}` names
+		// produced lazily by ensureSpritesForPlaces.
+		await pinSource.loadSprites(map);
 
 		// Component may have been destroyed while sprites were loading
 		// (user navigated away within ~1s of mount). Without this check
@@ -1323,425 +1054,8 @@ onMount(async () => {
 		// destroyed instance, so a plain `!map` check doesn't catch this.
 		if (destroyed) return;
 
-		map.addSource("places", {
-			type: "geojson",
-			data: EMPTY_COLLECTION,
-			cluster: true,
-			clusterRadius: 80,
-			// CLUSTERING_DISABLED_ZOOM is 17; clusterMaxZoom=16 means at z17+ all points unclustered.
-			clusterMaxZoom: CLUSTERING_DISABLED_ZOOM - 1,
-		});
-
-		// Separate non-clustered source for boosted places. Above
-		// BOOSTED_CLUSTERING_MAX_ZOOM, syncPlacesToSource routes boosted
-		// features here so they stay visually prominent above cluster discs and
-		// never get absorbed into a cluster icon. At/below that zoom they're
-		// routed into the clustered `places` source instead (see
-		// $lib/map/boostedClustering) — the MapLibre analogue of the legacy
-		// /map's dedicated boostedLayer + BOOSTED_CLUSTERING_MAX_ZOOM swap.
-		map.addSource("places-boosted", {
-			type: "geojson",
-			data: EMPTY_COLLECTION,
-		});
-
-		// Non-clustered source backing the merchant-density heatmap.
-		// Heatmap layers read raw point features, so they can't share the
-		// clustered `places` source — this dedicated source always carries
-		// the full unclustered list (see syncPlacesToSource). Visibility is
-		// toggled via the tools panel; off by default.
-		map.addSource("places-heatmap", {
-			type: "geojson",
-			data: EMPTY_COLLECTION,
-		});
-
-		// Merchant-density heatmap. Weight is uniform (1) so the gradient
-		// reflects pure point density. Radius and intensity scale up with
-		// zoom so the halo widens as you zoom out to a city/region view and
-		// tightens as pins take over. Opacity stays at full strength through
-		// zoom 14 and fades to zero from zoom 14→17 so the heatmap hands off
-		// cleanly to the individual pins at
-		// CLUSTERING_DISABLED_ZOOM.
-		map.addLayer({
-			id: "place-heatmap",
-			type: "heatmap",
-			source: "places-heatmap",
-			maxzoom: CLUSTERING_DISABLED_ZOOM,
-			layout: { visibility: "none" },
-			paint: {
-				"heatmap-weight": 1,
-				"heatmap-intensity": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					0,
-					0.5,
-					CLUSTERING_DISABLED_ZOOM,
-					3,
-				],
-				"heatmap-color": [
-					"interpolate",
-					["linear"],
-					["heatmap-density"],
-					0,
-					"rgba(0, 0, 255, 0)",
-					0.2,
-					"#67e8f9", // cyan-300
-					0.4,
-					"#22d3ee", // cyan-400
-					0.6,
-					"#facc15", // yellow-400
-					0.8,
-					"#facc15", // yellow-400 — yellow holds longer
-					1.0,
-					"#f97316", // orange-500
-					1.2,
-					"#ea580c", // orange-600
-					1.5,
-					"#dc2626", // red-600 — red only at extreme density
-				],
-				"heatmap-radius": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					0,
-					3,
-					CLUSTERING_DISABLED_ZOOM,
-					30,
-				],
-				"heatmap-opacity": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					14,
-					0.9,
-					CLUSTERING_DISABLED_ZOOM,
-					0,
-				],
-			},
-		});
-
-		// Translucent outer ring — green/yellow/orange tiers by point_count
-		// at 0.6 alpha.
-		map.addLayer({
-			id: "clusters-outer",
-			type: "circle",
-			source: "places",
-			filter: ["has", "point_count"],
-			paint: {
-				"circle-color": [
-					"step",
-					["get", "point_count"],
-					"rgba(181, 226, 140, 0.6)",
-					10,
-					"rgba(241, 211, 87, 0.6)",
-					100,
-					"rgba(253, 156, 115, 0.6)",
-				],
-				"circle-radius": 20,
-			},
-		});
-
-		map.addLayer({
-			id: "clusters-inner",
-			type: "circle",
-			source: "places",
-			filter: ["has", "point_count"],
-			paint: {
-				"circle-color": [
-					"step",
-					["get", "point_count"],
-					"rgba(110, 204, 57, 0.6)",
-					10,
-					"rgba(240, 194, 12, 0.6)",
-					100,
-					"rgba(241, 128, 23, 0.6)",
-				],
-				"circle-radius": 15,
-			},
-		});
-
-		map.addLayer({
-			id: "cluster-count",
-			type: "symbol",
-			source: "places",
-			filter: ["has", "point_count"],
-			layout: {
-				"text-field": ["get", "point_count_abbreviated"],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 12,
-				"text-allow-overlap": true,
-				"text-ignore-placement": true,
-				// Keep count upright when the map rotates.
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-			},
-			paint: {
-				"text-color": "#000",
-			},
-		});
-
-		// Symbol layer for unclustered points; boosted places use the orange pin.
-		// Drawn last so pins sit on top of cluster discs at boundaries.
-		map.addLayer({
-			id: "unclustered-point",
-			type: "symbol",
-			source: "places",
-			filter: ["!", ["has", "point_count"]],
-			layout: {
-				// Look up composite sprite (pin shape + baked category icon). Until
-				// the icon's sprite finishes loading, MapLibre logs a warning and
-				// skips the symbol; pins appear as their composite sprites resolve.
-				"icon-image": [
-					"concat",
-					"pin-",
-					["case", ["coalesce", ["get", "boosted"], false], "b", "r"],
-					"-",
-					["coalesce", ["get", "icon"], "question_mark"],
-				],
-				"icon-size": 1,
-				"icon-anchor": "bottom",
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				// Keep pins upright as the map rotates/pitches.
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		// Boosted pins — drawn from the separate non-clustered source on top
-		// of cluster discs so a paid boost is always visually prominent.
-		map.addLayer({
-			id: "boosted-point",
-			type: "symbol",
-			source: "places-boosted",
-			layout: {
-				"icon-image": [
-					"concat",
-					"pin-b-",
-					["coalesce", ["get", "icon"], "question_mark"],
-				],
-				"icon-size": 1,
-				"icon-anchor": "bottom",
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		// Comment count badge — green disc on the pin's top-right corner.
-		// Comment count badge — fixed 16×16 green disc rendered as a
-		// dedicated icon symbol layer. Two layers (disc + text) instead of
-		// one composite symbol so positioning stays simple — both share the
-		// same offset from the pin anchor.
-		// Pin is 32×43, icon-anchor: bottom. Top-right of the pin head is
-		// ~(+10, -36) px from the geographic anchor.
-		map.addLayer({
-			id: "comment-badge",
-			type: "symbol",
-			source: "places",
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				[">", ["get", "comments"], 0],
-			],
-			layout: {
-				"icon-image": "comment-badge-bg",
-				"icon-size": 1,
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-				"icon-offset": [10, -36],
-			},
-		});
-
-		map.addLayer({
-			id: "comment-badge-count",
-			type: "symbol",
-			source: "places",
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				[">", ["get", "comments"], 0],
-			],
-			layout: {
-				"text-field": ["to-string", ["get", "comments"]],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 11,
-				"text-allow-overlap": true,
-				"text-ignore-placement": true,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-				// text-offset is in ems; mirror the disc's pixel offset above.
-				"text-offset": [10 / 11, -36 / 11],
-			},
-			paint: {
-				"text-color": "#fff",
-			},
-		});
-
-		// Saved badge — white disc with bookmark glyph on the pin's
-		// top-left corner. Filter only fires when the feature's `saved`
-		// flag is true (recomputed when $savedPlaceIds size changes).
-		map.addLayer({
-			id: "saved-badge",
-			type: "symbol",
-			source: "places",
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				["==", ["get", "saved"], true],
-			],
-			layout: {
-				"icon-image": "saved-badge",
-				"icon-size": 1,
-				"icon-anchor": "center",
-				// Top-left of the pin head, relative to the bottom-anchored pin.
-				"icon-offset": [-12, -38],
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		// Place name labels — visible at high zoom once the enriched-details
-		// fetch has populated each place's name. Drawn before clusters-hit so
-		// the spiderfy hit-target stays on top for click routing.
-		map.addLayer({
-			id: "place-label",
-			type: "symbol",
-			source: "places",
-			minzoom: LABEL_VISIBLE_ZOOM,
-			filter: [
-				"all",
-				["!", ["has", "point_count"]],
-				["!=", ["get", "name"], ""],
-			],
-			layout: {
-				"text-field": ["get", "name"],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 14,
-				"text-anchor": "left",
-				// text-offset is in ems. Pin's right edge sits at ~+16 px from
-				// the geographic anchor (icon-anchor: bottom). Start the label
-				// 6 px past that, vertically centered on the pin head (~ -25 px).
-				"text-offset": [22 / 14, -25 / 14],
-				"text-max-width": 12,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-			},
-			paint: {
-				"text-color": [
-					"case",
-					["get", "boosted"],
-					"#f97316", // orange-500 (boosted)
-					"#0e7490", // cyan-700 (regular)
-				],
-				"text-halo-color": "#fff",
-				"text-halo-width": 1.2,
-				"text-halo-blur": 0,
-			},
-		});
-
-		// Mirrors of comment-badge / comment-badge-count / saved-badge /
-		// place-label for the parallel `places-boosted` source. Without
-		// these a boosted merchant with comments / saved state / a
-		// resolved label rendered as a bare orange pin.
-		map.addLayer({
-			id: "boosted-comment-badge",
-			type: "symbol",
-			source: "places-boosted",
-			filter: [">", ["get", "comments"], 0],
-			layout: {
-				"icon-image": "comment-badge-bg",
-				"icon-size": 1,
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-				"icon-offset": [10, -36],
-			},
-		});
-
-		map.addLayer({
-			id: "boosted-comment-badge-count",
-			type: "symbol",
-			source: "places-boosted",
-			filter: [">", ["get", "comments"], 0],
-			layout: {
-				"text-field": ["to-string", ["get", "comments"]],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 11,
-				"text-allow-overlap": true,
-				"text-ignore-placement": true,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-				"text-offset": [10 / 11, -36 / 11],
-			},
-			paint: {
-				"text-color": "#fff",
-			},
-		});
-
-		map.addLayer({
-			id: "boosted-saved-badge",
-			type: "symbol",
-			source: "places-boosted",
-			filter: ["==", ["get", "saved"], true],
-			layout: {
-				"icon-image": "saved-badge",
-				"icon-size": 1,
-				"icon-anchor": "center",
-				"icon-offset": [-12, -38],
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-		});
-
-		map.addLayer({
-			id: "boosted-place-label",
-			type: "symbol",
-			source: "places-boosted",
-			minzoom: LABEL_VISIBLE_ZOOM,
-			filter: ["!=", ["get", "name"], ""],
-			layout: {
-				"text-field": ["get", "name"],
-				"text-font": ["Noto Sans Bold"],
-				"text-size": 14,
-				"text-anchor": "left",
-				"text-offset": [22 / 14, -25 / 14],
-				"text-max-width": 12,
-				"text-rotation-alignment": "viewport",
-				"text-pitch-alignment": "viewport",
-			},
-			paint: {
-				"text-color": "#f97316", // orange-500 (always boosted on this source)
-				"text-halo-color": "#fff",
-				"text-halo-width": 1.2,
-				"text-halo-blur": 0,
-			},
-		});
-
-		// Symbol cluster layer used by spiderfy. Hit-testing on this layer's
-		// near-invisible icon picks up the cluster_id property and routes
-		// through the library, which auto-decides between zoom-on-click and
-		// spiderfying based on getClusterExpansionZoom vs maxZoom.
-		map.addLayer({
-			id: "clusters-hit",
-			type: "symbol",
-			source: "places",
-			filter: ["has", "point_count"],
-			layout: {
-				"icon-image": "cluster-hit",
-				"icon-size": 1,
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-			},
-		});
+		// Sources + fifteen layers (pins, clusters, badges, labels, heatmap).
+		pinSource.install(map);
 
 		// Spiderfy hooks the clusters-hit symbol layer. The library's
 		// internal decision is: if expansionZoom > forceSpiderifyMinZoom OR
@@ -1847,15 +1161,15 @@ onMount(async () => {
 			currentLat = c.lat;
 			currentLon = c.lng;
 			// Re-route boosted places when zoom crosses BOOSTED_CLUSTERING_MAX_ZOOM
-			// — the MapLibre analogue of the legacy boostedLayer swap. Only re-syncs
-			// on an actual flip, so steady-state pans stay cheap.
-			if (shouldClusterBoostedAtZoom(currentZoom) !== boostedAreClustered) {
-				syncPlacesToSource(lastSyncedList);
+			// — the MapLibre analogue of the legacy boostedLayer swap. The facade
+			// only re-renders on an actual flip, so steady-state pans stay cheap.
+			if (styleLoaded) {
+				pinSource.resyncForZoom(map);
 			}
 			// When the heatmap is active, zooming past CLUSTERING_DISABLED_ZOOM
 			// naturally removes the heatmap layer (its maxzoom), so re-show
 			// all the point/cluster/badge layers that were concealed.
-			applyHeatmapVisibility();
+			pinSource.applyHeatmapVisibility(map);
 			debouncedUpdateMerchantList();
 		});
 
@@ -1974,7 +1288,7 @@ onMount(async () => {
 		// exists. The toggle control can't do this itself — it's added
 		// before 'load' fires, so the layer isn't present at addControl
 		// time.
-		setHeatmapEnabled(heatmapEnabled);
+		pinSource.refreshHeatmapAfterStyle(map);
 		// Kick once on load — if the user lands above the threshold, labels
 		// should appear without requiring a move.
 		triggerEnrichmentIfNeeded();


### PR DESCRIPTION
## Summary

Closes #1170, per the re-review on that issue (hard dependency: stacked on #1194's `refactor/visible-places`, because the facade's render contract only works once visibility policy lives upstream in `selectVisiblePlaces`).

**Stacked on #1194** — GitHub will retarget to `main` when it merges; only the last commit is new here.

**What moved into `src/lib/map/placePinSource.ts`** (page: −728 lines)
- The three GeoJSON sources (`places` clustered, `places-boosted` standalone, `places-heatmap`) and all fifteen layers, installed by one `install(map)` call
- Badge/cluster-hit sprites (`loadSprites` — non-rejecting; a transient Iconify outage degrades the saved-badge instead of breaking init)
- `buildFeatureCollection` with the lazy name-resolution chain — saved ids, enriched cache, and display language are **injected deps** read as snapshots per render, so the module stays store-agnostic and testable
- `render(map, list)` — boosted routing via `routePlacesByBoostAndZoom`, heatmap refresh-while-visible, `ensureSpritesForPlaces`, and an `onRendered(count)` callback the page uses for the loading gate + `__mapPlacesCount` e2e hook
- `resyncForZoom` — the BOOSTED_CLUSTERING_MAX_ZOOM crossing re-sync, re-rendering only on an actual flip
- The heatmap machinery: enable/disable with seed-from-last-synced-list, conceal/reveal of pin layers below the reveal zoom, persisted-state re-apply after a style load
- `CUSTOM_SOURCE_IDS` / `CUSTOM_LAYER_IDS` exported for the page's `applyBasemap` transformStyle carryover

**What the page keeps** (the parts that genuinely touch page state): interactions, spiderfy, camera, label palette, and the render-signature gating from #1194 — the page decides *when* to render, the facade owns *how*.

**Contract preserved**: `render()` renders exactly the list it is given — it never re-filters. All visibility policy (search/category/recency/boosts) stays in the #1194 pipeline.

8 new unit tests pin the facade: boost routing on both sides of the zoom boundary, flip-only re-sync, heatmap seed-on-enable / skip-while-off / conceal-reveal zoom / persisted re-apply, and dep-injected feature properties. None of this had coverage before (it was inline in the page).

**Deliberate robustness delta** (called out per review): the facade's `loadSprites` catches a cluster-hit sprite failure with a console.warn where the old load path would have rejected inside the `load` handler and aborted the ENTIRE map init (no sources, no layers). The failure mode is now a silently missing spiderfy hit-target instead of a blank map. The saved-badge fetch keeps its existing warn-and-degrade behavior; both loaders stay hasImage-guarded no-ops on the normal path.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean
- [x] 514/514 unit tests green (8 new in `placePinSource.test.ts`)
- [x] Live-verified on the dev server (`/map`): 29,080 pins boot through the facade; heatmap toggle on (seeded, pins concealed) and off; basemap swap OpenStreetMap → Liberty → back with all clusters carried over; zero console errors
- [ ] CI (build, e2e, type-checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

