### PR TITLE
fix: stop the area drawer's boost-modal refetch loop (#1199)

### DIFF
--- a/src/components/area/AreaMerchantDrawer.svelte
+++ b/src/components/area/AreaMerchantDrawer.svelte
@@ -10,7 +10,7 @@ import {
 	fetchMerchantDetails,
 } from "$lib/merchantDrawerLogic";
 import { boost } from "$lib/store";
-import type { Place } from "$lib/types";
+import type { Boost, Place } from "$lib/types";
 import { isUpToDate as checkUpToDate } from "$lib/verification";
 
 export let merchantId: number | null = null;
@@ -61,17 +61,26 @@ const closeDrawer = () => {
 
 const handleBoost = () => boostMerchant(merchant, merchantId, setBoostLoading);
 
-$: if ($boost !== undefined && merchant) {
-	// Boost state changed - refresh merchant data. fresh bypasses the details
-	// cache so a just-boosted merchant is never served its pre-boost record.
-	if (merchantId) {
+// Refresh once per boost-state TRANSITION, tracked via lastSeenBoost. The
+// old shape re-fired whenever `merchant` was reassigned while $boost stayed
+// defined — and since the fetch itself reassigns `merchant`, that spun a
+// network loop for as long as the boost modal stayed open (#1199).
+// Modal open → fresh: true so the boost flow starts from current data (never
+// a pre-boost cached record). Modal close → plain fetch: after a completed
+// payment the write-through has primed the details cache, so this serves the
+// boosted record instantly; after a cancel it's an equally cheap cache hit.
+let lastSeenBoost: Boost;
+$: if ($boost !== lastSeenBoost) {
+	const opening = $boost !== undefined;
+	lastSeenBoost = $boost;
+	if (merchantId && merchant) {
 		fetchMerchantDetails(
 			merchantId,
 			merchantId,
 			(m) => (merchant = m),
 			(f) => (isLoading = f),
 			(id) => (lastFetchedId = id),
-			{ fresh: true },
+			opening ? { fresh: true } : undefined,
 		);
 	}
 }

--- a/src/components/area/AreaMerchantDrawer.svelte
+++ b/src/components/area/AreaMerchantDrawer.svelte
@@ -74,13 +74,23 @@ $: if ($boost !== lastSeenBoost) {
 	const opening = $boost !== undefined;
 	lastSeenBoost = $boost;
 	if (merchantId && merchant) {
+		// Same abort discipline as the merchantId-driven fetch above: a
+		// drawer close or merchant switch must cancel this too, so a late
+		// response can't stomp the state the drawer has since moved to.
+		if (abortController) {
+			abortController.abort();
+		}
+		abortController = new AbortController();
+
 		fetchMerchantDetails(
 			merchantId,
 			merchantId,
 			(m) => (merchant = m),
 			(f) => (isLoading = f),
 			(id) => (lastFetchedId = id),
-			opening ? { fresh: true } : undefined,
+			opening
+				? { signal: abortController.signal, fresh: true }
+				: { signal: abortController.signal },
 		);
 	}
 }


### PR DESCRIPTION
## Summary

Closes #1199. The area merchant drawer's `$: if ($boost !== undefined && merchant)` block re-ran whenever `merchant` was reassigned while the boost store stayed defined — and since `fetchMerchantDetails` itself reassigns `merchant` (`null` during the fetch, then the response), the block spun a **continuous network GET loop for as long as the boost modal stayed open**. This was also the substrate that made the details-cache write-order race in #1172 reachable.

**Fix**: track the last-seen `$boost` value (the same tracking-var pattern the codebase already uses for transition detection, e.g. `lastListMode` on the map page) so each boost-state *transition* triggers exactly one refresh:
- **modal open** → `fresh: true`, so the boost flow starts from current data, never a pre-boost cached record;
- **modal close** → plain fetch through the details cache: after a completed payment the write-through has already primed the boosted record (instant, no network); after a cancel it's an equally cheap cache hit. This preserves the fresh-after-payment display the old loop provided only by accident.

The block still re-runs on `merchant` reassignment (Svelte 4 dependency tracking), but the transition guard makes those re-runs free.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean, 545/545 unit tests
- [ ] CI (build, e2e, type-checks)
- [ ] Manual QA (needs a human — do **not** proceed past the modal, the later steps mint real invoices): open a community page → click a pin → click Boost → watch the network tab for ~10s. Before: continuous `/v4/places/:id` GETs. After: exactly one on open, one cache-served refresh on close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced boost modal refresh behavior with improved state tracking mechanisms. Optimized data fetching strategies with intelligent cache management—fresh data loads when opening boost modals, cached data usage when closing modals. Refined request handling to prevent redundant or stale requests during boost state transitions, delivering smoother and more responsive interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->