### PR TITLE
perf: area pages render from the SSR bundle — no more 5.7 MB world crawl (#1174)

### DIFF
--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -34,6 +34,9 @@ export let filteredPlaces: Place[];
 // renders); undefined while reports load or when the area has none — the
 // stars stay in their loading state rather than fabricating a grade.
 export let upToDatePercent: number | undefined = undefined;
+// Validated box:* camera hint from the SSR bundle (see areaSectionLoad).
+// Camera-only, never containment; null falls back to fitting the polygon.
+export let cameraBbox: [number, number, number, number] | null = null;
 
 type PlaceFeature = {
 	type: "Feature";
@@ -323,7 +326,9 @@ const initializeMapContents = (m: MapLibreMap) => {
 };
 
 const fitToArea = (m: MapLibreMap, animate = false) => {
-	const bbox = computeBbox(geoJSON);
+	// The curated box:* hint wins over deriving a box from the polygon —
+	// communities author it to frame their area better than a raw bbox.
+	const bbox = cameraBbox ?? computeBbox(geoJSON);
 	if (!bbox) return;
 	m.fitBounds(
 		[

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -28,15 +28,7 @@ import SponsorBadge from "$components/SponsorBadge.svelte";
 import Tip from "$components/Tip.svelte";
 import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
-import {
-	areaError,
-	areas,
-	places,
-	placesError,
-	reportError,
-	reports,
-} from "$lib/store";
-import { areasSync } from "$lib/sync/areas";
+import { places, placesError, reportError, reports } from "$lib/store";
 import { batchSync } from "$lib/sync/batchSync";
 import { reportsSync } from "$lib/sync/reports";
 import type {
@@ -47,22 +39,18 @@ import type {
 	Tagger,
 } from "$lib/types.js";
 import { TipType } from "$lib/types.js";
-import {
-	areaIconSrc,
-	errToast,
-	formatVerifiedHuman,
-	validateContinents,
-} from "$lib/utils";
+import { areaIconSrc, errToast, formatVerifiedHuman } from "$lib/utils";
 import { isRecentlyVerified } from "$lib/verification";
 
 onMount(() => {
-	batchSync([areasSync, reportsSync]);
+	// reportsSync feeds the stats section and the AreaMap grade stars. The
+	// world areas crawl (areasSync) is gone: the SSR bundle now carries this
+	// area's full tags, polygon included (#1174).
+	batchSync([reportsSync]);
 });
 
 // alert for element errors
 $: $placesError && errToast($placesError);
-// alert for area errors
-$: $areaError && errToast($areaError);
 // alert for report errors
 $: $reportError && errToast($reportError);
 
@@ -160,94 +148,46 @@ const fetchAreaTopEditors = async () => {
 const initializeData = async () => {
 	if (dataInitialized) return;
 
-	const areaFound = $areas.find((area) => {
-		if (type === "community") {
-			return (
-				area.id === data.id &&
-				area.tags?.type === "community" &&
-				area.tags.geo_json &&
-				area.tags.name &&
-				area.tags["icon:square"] &&
-				area.tags.continent
-			);
-		} else {
-			return (
-				area.id === data.id &&
-				area.tags?.type === "country" &&
-				area.id.length === 2 &&
-				area.tags.geo_json &&
-				area.tags.name &&
-				area.tags.continent &&
-				validateContinents(area.tags.continent)
-			);
-		}
-	});
-
-	if (!areaFound) {
-		console.error(
-			`Could not find ${type}, please try again or contact BTC Map.`,
-		);
-		goto("/404");
-		return;
-	}
-
-	area = areaFound.tags;
+	// The SSR bundle carries the full v3 tags (polygon included) and 404s
+	// server-side when required tags are missing — no $areas lookup, no
+	// world-areas crawl, no client goto("/404") (#1174).
+	area = data.tags;
 
 	avatar =
 		type === "community"
-			? areaIconSrc(areaFound.id, area["icon:square"])
-			: `https://static.btcmap.org/images/countries/${areaFound.id}.svg`;
+			? areaIconSrc(data.id, area["icon:square"])
+			: `https://static.btcmap.org/images/countries/${data.id}.svg`;
 	description = area.description;
 
 	if (type === "community") {
 		org = area.organization;
 		sponsor = area.sponsor;
-		website = area["contact:website"];
-		email = area["contact:email"];
-		phone = area["contact:phone"];
-		nostr = area["contact:nostr"];
-		twitter = area["contact:twitter"];
-		meetup = area["contact:meetup"];
-		telegram = area["contact:telegram"];
-		discord = area["contact:discord"];
-		youtube = area["contact:youtube"];
-		github = area["contact:github"];
-		matrix = area["contact:matrix"];
-		geyser = area["contact:geyser"];
-		satlantis = area["contact:satlantis"];
-		eventbrite = area["contact:eventbrite"];
-		reddit = area["contact:reddit"];
-		simplex = area["contact:simplex"];
-		instagram = area["contact:instagram"];
-		whatsapp = area["contact:whatsapp"];
-		facebook = area["contact:facebook"];
-		linkedin = area["contact:linkedin"];
-		rss = area["contact:rss"];
-		signal = area["contact:signal"];
-		hasContact = !!(
-			website ||
-			email ||
-			phone ||
-			nostr ||
-			twitter ||
-			meetup ||
-			telegram ||
-			discord ||
-			youtube ||
-			github ||
-			matrix ||
-			geyser ||
-			satlantis ||
-			eventbrite ||
-			reddit ||
-			simplex ||
-			instagram ||
-			whatsapp ||
-			facebook ||
-			linkedin ||
-			rss ||
-			signal
-		);
+		// The bundle lifts the contact:* tags into one typed object
+		({
+			website,
+			email,
+			phone,
+			nostr,
+			twitter,
+			meetup,
+			telegram,
+			discord,
+			youtube,
+			github,
+			matrix,
+			geyser,
+			satlantis,
+			eventbrite,
+			reddit,
+			simplex,
+			instagram,
+			whatsapp,
+			facebook,
+			linkedin,
+			rss,
+			signal,
+		} = data.contacts);
+		hasContact = Object.keys(data.contacts).length > 0;
 		verifiedDate = data.verifiedDate || area["verified:date"];
 		isVerifiedDateStale = !isRecentlyVerified(verifiedDate);
 
@@ -271,8 +211,6 @@ const initializeData = async () => {
 			return false;
 		}
 	});
-
-	issues = data.issues;
 
 	dataInitialized = true;
 };
@@ -298,7 +236,7 @@ $: if (data?.id !== lastAreaId) {
 	filteredPlaces = [];
 }
 
-$: $areas?.length && $places?.length && !dataInitialized && initializeData();
+$: data?.id && $places?.length && !dataInitialized && initializeData();
 
 // Fire the area top-editors fetch only when the user actually lands on /activity.
 // One REST call replaces the previous per-place enrichment shim.
@@ -360,6 +298,10 @@ let lightning: { destination: string; type: TipType } | undefined;
 let taggers: Tagger[] = [];
 
 let issues: PlaceIssue[] = [];
+// Reactive, not latched at init: issues arrive only with the maintain
+// section's load (per-section pruning in areaSectionLoad), so a
+// merchants -> maintain navigation must pick them up.
+$: issues = data?.issues ?? [];
 </script>
 
 <main class="my-10 space-y-16 text-center md:my-20">
@@ -529,6 +471,7 @@ let issues: PlaceIssue[] = [];
 			{name}
 			geoJSON={area?.geo_json}
 			{filteredPlaces}
+			cameraBbox={data.cameraBbox}
 			upToDatePercent={areaReports?.[0]?.tags.up_to_date_percent}
 		/>
 		<AreaMerchantHighlights {dataInitialized} {filteredPlaces} />

--- a/src/lib/areaSectionLoad.test.ts
+++ b/src/lib/areaSectionLoad.test.ts
@@ -19,9 +19,12 @@ const AREA_OK = {
 	id: 42,
 	deleted_at: null,
 	tags: {
+		type: "community",
 		url_alias: "some-area",
 		name: "Some Area",
 		description: "An area description",
+		continent: "europe",
+		geo_json: { type: "Polygon", coordinates: [] },
 		"verified:date": "2024-01-01",
 		"icon:square": "https://example.com/icon.png",
 	},
@@ -52,12 +55,14 @@ const communityConfig: AreaSectionConfig = {
 	notFoundMessage: "Community Not Found",
 	redirectBase: "/community",
 	isValidArea: (area) => !area.includes("/"),
+	hasRequiredTags: () => true,
 };
 
 const countryConfig: AreaSectionConfig = {
 	notFoundMessage: "Country Not Found",
 	redirectBase: "/country",
 	isValidArea: (area) => /^[\w-]+$/.test(area),
+	hasRequiredTags: () => true,
 };
 
 const captureThrow = async (fn: () => Promise<unknown>): Promise<unknown> => {
@@ -223,7 +228,7 @@ describe("loadAreaSection", () => {
 
 		const err = await captureThrow(() =>
 			loadAreaSection(
-				{ params: { area: "some-area", section: "merchants" }, fetch },
+				{ params: { area: "some-area", section: "maintain" }, fetch },
 				communityConfig,
 			),
 		);
@@ -234,7 +239,7 @@ describe("loadAreaSection", () => {
 		}
 	});
 
-	it("returns mapped area + issues data and requests the expected endpoints", async () => {
+	it("returns the bundle without an issues request for non-maintain sections", async () => {
 		const fetch = makeFetch();
 
 		const result = await loadAreaSection(
@@ -247,16 +252,139 @@ describe("loadAreaSection", () => {
 			numericId: 42,
 			name: "Some Area",
 			tickets: "maintenance",
-			issues: ISSUES_OK.requested_issues,
+			// Issues feed only the maintain section's table — the other
+			// sections' SSR payloads must not carry them
+			issues: [],
 			description: "An area description",
+			tags: AREA_OK.tags,
+			contacts: {},
+			cameraBbox: null,
 		});
 		expect(result.tags).toEqual(AREA_OK.tags);
 
-		const areaUrl = fetch.mock.calls[0][0].toString();
-		const issuesUrl = fetch.mock.calls[1][0].toString();
-		expect(areaUrl).toContain("/v3/areas/some-area");
-		expect(issuesUrl).toContain(
-			"/v4/place-issues?area_id=42&limit=10000&offset=0",
+		expect(fetch).toHaveBeenCalledTimes(1);
+		expect(fetch.mock.calls[0][0].toString()).toContain("/v3/areas/some-area");
+	});
+
+	it("fetches issues for the maintain section, paginating past the limit", async () => {
+		const page1 = Array.from({ length: 10000 }, (_, i) => ({ id: i }));
+		const page2 = [{ id: 10000 }, { id: 10001 }];
+		let issuesCall = 0;
+		const fetch = makeFetch({
+			issues: {
+				json: () => ({
+					requested_issues: issuesCall++ === 0 ? page1 : page2,
+				}),
+			},
+		});
+
+		const result = await loadAreaSection(
+			{ params: { area: "some-area", section: "maintain" }, fetch },
+			communityConfig,
 		);
+
+		expect(result.data.issues).toHaveLength(10002);
+		const issuesUrls = fetch.mock.calls
+			.map((call) => call[0].toString())
+			.filter((url) => url.includes("/v4/place-issues"));
+		expect(issuesUrls).toHaveLength(2);
+		expect(issuesUrls[0]).toContain("limit=10000&offset=0");
+		expect(issuesUrls[1]).toContain("limit=10000&offset=10000");
+	});
+
+	it("returns a 404 when required tags are missing", async () => {
+		const fetch = makeFetch();
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				{
+					...communityConfig,
+					hasRequiredTags: (tags) => !!tags["icon:square"] && false,
+				},
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(404);
+			expect(err.body.message).toBe("Community Not Found");
+		}
+	});
+
+	it("lifts contact tags into the typed contacts object", async () => {
+		const fetch = makeFetch({
+			areas: {
+				json: () => ({
+					...AREA_OK,
+					tags: {
+						...AREA_OK.tags,
+						"contact:website": "https://example.org",
+						"contact:telegram": "https://t.me/example",
+						"contact:email": "",
+					},
+				}),
+			},
+		});
+
+		const result = await loadAreaSection(
+			{ params: { area: "some-area", section: "merchants" }, fetch },
+			communityConfig,
+		);
+
+		// Empty strings are dropped; only authored contacts survive
+		expect(result.data.contacts).toEqual({
+			website: "https://example.org",
+			telegram: "https://t.me/example",
+		});
+	});
+
+	it("coerces numeric box:* tags into a camera bbox and rejects junk", async () => {
+		const withBox = (box: Record<string, unknown>) =>
+			makeFetch({
+				areas: {
+					json: () => ({ ...AREA_OK, tags: { ...AREA_OK.tags, ...box } }),
+				},
+			});
+		const load = (fetch: ReturnType<typeof makeFetch>) =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				communityConfig,
+			);
+
+		// The API serves numbers despite the historical string typing
+		const numeric = await load(
+			withBox({
+				"box:west": -17.3,
+				"box:south": 32.5,
+				"box:east": -16.2,
+				"box:north": 33.2,
+			}),
+		);
+		expect(numeric.data.cameraBbox).toEqual([-17.3, 32.5, -16.2, 33.2]);
+
+		// String-typed values coerce
+		const strings = await load(
+			withBox({
+				"box:west": "-17.3",
+				"box:south": "32.5",
+				"box:east": "-16.2",
+				"box:north": "33.2",
+			}),
+		);
+		expect(strings.data.cameraBbox).toEqual([-17.3, 32.5, -16.2, 33.2]);
+
+		// Junk, inverted, or wrap boxes fall back to the polygon fit
+		const junk = await load(withBox({ "box:west": "not-a-number" }));
+		expect(junk.data.cameraBbox).toBeNull();
+		const inverted = await load(
+			withBox({
+				"box:west": 10,
+				"box:south": 40,
+				"box:east": 5,
+				"box:north": 45,
+			}),
+		);
+		expect(inverted.data.cameraBbox).toBeNull();
 	});
 });

--- a/src/lib/areaSectionLoad.test.ts
+++ b/src/lib/areaSectionLoad.test.ts
@@ -421,6 +421,26 @@ describe("loadAreaSection", () => {
 		// Junk, inverted, or wrap boxes fall back to the polygon fit
 		const junk = await load(withBox({ "box:west": "not-a-number" }));
 		expect(junk.data.cameraBbox).toBeNull();
+
+		// Out-of-range coordinates fail closed — MapLibre throws on |lat| > 90
+		const badLat = await load(
+			withBox({
+				"box:west": -17.3,
+				"box:south": 32.5,
+				"box:east": -16.2,
+				"box:north": 95,
+			}),
+		);
+		expect(badLat.data.cameraBbox).toBeNull();
+		const badLon = await load(
+			withBox({
+				"box:west": -17.3,
+				"box:south": 32.5,
+				"box:east": 200,
+				"box:north": 33.2,
+			}),
+		);
+		expect(badLon.data.cameraBbox).toBeNull();
 		const inverted = await load(
 			withBox({
 				"box:west": 10,

--- a/src/lib/areaSectionLoad.test.ts
+++ b/src/lib/areaSectionLoad.test.ts
@@ -292,6 +292,44 @@ describe("loadAreaSection", () => {
 		expect(issuesUrls[1]).toContain("limit=10000&offset=10000");
 	});
 
+	it("maps a malformed issues payload to a 502 instead of an empty table", async () => {
+		const fetch = makeFetch({
+			issues: { json: () => ({ totally: "unexpected" }) },
+		});
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "maintain" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(502);
+		}
+	});
+
+	it("returns a 404 when url_alias is missing, regardless of config", async () => {
+		const { url_alias, ...tagsWithoutAlias } = AREA_OK.tags;
+		const fetch = makeFetch({
+			areas: { json: () => ({ ...AREA_OK, tags: tagsWithoutAlias }) },
+		});
+
+		const err = await captureThrow(() =>
+			loadAreaSection(
+				{ params: { area: "some-area", section: "merchants" }, fetch },
+				communityConfig,
+			),
+		);
+
+		expect(isHttpError(err)).toBe(true);
+		if (isHttpError(err)) {
+			expect(err.status).toBe(404);
+			expect(err.body.message).toBe("Community Not Found");
+		}
+	});
+
 	it("returns a 404 when required tags are missing", async () => {
 		const fetch = makeFetch();
 

--- a/src/lib/areaSectionLoad.test.ts
+++ b/src/lib/areaSectionLoad.test.ts
@@ -1,6 +1,8 @@
 import { isHttpError, isRedirect } from "@sveltejs/kit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { AreaTags } from "$lib/types";
+
 import type { AreaSectionConfig } from "./areaSectionLoad";
 import { loadAreaSection } from "./areaSectionLoad";
 
@@ -15,6 +17,10 @@ type FetchResponses = {
 	issues?: ResponseOverrides;
 };
 
+// satisfies (not a plain annotation) keeps literal inference, so the tests
+// that deliberately build broken variants by spreading/omitting keys still
+// typecheck — while the happy-path fixture is pinned to the contract the
+// loader assumes and fails to compile if AreaTags gains a required field.
 const AREA_OK = {
 	id: 42,
 	deleted_at: null,
@@ -28,7 +34,7 @@ const AREA_OK = {
 		"verified:date": "2024-01-01",
 		"icon:square": "https://example.com/icon.png",
 	},
-};
+} satisfies { id: number; deleted_at: string | null; tags: AreaTags };
 
 const ISSUES_OK = { requested_issues: [{ id: 1 }, { id: 2 }] };
 

--- a/src/lib/areaSectionLoad.ts
+++ b/src/lib/areaSectionLoad.ts
@@ -1,12 +1,22 @@
 import { error, isHttpError, redirect } from "@sveltejs/kit";
 
 import { API_BASE } from "$lib/api-base";
-import type { AreaPageProps, AreaTags } from "$lib/types";
+import type {
+	AreaContacts,
+	AreaPageProps,
+	AreaTags,
+	PlaceIssue,
+} from "$lib/types";
+import { AREA_CONTACT_KEYS } from "$lib/types";
 
 // Shared loader for the community/[area]/[section] and country/[area]/[section]
-// pages. Both fetch the same v3 area + v4 place-issues data and share the same
-// error handling; they differ only in how the area slug is validated, the
-// not-found copy, and the redirect base path.
+// pages. Both fetch the same v3 area data and share the same error handling;
+// they differ only in how the area slug is validated, which tags an area must
+// carry to be renderable, the not-found copy, and the redirect base path.
+//
+// The returned bundle carries the FULL tags (including the geo_json polygon)
+// so the client never has to re-download the multi-MB world areas crawl just
+// to recover a polygon this fetch already had (#1174).
 
 type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
 
@@ -19,6 +29,10 @@ export type AreaSectionConfig = {
 	notFoundMessage: string;
 	redirectBase: string;
 	isValidArea: (area: string) => boolean;
+	// The tags an area must carry to be renderable by AreaPage. This used to
+	// be a client-side $areas-lookup filter that ended in goto("/404") — after
+	// the 5.7 MB crawl. A malformed area now 404s at SSR time instead.
+	hasRequiredTags: (tags: AreaTags) => boolean;
 };
 
 export type AreaSectionResult = {
@@ -29,6 +43,75 @@ export type AreaSectionResult = {
 };
 
 const VALID_SECTIONS = ["merchants", "stats", "activity", "maintain"];
+
+// Place-issues are consumed only by the maintain section's IssuesTable —
+// the other sections' SSR payloads must not carry up to ~150 KB of issue
+// rows (the US) they never render. Section navigation re-runs this loader,
+// so landing on /maintain fetches them then.
+const SECTIONS_WITH_ISSUES = new Set(["maintain"]);
+
+const ISSUES_PAGE_LIMIT = 10000;
+// Backstop against a runaway loop, far above any real area today. If an
+// area ever exceeds it, we log the truncation instead of hiding it.
+const ISSUES_MAX_PAGES = 10;
+
+const fetchAllPlaceIssues = async (
+	fetch: FetchLike,
+	areaId: number,
+): Promise<PlaceIssue[]> => {
+	const all: PlaceIssue[] = [];
+	for (let page = 0; page < ISSUES_MAX_PAGES; page++) {
+		const response = await fetch(
+			`${API_BASE}/v4/place-issues?area_id=${areaId}&limit=${ISSUES_PAGE_LIMIT}&offset=${page * ISSUES_PAGE_LIMIT}`,
+		);
+		if (!response.ok) {
+			throw error(502, "Upstream API error");
+		}
+		const body = await response.json();
+		const rows: PlaceIssue[] = Array.isArray(body?.requested_issues)
+			? body.requested_issues
+			: [];
+		all.push(...rows);
+		// A short page means we've seen the tail; the old single-shot
+		// `offset=0` silently truncated anything past the first 10k.
+		if (rows.length < ISSUES_PAGE_LIMIT) return all;
+	}
+	console.warn(
+		`place-issues for area ${areaId} truncated at ${all.length} rows`,
+	);
+	return all;
+};
+
+// Lift the 22 `contact:*` string tags into one typed object so consumers
+// stop spelling `area["contact:satlantis"]` at every read site.
+const extractContacts = (tags: AreaTags): AreaContacts => {
+	const contacts: AreaContacts = {};
+	for (const key of AREA_CONTACT_KEYS) {
+		const value = tags[`contact:${key}`];
+		if (typeof value === "string" && value) {
+			contacts[key] = value;
+		}
+	}
+	return contacts;
+};
+
+// box:* tags are human-authored camera hints, served as numbers despite
+// their string typing — coerce and validate. They are CAMERA-ONLY, never
+// containment: a stale or too-small box must not be able to drop real
+// merchants (#1175 owns the geometry-derived, antimeridian-aware bbox for
+// containment). Wrap boxes (west > east) fall back to the client's
+// polygon-derived fit rather than guessing a convention here.
+const cameraBboxFromTags = (
+	tags: AreaTags,
+): [number, number, number, number] | null => {
+	const west = Number(tags["box:west"]);
+	const south = Number(tags["box:south"]);
+	const east = Number(tags["box:east"]);
+	const north = Number(tags["box:north"]);
+	if (![west, south, east, north].every(Number.isFinite)) return null;
+	if (south >= north || west >= east) return null;
+	return [west, south, east, north];
+};
 
 export const loadAreaSection = async (
 	{ params, fetch }: AreaSectionEvent,
@@ -67,29 +150,32 @@ export const loadAreaSection = async (
 			throw error(404, config.notFoundMessage);
 		}
 
+		const tags: AreaTags = fetchedArea.tags;
+
+		if (!config.hasRequiredTags(tags)) {
+			throw error(404, config.notFoundMessage);
+		}
+
 		// Ticket syncing is temporarily disabled during maintenance
 		const tickets = "maintenance";
 
-		const issuesResponse = await fetch(
-			`${API_BASE}/v4/place-issues?area_id=${fetchedArea.id}&limit=10000&offset=0`,
-		);
-
-		if (!issuesResponse.ok) {
-			throw error(502, "Upstream API error");
-		}
-
-		const issues = await issuesResponse.json();
+		const issues = SECTIONS_WITH_ISSUES.has(section)
+			? await fetchAllPlaceIssues(fetch, fetchedArea.id)
+			: [];
 
 		return {
 			data: {
-				id: fetchedArea.tags.url_alias,
+				id: tags.url_alias,
 				numericId: fetchedArea.id,
-				name: fetchedArea.tags.name,
+				name: tags.name,
 				tickets: tickets,
-				issues: issues.requested_issues,
-				description: fetchedArea.tags.description,
+				issues,
+				description: tags.description,
+				tags,
+				contacts: extractContacts(tags),
+				cameraBbox: cameraBboxFromTags(tags),
 			},
-			tags: fetchedArea.tags,
+			tags,
 		};
 	} catch (err) {
 		console.error(err);

--- a/src/lib/areaSectionLoad.ts
+++ b/src/lib/areaSectionLoad.ts
@@ -113,6 +113,11 @@ const cameraBboxFromTags = (
 	const east = Number(tags["box:east"]);
 	const north = Number(tags["box:north"]);
 	if (![west, south, east, north].every(Number.isFinite)) return null;
+	// Out-of-range coordinates must fail closed too: MapLibre's LngLat
+	// throws on latitudes beyond ±90 (crashing fitBounds mid-init), and
+	// longitudes beyond ±180 silently misplace the camera.
+	if (Math.abs(south) > 90 || Math.abs(north) > 90) return null;
+	if (Math.abs(west) > 180 || Math.abs(east) > 180) return null;
 	if (south >= north || west >= east) return null;
 	return [west, south, east, north];
 };

--- a/src/lib/areaSectionLoad.ts
+++ b/src/lib/areaSectionLoad.ts
@@ -68,9 +68,13 @@ const fetchAllPlaceIssues = async (
 			throw error(502, "Upstream API error");
 		}
 		const body = await response.json();
-		const rows: PlaceIssue[] = Array.isArray(body?.requested_issues)
-			? body.requested_issues
-			: [];
+		// A malformed payload (missing/non-array requested_issues) is an
+		// upstream schema break, not an empty page — surfacing it beats
+		// silently rendering an empty maintain table.
+		if (!Array.isArray(body?.requested_issues)) {
+			throw error(502, "Upstream API error");
+		}
+		const rows: PlaceIssue[] = body.requested_issues;
 		all.push(...rows);
 		// A short page means we've seen the tail; the old single-shot
 		// `offset=0` silently truncated anything past the first 10k.
@@ -152,7 +156,10 @@ export const loadAreaSection = async (
 
 		const tags: AreaTags = fetchedArea.tags;
 
-		if (!config.hasRequiredTags(tags)) {
+		// url_alias is a loader invariant, not a per-type config concern:
+		// data.id derives from it and feeds avatars, section links, and the
+		// top-editors fetch — an area without one is unrenderable.
+		if (!tags.url_alias || !config.hasRequiredTags(tags)) {
 			throw error(404, config.notFoundMessage);
 		}
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,10 +73,12 @@ export type AreaTags = {
 	"tips:lightning_address"?: string;
 	"tips:url"?: string;
 	sponsor?: boolean;
-	"box:north"?: string;
-	"box:east"?: string;
-	"box:south"?: string;
-	"box:west"?: string;
+	// Human-authored camera hints; the API serves numbers despite the
+	// historical string typing. Coerced + validated in areaSectionLoad.
+	"box:north"?: string | number;
+	"box:east"?: string | number;
+	"box:south"?: string | number;
+	"box:west"?: string | number;
 };
 
 export type AreaType = "community" | "country" | "trash";
@@ -386,12 +388,48 @@ export type DropdownLink = {
 
 export type ChartHistory = "7D" | "1M" | "3M" | "6M" | "YTD" | "1Y" | "ALL";
 
+// The `contact:*` tags lifted into one typed object (see areaSectionLoad's
+// extractContacts) so consumers stop indexing `area["contact:x"]` per key.
+export const AREA_CONTACT_KEYS = [
+	"website",
+	"email",
+	"phone",
+	"nostr",
+	"twitter",
+	"meetup",
+	"telegram",
+	"discord",
+	"youtube",
+	"github",
+	"matrix",
+	"geyser",
+	"satlantis",
+	"eventbrite",
+	"reddit",
+	"simplex",
+	"instagram",
+	"whatsapp",
+	"facebook",
+	"linkedin",
+	"rss",
+	"signal",
+] as const;
+export type AreaContactKey = (typeof AREA_CONTACT_KEYS)[number];
+export type AreaContacts = Partial<Record<AreaContactKey, string>>;
+
 export type AreaPageProps = {
 	id: string;
 	numericId: number;
 	name: string;
 	tickets: Tickets;
 	issues: PlaceIssue[];
+	// Full v3 tags, polygon included — the client renders from these instead
+	// of re-crawling the world areas feed to recover them (#1174)
+	tags: AreaTags;
+	contacts: AreaContacts;
+	// Validated box:* camera hint; null when absent/invalid (client falls
+	// back to fitting the polygon). Camera-only, never containment.
+	cameraBbox: [number, number, number, number] | null;
 	verifiedDate?: string;
 	description?: string;
 	iconSquare?: string;

--- a/src/routes/community/[area]/[section]/+page.server.ts
+++ b/src/routes/community/[area]/[section]/+page.server.ts
@@ -10,6 +10,14 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			redirectBase: "/community",
 			// Allow non-Latin aliases while still rejecting malformed path-like values.
 			isValidArea: (area) => !area.includes("/"),
+			// The tags AreaPage renders from — previously enforced client-side
+			// via the $areas-lookup filter.
+			hasRequiredTags: (tags) =>
+				tags.type === "community" &&
+				!!tags.geo_json &&
+				!!tags.name &&
+				!!tags["icon:square"] &&
+				!!tags.continent,
 		},
 	);
 

--- a/src/routes/country/[area]/[section]/+page.server.ts
+++ b/src/routes/country/[area]/[section]/+page.server.ts
@@ -1,4 +1,5 @@
 import { loadAreaSection } from "$lib/areaSectionLoad";
+import { validateContinents } from "$lib/utils";
 
 import type { PageServerLoad } from "./$types";
 
@@ -10,6 +11,15 @@ export const load: PageServerLoad = async ({ params, fetch }) => {
 			redirectBase: "/country",
 			// Alphanumeric, underscores, and hyphens only.
 			isValidArea: (area) => /^[\w-]+$/.test(area),
+			// The tags AreaPage renders from — previously enforced client-side
+			// via the $areas-lookup filter. (The old lookup's two-letter-id
+			// disambiguation is obsolete: the v3 slug fetch resolves directly.)
+			hasRequiredTags: (tags) =>
+				tags.type === "country" &&
+				!!tags.geo_json &&
+				!!tags.name &&
+				!!tags.continent &&
+				validateContinents(tags.continent),
 		},
 	);
 


### PR DESCRIPTION
## Summary

Closes #1174, implemented per the re-review on the issue (the only one of the nine rated *sound as filed*), with its three amendments addressed as noted below.

**The problem**: the SSR loader fetched the full `/v3/areas/{slug}` (polygon included) plus up to ~150 KB of place-issues for *every* section, returned five scalar fields, and threw the rest away — so the client re-downloaded **5.7 MB of world areas** (the v2 crawl) just to recover a polygon the server already had. `offset=0` with no pagination silently truncated areas with >10k issues.

**What changed**

*Loader (`areaSectionLoad.ts`)*
- The bundle now carries the **full tags** (polygon included — free-madeira 2.5 KB, Germany 20 KB, US 39 KB, all cheap next to 5.7 MB), a **typed `contacts` object** (the 22 `contact:*` keys lifted once, replacing `area["contact:x"]` at every read site), and a **validated `cameraBbox`** from the human-authored `box:*` hints (coerced from the numbers the API actually serves, finite-checked; inverted/wrap boxes rejected).
- **Per-section pruning**: place-issues are fetched only for `/maintain`, the one section that renders them. Section navigation re-runs the loader, so landing on maintain fetches them then.
- **Real pagination**: offset loop until a short page, 10-page backstop with a logged truncation instead of a silent one.
- **Required-tag validation moved server-side** (`config.hasRequiredTags`): a malformed area now 404s at SSR instead of the old client-side `goto("/404")` — which previously fired only *after* the full world crawl.

*Client (`AreaPage`/`AreaMap`)*
- `AreaPage` initializes from `data.tags` — **`areasSync` leaves this page's `batchSync` entirely**, along with the `$areaError` toast (which would otherwise surface stale errors from other routes — the same class Copilot caught on #1183).
- `issues` became reactive to `data` (previously latched at first init, which would have shown an empty maintain table after a merchants → maintain navigation under pruning).
- `AreaMap` prefers the curated `box:*` camera bbox, falling back to the existing polygon fit.

**The three re-review amendments**
1. *bbox convention*: no convention mixing introduced — `box:*` is used as-is when valid (camera-only), wrap boxes (west ≥ east) are rejected server-side and fall back to the unchanged polygon fit. The geometry-derived, antimeridian-aware (`geoBounds`) helper is deliberately left to #1175, which needs it for containment.
2. *`box:*` camera-only, never containment*: enforced by construction — containment still uses the polygon (`geoContains`), untouched.
3. *`up_to_date_percent`*: explicitly punted to `reportsSync` (the amendment's sanctioned option) — `reportsSync` stays in `batchSync` and feeds the stats section + AreaMap stars exactly as before.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean, **549/549** unit tests (5 new: per-section pruning, pagination past 10k, required-tags 404, contacts lifting incl. empty-string drop, box coercion/rejection matrix)
- [x] SSR-verified against the dev server: `/community/free-madeira/merchants` embeds `geo_json` with **zero** issue rows; `/maintain` embeds 134 issue rows; `/country/de/merchants` embeds the polygon; a bogus slug 502s — **pre-existing** (upstream v3 returns 500 "Query returned no rows" for unknown slugs; prod behaves identically today)
- [ ] CI (build, e2e, type-checks)
- [ ] Manual browser QA: community + country pages render map/pins/contacts, network tab shows **no** `/v2/areas` crawl, maintain table populates after navigating from merchants

🤖 Generated with [Claude Code](https://claude.com/claude-code)