### PR TITLE
perf: placesInArea — bbox-prefiltered, chunked containment; area pages mount off SSR (#1175)

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -9,7 +9,7 @@ export let type: "country" | "community";
 export let data: AreaPageProps;
 
 import type { GeoJSON } from "geojson";
-import { onMount } from "svelte";
+import { onDestroy, onMount } from "svelte";
 
 import AreaActivity from "$components/area/AreaActivity.svelte";
 import AreaMap from "$components/area/AreaMap.svelte";
@@ -212,6 +212,17 @@ const initializeData = async () => {
 // per completed sweep — never a partial one.
 let sweepGeneration = 0;
 let sweptAreaId: string | undefined;
+// True once the current area's sweep has published — the merchant
+// highlights' skeleton gate (an empty filteredPlaces before this is
+// "still sweeping", after it is a genuine empty area).
+let sweepDone = false;
+
+// Leaving the page entirely must abandon an in-flight sweep at its next
+// chunk boundary — without this it would burn through the remaining ~29k
+// geoContains tests for a component that no longer exists.
+onDestroy(() => {
+	sweepGeneration++;
+});
 
 const runContainmentSweep = async (areaPlaces: Place[], geoJson: GeoJSON) => {
 	const generation = ++sweepGeneration;
@@ -220,6 +231,7 @@ const runContainmentSweep = async (areaPlaces: Place[], geoJson: GeoJSON) => {
 	});
 	if (result && generation === sweepGeneration) {
 		filteredPlaces = result;
+		sweepDone = true;
 	}
 };
 
@@ -245,6 +257,7 @@ $: if (data?.id !== lastAreaId) {
 	// Abandon any in-flight containment sweep and let the new area resweep.
 	sweepGeneration++;
 	sweptAreaId = undefined;
+	sweepDone = false;
 }
 
 // Header + map mount straight off the SSR bundle — no store wait. The
@@ -496,7 +509,10 @@ $: issues = data?.issues ?? [];
 			cameraBbox={data.cameraBbox}
 			upToDatePercent={areaReports?.[0]?.tags.up_to_date_percent}
 		/>
-		<AreaMerchantHighlights {dataInitialized} {filteredPlaces} />
+		<!-- Gate on sweep completion, not dataInitialized: init now finishes
+		     before the sweep, and an empty filteredPlaces mid-sweep is "still
+		     loading", not "no merchants here". -->
+		<AreaMerchantHighlights dataInitialized={sweepDone} {filteredPlaces} />
 		{#if browser}
 			<Boost />
 		{/if}

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -8,8 +8,7 @@ import { page } from "$app/stores";
 export let type: "country" | "community";
 export let data: AreaPageProps;
 
-import rewind from "@mapbox/geojson-rewind";
-import { geoContains } from "d3-geo";
+import type { GeoJSON } from "geojson";
 import { onMount } from "svelte";
 
 import AreaActivity from "$components/area/AreaActivity.svelte";
@@ -27,6 +26,7 @@ import Socials from "$components/Socials.svelte";
 import SponsorBadge from "$components/SponsorBadge.svelte";
 import Tip from "$components/Tip.svelte";
 import { API_BASE } from "$lib/api-base";
+import { placesInAreaChunked } from "$lib/area/placesInArea";
 import api from "$lib/axios";
 import { places, placesError, reportError, reports } from "$lib/store";
 import { batchSync } from "$lib/sync/batchSync";
@@ -201,18 +201,26 @@ const initializeData = async () => {
 		}
 	}
 
-	const rewoundPoly = rewind(area.geo_json, true);
-
-	// For AreaMap, filter places from client store
-	filteredPlaces = $places.filter((place: Place) => {
-		if (geoContains(rewoundPoly, [place.lon, place.lat])) {
-			return true;
-		} else {
-			return false;
-		}
-	});
-
 	dataInitialized = true;
+};
+
+// The containment sweep is decoupled from init: the header and AreaMap
+// mount immediately off the SSR bundle, and the pins land when $places and
+// the chunked sweep are done. Once per area (matching the old semantics —
+// later $places republications don't resweep), generation-guarded so an
+// area navigation abandons an in-flight sweep, publishing one fresh array
+// per completed sweep — never a partial one.
+let sweepGeneration = 0;
+let sweptAreaId: string | undefined;
+
+const runContainmentSweep = async (areaPlaces: Place[], geoJson: GeoJSON) => {
+	const generation = ++sweepGeneration;
+	const result = await placesInAreaChunked(areaPlaces, geoJson, {
+		isStale: () => generation !== sweepGeneration,
+	});
+	if (result && generation === sweepGeneration) {
+		filteredPlaces = result;
+	}
 };
 
 // Reset area-scoped state when the user navigates client-side to a different area.
@@ -234,9 +242,23 @@ $: if (data?.id !== lastAreaId) {
 	taggersFetchGeneration++;
 	taggers = [];
 	filteredPlaces = [];
+	// Abandon any in-flight containment sweep and let the new area resweep.
+	sweepGeneration++;
+	sweptAreaId = undefined;
 }
 
-$: data?.id && $places?.length && !dataInitialized && initializeData();
+// Header + map mount straight off the SSR bundle — no store wait. The
+// containment sweep (which does need $places) runs separately below.
+$: data?.id && !dataInitialized && initializeData();
+
+// Source order matters (the #1177 lesson): this must sit BELOW the reset
+// and init reactives so an area navigation resets state and re-inits
+// before the sweep guard is evaluated — otherwise it would fire once
+// against the outgoing area's polygon.
+$: if (dataInitialized && $places.length && sweptAreaId !== data.id) {
+	sweptAreaId = data.id;
+	runContainmentSweep($places, area.geo_json);
+}
 
 // Fire the area top-editors fetch only when the user actually lands on /activity.
 // One REST call replaces the previous per-place enrichment shim.

--- a/src/lib/area/placesInArea.test.ts
+++ b/src/lib/area/placesInArea.test.ts
@@ -1,0 +1,157 @@
+import rewind from "@mapbox/geojson-rewind";
+import { geoBounds, geoContains } from "d3-geo";
+import type { GeoJSON } from "geojson";
+import { describe, expect, it } from "vitest";
+
+import type { Place } from "$lib/types";
+
+import { placesInArea, placesInAreaChunked, pointInArea } from "./placesInArea";
+
+let nextId = 1;
+const place = (lon: number, lat: number): Place =>
+	({ id: nextId++, lat, lon }) as Place;
+
+// lon 10..20, lat 10..20
+const square = (): GeoJSON => ({
+	type: "Polygon",
+	coordinates: [
+		[
+			[10, 10],
+			[20, 10],
+			[20, 20],
+			[10, 20],
+			[10, 10],
+		],
+	],
+});
+
+// Fiji-style archipelago straddling the antimeridian: MultiPolygon parts on
+// each side (real OSM areas split at ±180; a single ring jumping 175 → -175
+// would break planar winding math and invert the interior). geoBounds merges
+// the parts into a wrap bbox (west > east) — the case where a naive
+// `lon < w || lon > e` reject drops EVERY in-area place. (Parts touching
+// ±180 exactly make d3 report a safe full-width bbox instead — unprunable
+// but never wrong.)
+const wrapArea = (): GeoJSON => ({
+	type: "MultiPolygon",
+	coordinates: [
+		[
+			[
+				[175, -20],
+				[179, -20],
+				[179, -10],
+				[175, -10],
+				[175, -20],
+			],
+		],
+		[
+			[
+				[-179, -20],
+				[-175, -20],
+				[-175, -10],
+				[-179, -10],
+				[-179, -20],
+			],
+		],
+	],
+});
+
+describe("placesInArea", () => {
+	it("matches the naive rewind + geoContains sweep exactly", () => {
+		const geo = square();
+		const candidates = [
+			place(15, 15),
+			place(10.5, 19.5),
+			place(25, 15),
+			place(15, 25),
+			place(-15, -15),
+			place(19.9, 10.1),
+		];
+
+		const naive = candidates.filter((p) =>
+			geoContains(rewind(square(), true), [p.lon, p.lat]),
+		);
+		const result = placesInArea(candidates, geo);
+
+		expect(result).toEqual(naive);
+		expect(result.map((p) => [p.lon, p.lat])).toEqual([
+			[15, 15],
+			[10.5, 19.5],
+			[19.9, 10.1],
+		]);
+	});
+
+	it("keeps in-area places on both sides of the antimeridian", () => {
+		const geo = wrapArea();
+		// Guard the fixture itself: this test only covers the wrap branch if
+		// geoBounds actually reports west > east for it (on the rewound
+		// geometry — raw RFC7946 winding reads as the complement in d3)
+		const [[west], [east]] = geoBounds(
+			rewind(wrapArea(), true) as Parameters<typeof geoBounds>[0],
+		);
+		expect(west).toBeGreaterThan(east);
+
+		const inEast = place(177, -15);
+		const inWest = place(-177, -15);
+		// Inside the wrap bbox but in the water between the parts —
+		// bbox passes it, geoContains rejects it
+		const betweenParts = place(180, -15);
+		const outFar = place(0, -15);
+		const outLat = place(177, -50);
+
+		const result = placesInArea(
+			[inEast, inWest, betweenParts, outFar, outLat],
+			geo,
+		);
+		expect(result).toEqual([inEast, inWest]);
+	});
+
+	it("returns nothing for degenerate geometry instead of throwing", () => {
+		const empty: GeoJSON = { type: "Polygon", coordinates: [] };
+		expect(placesInArea([place(15, 15)], empty)).toEqual([]);
+	});
+});
+
+describe("pointInArea", () => {
+	it("agrees with the sweep on both bbox rejection and containment", () => {
+		const geo = square();
+		expect(pointInArea(geo, 15, 15)).toBe(true);
+		// bbox-rejected (far outside)
+		expect(pointInArea(geo, 100, 15)).toBe(false);
+		// inside the bbox but outside the polygon can't happen for a square —
+		// the wrap area covers the interesting geometry above
+		expect(pointInArea(wrapArea(), -177, -15)).toBe(true);
+	});
+});
+
+describe("placesInAreaChunked", () => {
+	it("produces the same result as the synchronous sweep across chunk boundaries", async () => {
+		const geo = square();
+		// Cross two chunk boundaries (chunk size 5000) so the yield path runs
+		const many: Place[] = [];
+		for (let i = 0; i < 12001; i++) {
+			// Alternate inside/outside deterministically
+			many.push(i % 2 === 0 ? place(15, 15) : place(25, 15));
+		}
+
+		const chunked = await placesInAreaChunked(many, geo);
+		expect(chunked).toEqual(placesInArea(many, geo));
+		expect(chunked).toHaveLength(6001);
+	});
+
+	it("returns null when marked stale instead of publishing a partial result", async () => {
+		const geo = square();
+		const many: Place[] = [];
+		for (let i = 0; i < 6000; i++) {
+			many.push(place(15, 15));
+		}
+
+		let checks = 0;
+		const result = await placesInAreaChunked(many, geo, {
+			// Fresh for the first chunk, stale from the second boundary on —
+			// simulating an area navigation mid-sweep
+			isStale: () => ++checks > 1,
+		});
+		expect(result).toBeNull();
+	});
+});

--- a/src/lib/area/placesInArea.ts
+++ b/src/lib/area/placesInArea.ts
@@ -1,0 +1,117 @@
+import rewind from "@mapbox/geojson-rewind";
+import { geoBounds, geoContains } from "d3-geo";
+import type { GeoJSON } from "geojson";
+
+import type { Place } from "$lib/types";
+import { yieldToMain } from "$lib/utils";
+
+// The one point-in-area rule: a wrap-aware bbox prefilter cheaply rejects the
+// obvious outsiders, then geoContains decides for the survivors against the
+// rewound polygon. The bbox is ALWAYS derived from the polygon itself
+// (d3-geo's spherical geoBounds — antimeridian-aware, west > east for
+// wrapping areas like Fiji). There is deliberately NO caller-supplied bbox
+// parameter: an external box (e.g. the human-authored box:* camera hints)
+// smaller than the polygon would silently drop real merchants — advisory
+// perf data must never become a correctness filter (#1175 re-review).
+
+type AreaTester = (lon: number, lat: number) => boolean;
+
+// Both derived artifacts are cached per polygon object: geoBounds walks every
+// coordinate, and rewind is O(coords) too. WeakMap keying means a new SSR
+// bundle (new object) naturally gets fresh entries.
+const bboxCache = new WeakMap<
+	object,
+	[number, number, number, number] | null
+>();
+const testerCache = new WeakMap<object, AreaTester>();
+
+const deriveBbox = (
+	geoJson: GeoJSON,
+): [number, number, number, number] | null => {
+	const cached = bboxCache.get(geoJson);
+	if (cached !== undefined) return cached;
+	let bbox: [number, number, number, number] | null = null;
+	try {
+		// geoBounds returns [[west, south], [east, north]] on the sphere.
+		const [[w, s], [e, n]] = geoBounds(
+			geoJson as Parameters<typeof geoBounds>[0],
+		);
+		if ([w, s, e, n].every(Number.isFinite)) {
+			bbox = [w, s, e, n];
+		}
+	} catch {
+		// Degenerate geometry — no prefilter, geoContains decides everything
+	}
+	bboxCache.set(geoJson, bbox);
+	return bbox;
+};
+
+const createAreaTester = (geoJson: GeoJSON): AreaTester => {
+	const cached = testerCache.get(geoJson);
+	if (cached) return cached;
+
+	// Rewind BEFORE deriving bounds: d3 interprets ring winding spherically,
+	// so on raw RFC7946 (counterclockwise-exterior) data geoBounds sees the
+	// COMPLEMENT of the area and reports a useless full-width bbox — the
+	// prefilter would be silently inert for every well-formed polygon.
+	const rewoundPoly = rewind(geoJson, true);
+	const bbox = deriveBbox(rewoundPoly);
+
+	const tester: AreaTester = (lon, lat) => {
+		if (bbox) {
+			const [w, s, e, n] = bbox;
+			// Antimeridian-wrapping bboxes (Fiji, far-east Russia) have w > e:
+			// the valid longitude range is [w, 180] ∪ [-180, e]. A naive
+			// `lon < w || lon > e` reject against a wrap bbox would drop
+			// EVERY in-area place.
+			const outsideLon = w <= e ? lon < w || lon > e : lon < w && lon > e;
+			if (outsideLon || lat < s || lat > n) return false;
+		}
+		try {
+			return geoContains(rewoundPoly, [lon, lat]);
+		} catch {
+			return false;
+		}
+	};
+	testerCache.set(geoJson, tester);
+	return tester;
+};
+
+export const pointInArea = (
+	geoJson: GeoJSON,
+	lon: number,
+	lat: number,
+): boolean => createAreaTester(geoJson)(lon, lat);
+
+// Pure, synchronous sweep — the unit-testable equivalence anchor.
+export const placesInArea = (places: Place[], geoJson: GeoJSON): Place[] => {
+	const test = createAreaTester(geoJson);
+	return places.filter((place) => test(place.lon, place.lat));
+};
+
+const SWEEP_CHUNK_SIZE = 5000;
+
+// Chunked sweep for the ~29k-place store: yields to the main thread between
+// chunks so a heavy country polygon (Brazil's is 69 KB of coordinates)
+// doesn't block rendering for the whole pass. isStale is checked at every
+// chunk boundary; a stale sweep returns null and the caller publishes
+// nothing — one fresh array per completed sweep, never partial results.
+export const placesInAreaChunked = async (
+	places: Place[],
+	geoJson: GeoJSON,
+	opts: { isStale?: () => boolean } = {},
+): Promise<Place[] | null> => {
+	const test = createAreaTester(geoJson);
+	const result: Place[] = [];
+	for (let start = 0; start < places.length; start += SWEEP_CHUNK_SIZE) {
+		if (opts.isStale?.()) return null;
+		const end = Math.min(start + SWEEP_CHUNK_SIZE, places.length);
+		for (let i = start; i < end; i++) {
+			const place = places[i];
+			if (test(place.lon, place.lat)) result.push(place);
+		}
+		if (end < places.length) await yieldToMain();
+	}
+	if (opts.isStale?.()) return null;
+	return result;
+};


### PR DESCRIPTION
## Summary

Closes #1175, per the re-review on the issue (its amendments folded in; #1174 — the stated hard dependency — merged as #1210).

**What changed**

*New module: `src/lib/area/placesInArea.ts`* — the one point-in-area rule (pure + unit-testable):
- Wrap-aware bbox prefilter derived from the polygon itself via spherical `geoBounds` — antimeridian areas (Fiji-style MultiPolygons) produce west > east bboxes, and the union check keeps in-area places on both sides where a naive `lon < w || lon > e` reject would drop every one of them.
- **Deliberately no caller-supplied bbox parameter** (the re-review's amendment): advisory perf data must never become a correctness filter — the `box:*` camera hints from #1210 stay out of containment by construction.
- `geoContains` decides for the survivors against the once-rewound, per-polygon-cached geometry.
- `placesInAreaChunked`: yields to the main thread between 5k-place chunks and honors a staleness token with all-or-nothing publication.

*AreaPage adoption*:
- **Header and AreaMap mount straight off the SSR bundle** — initialization no longer waits for `$places`, so the polygon renders immediately and the pins land when the sweep completes (the issue's "no longer hostage" win, now actually possible post-#1210).
- The containment sweep is chunked (Brazil's 69 KB polygon can no longer block rendering for the whole ~29k-place pass) and generation-guarded: an area navigation abandons the in-flight sweep, and each completed sweep publishes exactly one fresh array — addressing the re-review's corrected version of the "fires twice" claim (the double `filteredPlaces` prop turnover).

**Found along the way** (pinned by the fixture-guard test): bounds must be derived from the *rewound* geometry — d3 interprets raw RFC7946 winding as the complement of the area and reports a useless full-width bbox. This is why the repo's existing prefilters (computed on raw polygons) never actually pruned anything; this module's does.

**Coordination note for #1176** (per re-review): the sweep's generation token owns in-flight-abandonment; the page's reset block still owns state clearing. The stacked #1176 PR keeps AreaMap outside any `{#key}` boundary, so this lifecycle stays load-bearing.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean, **557/557** unit tests (6 new: naive-sweep equivalence, antimeridian survival with a wrap-bbox fixture guard, degenerate geometry, chunk-boundary equivalence, stale-abort)
- [ ] CI (build, e2e, type-checks)
- [ ] Manual browser QA: community + country pages — map appears immediately with the outline, pins fill in; navigating between areas mid-load doesn't leak the previous area's pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)