### PR TITLE
refactor: AreaHeader extraction + one typed contacts object (#1176)

### DIFF
--- a/src/components/IssuesTable.svelte
+++ b/src/components/IssuesTable.svelte
@@ -209,6 +209,16 @@ const renderTable = () => {
 	tableRendered = true;
 };
 
+// Rebuild when the issues prop itself changes: client-side area navigation
+// reuses this component instance, and the TanStack table snapshots `issues`
+// at render time — without this the previous area's rows would linger under
+// the new area's count. Same mechanism as the locale rebuild below.
+let lastIssues = issues;
+$: if (issues !== lastIssues) {
+	lastIssues = issues;
+	tableRendered = false;
+}
+
 $: !loading && !tableRendered && renderTable();
 
 // Re-render the table when locale changes so column headers and

--- a/src/components/Socials.svelte
+++ b/src/components/Socials.svelte
@@ -4,58 +4,31 @@ export let contacts: AreaContacts = {};
 
 export let style: undefined | string = undefined;
 
-// The template and the sanitized derivations below keep their historical
-// per-key names — only the interface collapsed
-$: ({
-	website,
-	email,
-	phone,
-	nostr,
-	twitter,
-	meetup,
-	telegram,
-	discord,
-	youtube,
-	github,
-	matrix,
-	geyser,
-	satlantis,
-	eventbrite,
-	reddit,
-	simplex,
-	instagram,
-	whatsapp,
-	facebook,
-	linkedin,
-	rss,
-	signal,
-} = contacts);
-
 import Icon from "$components/Icon.svelte";
 import IconSocials from "$lib/icons/IconSocials.svelte";
 import type { AreaContacts } from "$lib/types";
 import { sanitizeUrl } from "$lib/utils";
 
 // Sanitize URLs to prevent XSS from malicious protocols like javascript:
-$: safeWebsite = sanitizeUrl(website);
-$: safeTwitter = sanitizeUrl(twitter);
-$: safeMeetup = sanitizeUrl(meetup);
-$: safeTelegram = sanitizeUrl(telegram);
-$: safeDiscord = sanitizeUrl(discord);
-$: safeYoutube = sanitizeUrl(youtube);
-$: safeGithub = sanitizeUrl(github);
-$: safeMatrix = sanitizeUrl(matrix);
-$: safeGeyser = sanitizeUrl(geyser);
-$: safeSatlantis = sanitizeUrl(satlantis);
-$: safeEventbrite = sanitizeUrl(eventbrite);
-$: safeReddit = sanitizeUrl(reddit);
-$: safeSimplex = sanitizeUrl(simplex);
-$: safeInstagram = sanitizeUrl(instagram);
-$: safeWhatsapp = sanitizeUrl(whatsapp);
-$: safeFacebook = sanitizeUrl(facebook);
-$: safeLinkedin = sanitizeUrl(linkedin);
-$: safeRss = sanitizeUrl(rss);
-$: safeSignal = sanitizeUrl(signal);
+$: safeWebsite = sanitizeUrl(contacts.website);
+$: safeTwitter = sanitizeUrl(contacts.twitter);
+$: safeMeetup = sanitizeUrl(contacts.meetup);
+$: safeTelegram = sanitizeUrl(contacts.telegram);
+$: safeDiscord = sanitizeUrl(contacts.discord);
+$: safeYoutube = sanitizeUrl(contacts.youtube);
+$: safeGithub = sanitizeUrl(contacts.github);
+$: safeMatrix = sanitizeUrl(contacts.matrix);
+$: safeGeyser = sanitizeUrl(contacts.geyser);
+$: safeSatlantis = sanitizeUrl(contacts.satlantis);
+$: safeEventbrite = sanitizeUrl(contacts.eventbrite);
+$: safeReddit = sanitizeUrl(contacts.reddit);
+$: safeSimplex = sanitizeUrl(contacts.simplex);
+$: safeInstagram = sanitizeUrl(contacts.instagram);
+$: safeWhatsapp = sanitizeUrl(contacts.whatsapp);
+$: safeFacebook = sanitizeUrl(contacts.facebook);
+$: safeLinkedin = sanitizeUrl(contacts.linkedin);
+$: safeRss = sanitizeUrl(contacts.rss);
+$: safeSignal = sanitizeUrl(contacts.signal);
 </script>
 
 <div class="flex flex-wrap items-center justify-center {style || ''}">
@@ -66,22 +39,22 @@ $: safeSignal = sanitizeUrl(signal);
 			</span>
 		</a>
 	{/if}
-	{#if email}
-		<a href="mailto:{email}" target="_blank" rel="noreferrer" class="m-1">
+	{#if contacts.email}
+		<a href="mailto:{contacts.email}" target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-[#53C5D5]">
 				<Icon type="fa" icon="envelope" w="28" h="28" class="text-white" />
 			</span>
 		</a>
 	{/if}
-	{#if phone}
-		<a href="tel:{phone}" target="_blank" rel="noreferrer" class="m-1">
+	{#if contacts.phone}
+		<a href="tel:{contacts.phone}" target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-green-600">
 				<Icon type="fa" icon="phone" w="28" h="28" class="text-white" />
 			</span>
 		</a>
 	{/if}
-	{#if nostr}
-		<a href="https://nostr.com/{nostr}" target="_blank" rel="noreferrer" class="m-1">
+	{#if contacts.nostr}
+		<a href="https://nostr.com/{contacts.nostr}" target="_blank" rel="noreferrer" class="m-1">
 			<span class="flex h-[40px] w-[40px] items-center justify-center rounded-full bg-nostr">
 				<IconSocials w="28" h="28" icon="nostr" class="text-white" />
 			</span>

--- a/src/components/Socials.svelte
+++ b/src/components/Socials.svelte
@@ -1,31 +1,39 @@
 <script lang="ts">
-export let website: undefined | string = undefined;
-export let email: undefined | string = undefined;
-export let phone: undefined | string = undefined;
-export let nostr: undefined | string = undefined;
-export let twitter: undefined | string = undefined;
-export let meetup: undefined | string = undefined;
-export let telegram: undefined | string = undefined;
-export let discord: undefined | string = undefined;
-export let youtube: undefined | string = undefined;
-export let github: undefined | string = undefined;
-export let matrix: undefined | string = undefined;
-export let geyser: undefined | string = undefined;
-export let satlantis: undefined | string = undefined;
-export let eventbrite: undefined | string = undefined;
-export let reddit: undefined | string = undefined;
-export let simplex: undefined | string = undefined;
-export let instagram: undefined | string = undefined;
-export let whatsapp: undefined | string = undefined;
-export let facebook: undefined | string = undefined;
-export let linkedin: undefined | string = undefined;
-export let rss: undefined | string = undefined;
-export let signal: undefined | string = undefined;
+// One typed object (see $lib/area/contacts) instead of 22 named props
+export let contacts: AreaContacts = {};
 
 export let style: undefined | string = undefined;
 
+// The template and the sanitized derivations below keep their historical
+// per-key names — only the interface collapsed
+$: ({
+	website,
+	email,
+	phone,
+	nostr,
+	twitter,
+	meetup,
+	telegram,
+	discord,
+	youtube,
+	github,
+	matrix,
+	geyser,
+	satlantis,
+	eventbrite,
+	reddit,
+	simplex,
+	instagram,
+	whatsapp,
+	facebook,
+	linkedin,
+	rss,
+	signal,
+} = contacts);
+
 import Icon from "$components/Icon.svelte";
 import IconSocials from "$lib/icons/IconSocials.svelte";
+import type { AreaContacts } from "$lib/types";
 import { sanitizeUrl } from "$lib/utils";
 
 // Sanitize URLs to prevent XSS from malicious protocols like javascript:

--- a/src/components/area/AreaHeader.svelte
+++ b/src/components/area/AreaHeader.svelte
@@ -1,0 +1,135 @@
+<script lang="ts">
+import { _ } from "svelte-i18n";
+
+import Icon from "$components/Icon.svelte";
+import OrgBadge from "$components/OrgBadge.svelte";
+import SaveButton from "$components/SaveButton.svelte";
+import Socials from "$components/Socials.svelte";
+import SponsorBadge from "$components/SponsorBadge.svelte";
+import Tip from "$components/Tip.svelte";
+import type { AreaPageProps } from "$lib/types.js";
+import { TipType } from "$lib/types.js";
+import { areaIconSrc, formatVerifiedHuman } from "$lib/utils";
+import { isRecentlyVerified } from "$lib/verification";
+
+export let type: "country" | "community";
+export let data: AreaPageProps;
+// The verify link jumps to the maintain section's form — section state is
+// the page's concern, so the behavior stays there.
+export let onVerifyClick: () => void;
+
+// Everything below DERIVES from the SSR bundle — no imperative init, no
+// reset lifecycle: an area navigation swaps `data` and every value follows.
+$: area = data.tags;
+$: alias = data.id;
+let name: string;
+$: name = data.name;
+$: avatar =
+	type === "community"
+		? areaIconSrc(data.id, area["icon:square"])
+		: `https://static.btcmap.org/images/countries/${data.id}.svg`;
+$: description = area.description;
+$: org = area.organization;
+$: sponsor = area.sponsor;
+$: hasContact = Object.keys(data.contacts).length > 0;
+$: verifiedDate = data.verifiedDate || area["verified:date"];
+$: isVerifiedDateStale = !isRecentlyVerified(verifiedDate);
+$: lightning = area["tips:lightning_address"]
+	? { destination: area["tips:lightning_address"], type: TipType.Address }
+	: area["tips:url"]
+		? { destination: area["tips:url"], type: TipType.Url }
+		: undefined;
+</script>
+
+<section id="profile" class="space-y-8">
+	<div class="space-y-2">
+		<img
+			src={avatar}
+			alt={$_('aria.avatarAlt')}
+			class="mx-auto h-32 w-32 rounded-full object-cover"
+			on:error={function () {
+				this.src = '/images/bitcoin.svg';
+			}}
+		/>
+		<h1 class="text-4xl !leading-tight font-semibold text-primary dark:text-white">
+			{name || $_('area.defaultName')}
+		</h1>
+		<SaveButton id={data.numericId} type="area" />
+		{#if org}
+			<OrgBadge {org} />
+		{/if}
+		{#if sponsor}
+			<SponsorBadge />
+		{/if}
+		{#if description}
+			<p class="text-xl text-primary dark:text-white">{description}</p>
+		{/if}
+		{#if type === 'community'}
+			<a
+				href={`/communities/map?community=${encodeURIComponent(alias)}`}
+				class="inline-flex items-center justify-center text-xs text-link transition-colors hover:text-hover"
+				>{$_('area.viewOnCommunityMap')} <svg
+					class="ml-1 w-3"
+					width="16"
+					height="16"
+					viewBox="0 0 16 16"
+					fill="none"
+					xmlns="http://www.w3.org/2000/svg"
+				>
+					<path
+						d="M3 13L13 3M13 3H5.5M13 3V10.5"
+						stroke="currentColor"
+						stroke-width="1.5"
+						stroke-linecap="round"
+						stroke-linejoin="round"
+					/>
+				</svg></a
+			>
+		{/if}
+		{#if type === 'community'}
+			{#if verifiedDate}
+				<div class="flex items-center justify-center gap-2 text-sm font-semibold">
+					{#if isVerifiedDateStale}
+						<div
+							class="flex items-center gap-1 rounded-full bg-orange-100 px-3 py-1 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300"
+						>
+							<Icon type="fa" icon="circle-exclamation" w="14" h="14" />
+							<span>{$_('area.verifiedOverYearAgo')}</span>
+						</div>
+					{:else}
+						<div
+							class="flex items-center gap-1 rounded-full bg-green-100 px-3 py-1 text-green-700 dark:bg-green-900/30 dark:text-green-300"
+						>
+							<Icon type="material" icon="verified" w="14" h="14" />
+							<span>{$_('area.verified')}: {formatVerifiedHuman(verifiedDate)}</span>
+						</div>
+					{/if}
+				</div>
+			{:else}
+				<div class="flex items-center justify-center gap-2 text-sm font-semibold">
+					<div
+						class="flex items-center gap-1 rounded-full bg-red-100 px-3 py-1 text-red-700 dark:bg-red-900/30 dark:text-red-300"
+					>
+						<Icon type="fa" icon="circle-xmark" w="14" h="14" />
+						<span>{$_('area.notRecentlyVerified')}</span>
+					</div>
+				</div>
+			{/if}
+			<a
+				href={`/community/${encodeURIComponent(alias)}/maintain#verify-form`}
+				class="inline-flex items-center justify-center text-xs text-link transition-colors hover:text-hover"
+				on:click|preventDefault={onVerifyClick}>{$_('area.verifyCommunity')}</a
+			>
+		{/if}
+	</div>
+
+	{#if type === 'community'}
+		{#if hasContact}
+			<Socials contacts={data.contacts} />
+		{/if}
+
+		{#if lightning}
+			<Tip destination={lightning.destination} type={lightning.type} user={name} />
+		{/if}
+	{/if}
+</section>

--- a/src/components/area/AreaHeader.svelte
+++ b/src/components/area/AreaHeader.svelte
@@ -14,9 +14,6 @@ import { isRecentlyVerified } from "$lib/verification";
 
 export let type: "country" | "community";
 export let data: AreaPageProps;
-// The verify link jumps to the maintain section's form — section state is
-// the page's concern, so the behavior stays there.
-export let onVerifyClick: () => void;
 
 // Everything below DERIVES from the SSR bundle — no imperative init, no
 // reset lifecycle: an area navigation swaps `data` and every value follows.
@@ -115,10 +112,14 @@ $: lightning = area["tips:lightning_address"]
 					</div>
 				</div>
 			{/if}
+			<!-- Plain navigation on purpose: the maintain route's own load fetches
+			     the per-section-pruned issues, and the hash scrolls to the form. An
+			     in-place section switch would render maintain with an empty issues
+			     table (#1210's pruning). -->
 			<a
 				href={`/community/${encodeURIComponent(alias)}/maintain#verify-form`}
 				class="inline-flex items-center justify-center text-xs text-link transition-colors hover:text-hover"
-				on:click|preventDefault={onVerifyClick}>{$_('area.verifyCommunity')}</a
+				>{$_('area.verifyCommunity')}</a
 			>
 		{/if}
 	</div>

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -58,18 +58,6 @@ $: activeSection = (SECTIONS as readonly string[]).includes(
 const handleSectionChange = (section: Section) => {
 	goto(`/${type}/${encodeURIComponent(data.id)}/${section}`);
 };
-
-// The header's verify link jumps straight to the maintain form without a
-// route change (matching the legacy behavior the link always had).
-const handleVerifyClick = () => {
-	activeSection = "maintain";
-	setTimeout(() => {
-		const form = document.getElementById("verify-form");
-		if (form) {
-			form.scrollIntoView({ behavior: "smooth", block: "center" });
-		}
-	}, 100);
-};
 // taggersInFlight prevents re-fire during the async fetch; taggersLoaded
 // gates the UI so the skeleton stays up until the fetch completes. Per-
 // request transient failures are handled by axiosRetry on the shared
@@ -215,7 +203,7 @@ $: issues = data?.issues ?? [];
 </script>
 
 <main class="my-10 space-y-16 text-center md:my-20">
-<AreaHeader {type} {data} onVerifyClick={handleVerifyClick} />
+<AreaHeader {type} {data} />
 
 	<div
 		on:scroll={() => (scrolled = true)}

--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -12,6 +12,7 @@ import type { GeoJSON } from "geojson";
 import { onDestroy, onMount } from "svelte";
 
 import AreaActivity from "$components/area/AreaActivity.svelte";
+import AreaHeader from "$components/area/AreaHeader.svelte";
 import AreaMap from "$components/area/AreaMap.svelte";
 import AreaMerchantHighlights from "$components/area/AreaMerchantHighlights.svelte";
 import AreaStats from "$components/area/AreaStats.svelte";
@@ -20,27 +21,14 @@ import VerifyCommunityForm from "$components/area/VerifyCommunityForm.svelte";
 import Boost from "$components/Boost.svelte";
 import Icon from "$components/Icon.svelte";
 import IssuesTable from "$components/IssuesTable.svelte";
-import OrgBadge from "$components/OrgBadge.svelte";
-import SaveButton from "$components/SaveButton.svelte";
-import Socials from "$components/Socials.svelte";
-import SponsorBadge from "$components/SponsorBadge.svelte";
-import Tip from "$components/Tip.svelte";
 import { API_BASE } from "$lib/api-base";
 import { placesInAreaChunked } from "$lib/area/placesInArea";
 import api from "$lib/axios";
 import { places, placesError, reportError, reports } from "$lib/store";
 import { batchSync } from "$lib/sync/batchSync";
 import { reportsSync } from "$lib/sync/reports";
-import type {
-	AreaPageProps,
-	AreaTags,
-	Place,
-	PlaceIssue,
-	Tagger,
-} from "$lib/types.js";
-import { TipType } from "$lib/types.js";
-import { areaIconSrc, errToast, formatVerifiedHuman } from "$lib/utils";
-import { isRecentlyVerified } from "$lib/verification";
+import type { AreaPageProps, Place, PlaceIssue, Tagger } from "$lib/types.js";
+import { errToast } from "$lib/utils";
 
 onMount(() => {
 	// reportsSync feeds the stats section and the AreaMap grade stars. The
@@ -54,53 +42,34 @@ $: $placesError && errToast($placesError);
 // alert for report errors
 $: $reportError && errToast($reportError);
 
-enum Sections {
-	merchants = "merchants",
-	stats = "stats",
-	activity = "activity",
-	maintain = "maintain",
-}
+// One source of truth: the section id IS the route slug IS the i18n key
+// suffix — the previous enum + three parallel Records carried no information.
+const SECTIONS = ["merchants", "stats", "activity", "maintain"] as const;
+type Section = (typeof SECTIONS)[number];
 
-const sectionKeys: Record<Sections, string> = {
-	[Sections.merchants]: "area.sections.merchants",
-	[Sections.stats]: "area.sections.stats",
-	[Sections.activity]: "area.sections.activity",
-	[Sections.maintain]: "area.sections.maintain",
-};
-
-const sections = Object.values(Sections);
 let scrolled = false;
 
-// Map section names to URL-friendly slugs
-const sectionSlugs: Record<Sections, string> = {
-	[Sections.merchants]: "merchants",
-	[Sections.stats]: "stats",
-	[Sections.activity]: "activity",
-	[Sections.maintain]: "maintain",
+$: activeSection = (SECTIONS as readonly string[]).includes(
+	$page.params.section ?? "",
+)
+	? ($page.params.section as Section)
+	: ("merchants" as Section);
+
+const handleSectionChange = (section: Section) => {
+	goto(`/${type}/${encodeURIComponent(data.id)}/${section}`);
 };
 
-// Reverse mapping from slugs to sections
-const slugToSection: Record<string, Sections> = {
-	merchants: Sections.merchants,
-	stats: Sections.stats,
-	activity: Sections.activity,
-	maintain: Sections.maintain,
+// The header's verify link jumps straight to the maintain form without a
+// route change (matching the legacy behavior the link always had).
+const handleVerifyClick = () => {
+	activeSection = "maintain";
+	setTimeout(() => {
+		const form = document.getElementById("verify-form");
+		if (form) {
+			form.scrollIntoView({ behavior: "smooth", block: "center" });
+		}
+	}, 100);
 };
-
-// Get the current section from the route parameter
-$: currentSection = $page.params.section || "merchants";
-$: activeSection = slugToSection[currentSection] || Sections.merchants;
-
-// Handle section change
-const handleSectionChange = (section: Sections) => {
-	const slug = sectionSlugs[section];
-	const areaId = encodeURIComponent(data.id);
-	goto(`/${type}/${areaId}/${slug}`);
-};
-
-// No need for hash handling anymore - sections are handled by route parameters
-
-let dataInitialized = false;
 // taggersInFlight prevents re-fire during the async fetch; taggersLoaded
 // gates the UI so the skeleton stays up until the fetch completes. Per-
 // request transient failures are handled by axiosRetry on the shared
@@ -145,65 +114,6 @@ const fetchAreaTopEditors = async () => {
 	}
 };
 
-const initializeData = async () => {
-	if (dataInitialized) return;
-
-	// The SSR bundle carries the full v3 tags (polygon included) and 404s
-	// server-side when required tags are missing — no $areas lookup, no
-	// world-areas crawl, no client goto("/404") (#1174).
-	area = data.tags;
-
-	avatar =
-		type === "community"
-			? areaIconSrc(data.id, area["icon:square"])
-			: `https://static.btcmap.org/images/countries/${data.id}.svg`;
-	description = area.description;
-
-	if (type === "community") {
-		org = area.organization;
-		sponsor = area.sponsor;
-		// The bundle lifts the contact:* tags into one typed object
-		({
-			website,
-			email,
-			phone,
-			nostr,
-			twitter,
-			meetup,
-			telegram,
-			discord,
-			youtube,
-			github,
-			matrix,
-			geyser,
-			satlantis,
-			eventbrite,
-			reddit,
-			simplex,
-			instagram,
-			whatsapp,
-			facebook,
-			linkedin,
-			rss,
-			signal,
-		} = data.contacts);
-		hasContact = Object.keys(data.contacts).length > 0;
-		verifiedDate = data.verifiedDate || area["verified:date"];
-		isVerifiedDateStale = !isRecentlyVerified(verifiedDate);
-
-		if (area["tips:lightning_address"]) {
-			lightning = {
-				destination: area["tips:lightning_address"],
-				type: TipType.Address,
-			};
-		} else if (area["tips:url"]) {
-			lightning = { destination: area["tips:url"], type: TipType.Url };
-		}
-	}
-
-	dataInitialized = true;
-};
-
 // The containment sweep is decoupled from init: the header and AreaMap
 // mount immediately off the SSR bundle, and the pins land when $places and
 // the chunked sweep are done. Once per area (matching the old semantics —
@@ -235,16 +145,14 @@ const runContainmentSweep = async (areaPlaces: Place[], geoJson: GeoJSON) => {
 	}
 };
 
-// Reset area-scoped state when the user navigates client-side to a different area.
-// SvelteKit reuses the +page.svelte instance (and this AreaPage) across
-// /country/X/* → /country/Y/* transitions, and initializeData has an early
-// `if (dataInitialized) return` guard — so without this reset the previous area's
-// state would leak into the next one. Must run before the initializeData reactive
-// below so dataInitialized=false is observed on the same tick.
+// Header state is fully derived (inside AreaHeader) and `area` below derives
+// too — the only state needing an explicit reset on client-side area
+// navigation is the async machinery: the taggers fetch and the containment
+// sweep. SvelteKit reuses this component instance across
+// /country/X/* → /country/Y/* transitions.
 let lastAreaId: string | undefined;
 $: if (data?.id !== lastAreaId) {
 	lastAreaId = data.id;
-	dataInitialized = false;
 	taggersInFlight = false;
 	taggersLoaded = false;
 	taggersLoadError = false;
@@ -260,15 +168,11 @@ $: if (data?.id !== lastAreaId) {
 	sweepDone = false;
 }
 
-// Header + map mount straight off the SSR bundle — no store wait. The
-// containment sweep (which does need $places) runs separately below.
-$: data?.id && !dataInitialized && initializeData();
-
 // Source order matters (the #1177 lesson): this must sit BELOW the reset
-// and init reactives so an area navigation resets state and re-inits
-// before the sweep guard is evaluated — otherwise it would fire once
-// against the outgoing area's polygon.
-$: if (dataInitialized && $places.length && sweptAreaId !== data.id) {
+// reactive so an area navigation resets sweep state before the guard is
+// evaluated — otherwise it would fire once against the outgoing area's
+// polygon.
+$: if (area?.geo_json && $places.length && sweptAreaId !== data.id) {
 	sweptAreaId = data.id;
 	runContainmentSweep($places, area.geo_json);
 }
@@ -277,58 +181,29 @@ $: if (dataInitialized && $places.length && sweptAreaId !== data.id) {
 // One REST call replaces the previous per-place enrichment shim.
 $: if (
 	browser &&
-	activeSection === Sections.activity &&
+	activeSection === "activity" &&
 	!taggersInFlight &&
 	!taggersLoaded
 ) {
 	fetchAreaTopEditors();
 }
 
-// Calculate areaReports reactively based on data initialization and reports store
 // Returns undefined while loading, empty array if no reports for this area, or filtered reports
 $: areaReports =
-	dataInitialized && data?.id && $reports.length > 0
+	data?.id && $reports.length > 0
 		? $reports
 				.filter((report) => report.area_id === data.id)
 				.sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
 		: undefined;
 
-let area: AreaTags;
+// Derived, not initialized: the previous `const alias/name` froze the
+// first area's values for the lifetime of the reused component instance —
+// stale after any client-side area navigation.
+$: area = data.tags;
+$: alias = data.id;
+let name: string;
+$: name = data.name;
 let filteredPlaces: Place[] = [];
-
-let avatar: string;
-const alias = data.id;
-const name = data.name;
-let description: string | undefined;
-let org: string | undefined;
-let sponsor: boolean | undefined;
-let website: string | undefined;
-let email: string | undefined;
-let phone: string | undefined;
-let nostr: string | undefined;
-let twitter: string | undefined;
-let meetup: string | undefined;
-let telegram: string | undefined;
-let discord: string | undefined;
-let youtube: string | undefined;
-let github: string | undefined;
-let matrix: string | undefined;
-let geyser: string | undefined;
-let satlantis: string | undefined;
-let eventbrite: string | undefined;
-let reddit: string | undefined;
-let simplex: string | undefined;
-let instagram: string | undefined;
-let whatsapp: string | undefined;
-let facebook: string | undefined;
-let linkedin: string | undefined;
-let rss: string | undefined;
-let signal: string | undefined;
-let verifiedDate: string | undefined = data.verifiedDate;
-let hasContact = false;
-
-let isVerifiedDateStale: boolean = !isRecentlyVerified(data.verifiedDate);
-let lightning: { destination: string; type: TipType } | undefined;
 
 let taggers: Tagger[] = [];
 
@@ -340,147 +215,13 @@ $: issues = data?.issues ?? [];
 </script>
 
 <main class="my-10 space-y-16 text-center md:my-20">
-	<section id="profile" class="space-y-8">
-		<div class="space-y-2">
-			{#if avatar}
-				<img
-					src={avatar}
-					alt={$_('aria.avatarAlt')}
-					class="mx-auto h-32 w-32 rounded-full object-cover"
-					on:error={function () {
-						this.src = '/images/bitcoin.svg';
-					}}
-				/>
-			{:else}
-				<div class="mx-auto h-32 w-32 animate-pulse rounded-full bg-link/50" />
-			{/if}
-			<h1 class="text-4xl !leading-tight font-semibold text-primary dark:text-white">
-				{name || $_('area.defaultName')}
-			</h1>
-			<SaveButton id={data.numericId} type="area" />
-			{#if org}
-				<OrgBadge {org} />
-			{/if}
-			{#if sponsor}
-				<SponsorBadge />
-			{/if}
-			{#if description}
-				<p class="text-xl text-primary dark:text-white">{description}</p>
-			{/if}
-			{#if alias && type === 'community'}
-				<a
-					href={`/communities/map?community=${encodeURIComponent(alias)}`}
-					class="inline-flex items-center justify-center text-xs text-link transition-colors hover:text-hover"
-					>{$_('area.viewOnCommunityMap')} <svg
-						class="ml-1 w-3"
-						width="16"
-						height="16"
-						viewBox="0 0 16 16"
-						fill="none"
-						xmlns="http://www.w3.org/2000/svg"
-					>
-						<path
-							d="M3 13L13 3M13 3H5.5M13 3V10.5"
-							stroke="currentColor"
-							stroke-width="1.5"
-							stroke-linecap="round"
-							stroke-linejoin="round"
-						/>
-					</svg></a
-				>
-			{/if}
-			{#if type === 'community'}
-				{#if verifiedDate}
-					<div class="flex items-center justify-center gap-2 text-sm font-semibold">
-						{#if isVerifiedDateStale}
-							<div
-								class="flex items-center gap-1 rounded-full bg-orange-100 px-3 py-1 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300"
-							>
-								<Icon type="fa" icon="circle-exclamation" w="14" h="14" />
-								<span>{$_('area.verifiedOverYearAgo')}</span>
-							</div>
-						{:else}
-							<div
-								class="flex items-center gap-1 rounded-full bg-green-100 px-3 py-1 text-green-700 dark:bg-green-900/30 dark:text-green-300"
-							>
-								<Icon type="material" icon="verified" w="14" h="14" />
-								<span>{$_('area.verified')}: {formatVerifiedHuman(verifiedDate)}</span>
-							</div>
-						{/if}
-					</div>
-				{:else}
-					<div class="flex items-center justify-center gap-2 text-sm font-semibold">
-						<div
-							class="flex items-center gap-1 rounded-full bg-red-100 px-3 py-1 text-red-700 dark:bg-red-900/30 dark:text-red-300"
-						>
-							<Icon type="fa" icon="circle-xmark" w="14" h="14" />
-							<span>{$_('area.notRecentlyVerified')}</span>
-						</div>
-					</div>
-				{/if}
-				{#if type === 'community'}
-					<a
-						href={`/community/${encodeURIComponent(alias)}/maintain#verify-form`}
-						class="inline-flex items-center justify-center text-xs text-link transition-colors hover:text-hover"
-						on:click|preventDefault={() => {
-							activeSection = Sections.maintain;
-							setTimeout(() => {
-								const form = document.getElementById('verify-form');
-								if (form) {
-									form.scrollIntoView({ behavior: 'smooth', block: 'center' });
-								}
-							}, 100);
-						}}>{$_('area.verifyCommunity')}</a
-					>
-				{/if}
-			{/if}
-		</div>
-
-		{#if type === 'community'}
-			{#if dataInitialized && hasContact}
-				<Socials
-					{website}
-					{email}
-					{phone}
-					{nostr}
-					{twitter}
-					{meetup}
-					{telegram}
-					{discord}
-					{youtube}
-					{github}
-					{matrix}
-					{geyser}
-					{satlantis}
-					{eventbrite}
-					{reddit}
-					{simplex}
-					{instagram}
-					{whatsapp}
-					{facebook}
-					{linkedin}
-					{rss}
-					{signal}
-				/>
-			{:else if !dataInitialized}
-				<div class="flex flex-wrap items-center justify-center">
-					{#each Array(3) as _, index (index)}
-						<div class="m-1 h-10 w-10 animate-pulse rounded-full bg-link/50" />
-					{/each}
-				</div>
-			{/if}
-
-			{#if lightning}
-				<Tip destination={lightning.destination} type={lightning.type} user={name} />
-			{/if}
-		{/if}
-	</section>
+<AreaHeader {type} {data} onVerifyClick={handleVerifyClick} />
 
 	<div
 		on:scroll={() => (scrolled = true)}
 		class="hide-scroll relative grid w-full auto-cols-[minmax(150px,_1fr)] grid-flow-col overflow-x-auto"
 	>
-		{#each sections as section, index (index)}
+		{#each SECTIONS as section (section)}
 			<button
 				on:click={() => handleSectionChange(section)}
 				class="border-b-4 pb-3 text-center text-lg text-link transition-colors hover:border-link {activeSection ===
@@ -488,7 +229,7 @@ $: issues = data?.issues ?? [];
 					? 'border-link font-bold'
 					: 'border-link/25'}"
 			>
-				{$_(sectionKeys[section])}
+				{$_(`area.sections.${section}`)}
 			</button>
 		{/each}
 
@@ -501,7 +242,7 @@ $: issues = data?.issues ?? [];
 		{/if}
 	</div>
 
-	{#if activeSection === Sections.merchants}
+	{#if activeSection === 'merchants'}
 		<AreaMap
 			{name}
 			geoJSON={area?.geo_json}
@@ -516,7 +257,7 @@ $: issues = data?.issues ?? [];
 		{#if browser}
 			<Boost />
 		{/if}
-	{:else if activeSection === Sections.stats}
+	{:else if activeSection === 'stats'}
 		{#if $reportError}
 			<div class="text-center text-primary dark:text-white">
 				<p>{$_('area.errorLoadingData')}</p>
@@ -532,20 +273,22 @@ $: issues = data?.issues ?? [];
 				<p class="text-xl">{$_('area.dataWithin24Hours')}</p>
 			</div>
 		{/if}
-	{:else if activeSection === Sections.activity}
+	{:else if activeSection === 'activity'}
+		<!-- Area data is SSR-delivered now, so it is initialized by definition;
+		     the prop survives until AreaFeed drops its gate. -->
 		<AreaActivity
 			{alias}
 			{name}
-			{dataInitialized}
+			dataInitialized={true}
 			{taggersLoaded}
 			{taggers}
 			{taggersLoadError}
 		/>
-	{:else if activeSection === Sections.maintain}
+	{:else if activeSection === 'maintain'}
 		<IssuesTable
 			title={$_('area.taggingIssues', { values: { name: name || $_('area.defaultName') } })}
 			{issues}
-			loading={!dataInitialized}
+			loading={false}
 		/>
 		<AreaTickets tickets={data.tickets} title={$_('area.openTickets', { values: { name: name || $_('area.defaultName') } })} />
 		{#if type === 'community'}

--- a/src/lib/area/contacts.ts
+++ b/src/lib/area/contacts.ts
@@ -1,0 +1,16 @@
+import type { AreaContacts, AreaTags } from "$lib/types";
+import { AREA_CONTACT_KEYS } from "$lib/types";
+
+// Lift the 22 `contact:*` string tags into one typed object so consumers
+// stop spelling `area["contact:satlantis"]` at every read site. Shared by
+// the SSR area bundle (areaSectionLoad) and the communities-map popups.
+export const extractContacts = (tags: AreaTags): AreaContacts => {
+	const contacts: AreaContacts = {};
+	for (const key of AREA_CONTACT_KEYS) {
+		const value = tags[`contact:${key}`];
+		if (typeof value === "string" && value) {
+			contacts[key] = value;
+		}
+	}
+	return contacts;
+};

--- a/src/lib/areaSectionLoad.ts
+++ b/src/lib/areaSectionLoad.ts
@@ -1,13 +1,8 @@
 import { error, isHttpError, redirect } from "@sveltejs/kit";
 
 import { API_BASE } from "$lib/api-base";
-import type {
-	AreaContacts,
-	AreaPageProps,
-	AreaTags,
-	PlaceIssue,
-} from "$lib/types";
-import { AREA_CONTACT_KEYS } from "$lib/types";
+import { extractContacts } from "$lib/area/contacts";
+import type { AreaPageProps, AreaTags, PlaceIssue } from "$lib/types";
 
 // Shared loader for the community/[area]/[section] and country/[area]/[section]
 // pages. Both fetch the same v3 area data and share the same error handling;
@@ -84,19 +79,6 @@ const fetchAllPlaceIssues = async (
 		`place-issues for area ${areaId} truncated at ${all.length} rows`,
 	);
 	return all;
-};
-
-// Lift the 22 `contact:*` string tags into one typed object so consumers
-// stop spelling `area["contact:satlantis"]` at every read site.
-const extractContacts = (tags: AreaTags): AreaContacts => {
-	const contacts: AreaContacts = {};
-	for (const key of AREA_CONTACT_KEYS) {
-		const value = tags[`contact:${key}`];
-		if (typeof value === "string" && value) {
-			contacts[key] = value;
-		}
-	}
-	return contacts;
 };
 
 // box:* tags are human-authored camera hints, served as numbers despite

--- a/src/routes/communities/[section]/components/CommunityCard.svelte
+++ b/src/routes/communities/[section]/components/CommunityCard.svelte
@@ -4,6 +4,7 @@ import Socials from "$components/Socials.svelte";
 import SponsorBadge from "$components/SponsorBadge.svelte";
 import TextLink from "$components/TextLink.svelte";
 import Tip from "$components/Tip.svelte";
+import { extractContacts } from "$lib/area/contacts";
 import { getOrganizationDisplayName } from "$lib/organizationDisplayNames";
 import type { AreaTags } from "$lib/types";
 import { TipType } from "$lib/types";
@@ -15,51 +16,8 @@ export let id: string;
 export let tags: AreaTags;
 
 $: image = tags["icon:square"] && tags["icon:square"];
-$: website = tags["contact:website"] && tags["contact:website"];
-$: email = tags["contact:email"] && tags["contact:email"];
-$: phone = tags["contact:phone"] && tags["contact:phone"];
-$: nostr = tags["contact:nostr"] && tags["contact:nostr"];
-$: twitter = tags["contact:twitter"] && tags["contact:twitter"];
-$: meetup = tags["contact:meetup"] && tags["contact:meetup"];
-$: telegram = tags["contact:telegram"] && tags["contact:telegram"];
-$: discord = tags["contact:discord"] && tags["contact:discord"];
-$: youtube = tags["contact:youtube"] && tags["contact:youtube"];
-$: github = tags["contact:github"] && tags["contact:github"];
-$: matrix = tags["contact:matrix"] && tags["contact:matrix"];
-$: geyser = tags["contact:geyser"] && tags["contact:geyser"];
-$: satlantis = tags["contact:satlantis"] && tags["contact:satlantis"];
-$: eventbrite = tags["contact:eventbrite"] && tags["contact:eventbrite"];
-$: reddit = tags["contact:reddit"] && tags["contact:reddit"];
-$: simplex = tags["contact:simplex"] && tags["contact:simplex"];
-$: instagram = tags["contact:instagram"] && tags["contact:instagram"];
-$: whatsapp = tags["contact:whatsapp"] && tags["contact:whatsapp"];
-$: facebook = tags["contact:facebook"] && tags["contact:facebook"];
-$: linkedin = tags["contact:linkedin"] && tags["contact:linkedin"];
-$: rss = tags["contact:rss"] && tags["contact:rss"];
-$: signal = tags["contact:signal"] && tags["contact:signal"];
-$: hasContact =
-	website ||
-	email ||
-	phone ||
-	nostr ||
-	twitter ||
-	meetup ||
-	telegram ||
-	discord ||
-	youtube ||
-	github ||
-	matrix ||
-	geyser ||
-	satlantis ||
-	eventbrite ||
-	reddit ||
-	simplex ||
-	instagram ||
-	whatsapp ||
-	facebook ||
-	linkedin ||
-	rss ||
-	signal;
+$: contacts = extractContacts(tags);
+$: hasContact = Object.keys(contacts).length > 0;
 $: tip =
 	(tags["tips:lightning_address"] && {
 		destination: tags["tips:lightning_address"],
@@ -101,28 +59,7 @@ $: tip =
 
 	{#if hasContact}
 		<Socials
-			{website}
-			{email}
-			{phone}
-			{nostr}
-			{twitter}
-			{meetup}
-			{telegram}
-			{discord}
-			{youtube}
-			{github}
-			{matrix}
-			{geyser}
-			{satlantis}
-			{eventbrite}
-			{reddit}
-			{simplex}
-			{instagram}
-			{whatsapp}
-			{facebook}
-			{linkedin}
-			{rss}
-			{signal}
+			{contacts}
 			style="border-t border-t-gray-200 p-4 w-full dark:border-t-white/95"
 		/>
 	{/if}

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -16,6 +16,7 @@ import { get } from "svelte/store";
 import MapLoadingMain from "$components/MapLoadingMain.svelte";
 import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import Socials from "$components/Socials.svelte";
+import { extractContacts } from "$lib/area/contacts";
 import { _ } from "$lib/i18n";
 import {
 	BASEMAPS,
@@ -219,30 +220,7 @@ const buildPopupHtml = (
 
 	const socials = new Socials({
 		target: socialsMount,
-		props: {
-			website: community.tags["contact:website"],
-			email: community.tags["contact:email"],
-			phone: community.tags["contact:phone"],
-			nostr: community.tags["contact:nostr"],
-			twitter: community.tags["contact:twitter"],
-			meetup: community.tags["contact:meetup"],
-			telegram: community.tags["contact:telegram"],
-			discord: community.tags["contact:discord"],
-			youtube: community.tags["contact:youtube"],
-			github: community.tags["contact:github"],
-			matrix: community.tags["contact:matrix"],
-			geyser: community.tags["contact:geyser"],
-			satlantis: community.tags["contact:satlantis"],
-			eventbrite: community.tags["contact:eventbrite"],
-			reddit: community.tags["contact:reddit"],
-			simplex: community.tags["contact:simplex"],
-			instagram: community.tags["contact:instagram"],
-			whatsapp: community.tags["contact:whatsapp"],
-			facebook: community.tags["contact:facebook"],
-			linkedin: community.tags["contact:linkedin"],
-			rss: community.tags["contact:rss"],
-			signal: community.tags["contact:signal"],
-		},
+		props: { contacts: extractContacts(community.tags) },
 	});
 
 	return { container, socials };


### PR DESCRIPTION
## Summary

The #1176 split, scoped per the re-review on the issue. **Stacked on #1211** (`refactor/places-in-area`) — GitHub retargets to `main` when it merges; only the last two commits are new here. Refs #1176 (the remaining slice — per-route section components — is a judgment call once this lands; see below).

**Commit 1 — `Socials` takes one typed `contacts` object**
- `extractContacts` moves to `$lib/area/contacts.ts`, shared by the SSR bundle (`areaSectionLoad`), the communities-map popups, and `CommunityCard` — which each carried their own 22-line `contact:*` fan-out. All three now pass `contacts: AreaContacts`.
- `Socials`' interface collapses from 22 named props to one object; its internals (per-key sanitization, template) are unchanged — only the seam moved.

**Commit 2 — `AreaHeader` extraction; derive, don't initialize**
- The header half of the 544-line AreaPage becomes `AreaHeader.svelte`: prop-in/markup-out, with every value **derived** from the SSR bundle — no imperative init, no reset lifecycle. An area navigation swaps `data` and everything follows.
- That deletes `initializeData` wholesale, the 22 contact locals, `dataInitialized` (each child now gets an honest signal: merchant highlights gate on **sweep completion**, the issues table's `loading` is `false` because issues arrive with the maintain route's own load), and most of the manual reset block — only the async machinery (taggers fetch, containment sweep) still needs explicit resets.
- The three parallel section `Record`s collapse into one `SECTIONS` array: the section id *is* the route slug *is* the i18n key suffix.
- **Latent bug fixed**: `alias`/`name` were `const`s frozen at first mount, while the component instance is reused across client-side area navigations — stale header identity after any /community/X → /community/Y transition.

**Deliberately NOT done** (the re-review's constraints):
- **No `{#key}` boundary.** AreaMap's instance-reuse path (setData + animated fitBounds across area navs) must survive; a keyed teardown would refetch style + tiles per navigation — a visible regression. The (now much smaller) reset block is the accepted cost.
- **`reportsSync` stays page-level** — the merchants section consumes the report-fed AreaMap stars (#1186), so pushing it into stats-only would leave them pulsing forever.
- Full per-route section components: what remains of AreaPage after this is ~330 lines of section wiring; whether that final slice pays for itself is worth judging against the post-merge file, so the issue stays open.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean, 557/557 unit tests
- [x] SSR smoke via dev server: community page renders `#profile` header, name, and verified chip; country stats 200
- [ ] CI (build, e2e, type-checks)
- [ ] Manual browser QA: community + country pages (header, socials, tip, verify-link jump to the maintain form), communities index cards, communities-map popups, cross-area client navigation (header follows, no stale name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added area header component displaying profile information, including avatar, name, description, organization details, verification status indicators, and contact information for geographic areas and communities.

* **Bug Fixes**
  * Fixed issues table not reflecting updates when data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->