### PR TITLE
refactor: placeCache — one owner for the places blob and $places writes (#1172)

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -26,6 +26,7 @@ import { placesInAreaChunked } from "$lib/area/placesInArea";
 import api from "$lib/axios";
 import { places, placesError, reportError, reports } from "$lib/store";
 import { batchSync } from "$lib/sync/batchSync";
+import { placesPublished } from "$lib/sync/placeCache";
 import { reportsSync } from "$lib/sync/reports";
 import type { AreaPageProps, Place, PlaceIssue, Tagger } from "$lib/types.js";
 import { errToast } from "$lib/utils";
@@ -160,7 +161,11 @@ $: if (data?.id !== lastAreaId) {
 // reactive so an area navigation resets sweep state before the guard is
 // evaluated — otherwise it would fire once against the outgoing area's
 // polygon.
-$: if (area?.geo_json && $places.length && sweptAreaId !== data.id) {
+// Gate on publication, not $places.length: length can't distinguish "still
+// hydrating" from "legitimately empty", so an empty-but-complete dataset
+// would strand the highlights skeleton. A published empty store sweeps to
+// [] and completes like any other result.
+$: if (area?.geo_json && $placesPublished && sweptAreaId !== data.id) {
 	sweptAreaId = data.id;
 	runContainmentSweep($places, area.geo_json);
 }

--- a/src/lib/sync/placeCache.test.ts
+++ b/src/lib/sync/placeCache.test.ts
@@ -51,6 +51,24 @@ describe("readPlaceCache", () => {
 		}
 	});
 
+	it("treats a non-empty all-invalid array as corruption, not a warm empty cache", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			// The literal #1187 shape: a string char-iterated into an array.
+			// Reading this as warm-but-empty would skip the baseline download.
+			mockGetItem.mockResolvedValueOnce(["\n", "\n", "\n"]);
+			expect(await readPlaceCache()).toBeNull();
+			expect(warnSpy).toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("preserves a legitimately empty array blob", async () => {
+		mockGetItem.mockResolvedValueOnce([]);
+		expect(await readPlaceCache()).toEqual([]);
+	});
+
 	it("drops rows that don't look like places and keeps the rest", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		try {
@@ -59,6 +77,7 @@ describe("readPlaceCache", () => {
 				"\n",
 				{ id: "nope" },
 				{ id: 2, lat: Number.NaN, lon: 0 },
+				{ id: Number.NaN, lat: 1, lon: 2 },
 				place(3),
 			]);
 			const rows = await readPlaceCache();

--- a/src/lib/sync/placeCache.test.ts
+++ b/src/lib/sync/placeCache.test.ts
@@ -69,9 +69,12 @@ describe("readPlaceCache", () => {
 		expect(await readPlaceCache()).toEqual([]);
 	});
 
-	it("drops rows that don't look like places and keeps the rest", async () => {
+	it("treats ANY dropped row as corruption — partial snapshots never hydrate", async () => {
 		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 		try {
+			// A partial snapshot would delta-sync forever without restoring the
+			// lost rows; at hydrate time the blob is the only copy, so any loss
+			// means cold cache + baseline re-download.
 			mockGetItem.mockResolvedValueOnce([
 				place(1),
 				"\n",
@@ -80,8 +83,7 @@ describe("readPlaceCache", () => {
 				{ id: Number.NaN, lat: 1, lon: 2 },
 				place(3),
 			]);
-			const rows = await readPlaceCache();
-			expect(rows?.map((r) => r.id)).toEqual([1, 3]);
+			expect(await readPlaceCache()).toBeNull();
 			expect(warnSpy).toHaveBeenCalled();
 		} finally {
 			warnSpy.mockRestore();

--- a/src/lib/sync/placeCache.test.ts
+++ b/src/lib/sync/placeCache.test.ts
@@ -1,0 +1,133 @@
+import { get } from "svelte/store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { places } from "$lib/store";
+import type { Place } from "$lib/types";
+
+vi.mock("localforage", () => ({
+	default: {
+		getItem: vi.fn(),
+		setItem: vi.fn(),
+	},
+}));
+
+import localforage from "localforage";
+
+import {
+	placesPublished,
+	publishPlaces,
+	readPlaceCache,
+	readPlacesSyncedAt,
+	writePlacesSyncedAt,
+} from "./placeCache";
+
+const mockGetItem = vi.mocked(localforage.getItem);
+const mockSetItem = vi.mocked(localforage.setItem);
+
+const place = (id: number): Place => ({ id, lat: 1, lon: 2 }) as Place;
+
+beforeEach(() => {
+	mockGetItem.mockReset();
+	mockSetItem.mockReset();
+	mockSetItem.mockResolvedValue(undefined as never);
+	places.set([]);
+});
+
+describe("readPlaceCache", () => {
+	it("returns null for a cold cache", async () => {
+		mockGetItem.mockResolvedValueOnce(null);
+		expect(await readPlaceCache()).toBeNull();
+	});
+
+	it("treats a corrupt non-array blob as a cold cache", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			// The #1187 class: a persisted error page / char-iterated string
+			mockGetItem.mockResolvedValueOnce("<html>maintenance</html>");
+			expect(await readPlaceCache()).toBeNull();
+			expect(warnSpy).toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+
+	it("drops rows that don't look like places and keeps the rest", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			mockGetItem.mockResolvedValueOnce([
+				place(1),
+				"\n",
+				{ id: "nope" },
+				{ id: 2, lat: Number.NaN, lon: 0 },
+				place(3),
+			]);
+			const rows = await readPlaceCache();
+			expect(rows?.map((r) => r.id)).toEqual([1, 3]);
+			expect(warnSpy).toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});
+
+describe("publishPlaces", () => {
+	it("persists, publishes to $places, and latches placesPublished", async () => {
+		const rows = [place(1), place(2)];
+		const result = await publishPlaces(rows);
+
+		expect(result.persisted).toBe(true);
+		expect(mockSetItem).toHaveBeenCalledWith("places_v4", rows);
+		expect(get(places)).toEqual(rows);
+		expect(get(placesPublished)).toBe(true);
+	});
+
+	it("still publishes when persistence fails", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			mockSetItem.mockRejectedValueOnce(new Error("quota exceeded"));
+			const rows = [place(7)];
+			const result = await publishPlaces(rows);
+
+			// The session keeps working on broken storage
+			expect(result.persisted).toBe(false);
+			expect(get(places)).toEqual(rows);
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
+	it("skips persistence when asked (CDN fallback path)", async () => {
+		const result = await publishPlaces([place(9)], { persist: false });
+		expect(result.persisted).toBe(false);
+		expect(mockSetItem).not.toHaveBeenCalled();
+		expect(get(places).map((r) => r.id)).toEqual([9]);
+	});
+
+	it("sanitizes rows at the write boundary too", async () => {
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		try {
+			await publishPlaces([place(1), "junk" as unknown as Place]);
+			expect(get(places).map((r) => r.id)).toEqual([1]);
+			expect(mockSetItem).toHaveBeenCalledWith("places_v4", [
+				expect.objectContaining({ id: 1 }),
+			]);
+			expect(warnSpy).toHaveBeenCalled();
+		} finally {
+			warnSpy.mockRestore();
+		}
+	});
+});
+
+describe("synced-at watermark", () => {
+	it("reads and writes through the shared keys", async () => {
+		mockGetItem.mockResolvedValueOnce("2026-08-01T00:00:00.000Z");
+		expect(await readPlacesSyncedAt()).toBe("2026-08-01T00:00:00.000Z");
+		expect(mockGetItem).toHaveBeenCalledWith("places_v4_synced_at");
+
+		await writePlacesSyncedAt("2026-08-04T12:00:00.000Z");
+		expect(mockSetItem).toHaveBeenCalledWith(
+			"places_v4_synced_at",
+			"2026-08-04T12:00:00.000Z",
+		);
+	});
+});

--- a/src/lib/sync/placeCache.ts
+++ b/src/lib/sync/placeCache.ts
@@ -1,0 +1,95 @@
+import localforage from "localforage";
+import { writable } from "svelte/store";
+
+import { places } from "$lib/store";
+import type { Place } from "$lib/types";
+import { yieldToMain } from "$lib/utils";
+
+// The one owner of the places_v4 blob and the $places write path (#1172).
+// Previously three writers (elementsSync, ensureVerifiedDates,
+// applyPlaceUpdate) each carried their own persist/publish ordering and
+// error semantics, and the hydrate read trusted the blob blindly — the
+// exact boundary the #1187 "\n" corruption class exploited.
+
+const BLOB_KEY = "places_v4";
+const SYNCED_AT_KEY = "places_v4_synced_at";
+
+// Trust boundary: a row must look like a place before it may enter the
+// store or the blob. A non-JSON API body that char-iterated into an array
+// (the #1187 class) dies here instead of persisting forever.
+const isPlaceRow = (row: unknown): row is Place => {
+	if (typeof row !== "object" || row === null) return false;
+	const p = row as { id?: unknown; lat?: unknown; lon?: unknown };
+	return (
+		typeof p.id === "number" &&
+		typeof p.lat === "number" &&
+		Number.isFinite(p.lat) &&
+		typeof p.lon === "number" &&
+		Number.isFinite(p.lon)
+	);
+};
+
+const sanitizePlaceRows = (rows: unknown, context: string): Place[] | null => {
+	if (!Array.isArray(rows)) return null;
+	const valid = rows.filter(isPlaceRow);
+	if (valid.length !== rows.length) {
+		console.warn(
+			`placeCache (${context}): dropped ${rows.length - valid.length} invalid rows`,
+		);
+	}
+	return valid;
+};
+
+// True once this session has published at least once. Distinguishes "still
+// hydrating/downloading" from "legitimately empty" — which $places.length
+// alone cannot (the completion-state gap CodeRabbit flagged on #1212).
+const published = writable(false);
+export const placesPublished = { subscribe: published.subscribe };
+
+// Hydrate read. A corrupt blob (non-array, e.g. a persisted error page)
+// reads as null — the same as a cold cache — so the caller re-downloads the
+// baseline and the corruption self-heals instead of resurrecting each session.
+export const readPlaceCache = async (): Promise<Place[] | null> => {
+	const raw = await localforage.getItem<unknown>(BLOB_KEY);
+	if (raw == null) return null;
+	const rows = sanitizePlaceRows(raw, "hydrate");
+	if (rows === null) {
+		console.warn("placeCache: blob is not an array — ignoring corrupt cache");
+		return null;
+	}
+	return rows;
+};
+
+export const readPlacesSyncedAt = (): Promise<string | null> =>
+	localforage.getItem<string>(SYNCED_AT_KEY);
+
+export const writePlacesSyncedAt = (iso: string): Promise<string> =>
+	localforage.setItem(SYNCED_AT_KEY, iso);
+
+export type PublishResult = { persisted: boolean };
+
+// THE write path: rows are validated, the store ALWAYS updates — the
+// session must keep working when IndexedDB is full or broken — and
+// persistence is best-effort, reported to the caller so each can apply its
+// own error surface (sync toasts placesError; the boost write-through just
+// warns).
+export const publishPlaces = async (
+	rows: Place[],
+	opts: { persist?: boolean } = {},
+): Promise<PublishResult> => {
+	const valid = sanitizePlaceRows(rows, "publish") ?? [];
+	let persisted = false;
+	if (opts.persist !== false) {
+		try {
+			await localforage.setItem(BLOB_KEY, valid);
+			persisted = true;
+		} catch (error) {
+			console.error("placeCache: could not persist places blob:", error);
+		}
+	}
+	// Yield to main thread before updating the store to prevent UI freeze
+	await yieldToMain();
+	places.set(valid);
+	published.set(true);
+	return { persisted };
+};

--- a/src/lib/sync/placeCache.ts
+++ b/src/lib/sync/placeCache.ts
@@ -22,6 +22,7 @@ const isPlaceRow = (row: unknown): row is Place => {
 	const p = row as { id?: unknown; lat?: unknown; lon?: unknown };
 	return (
 		typeof p.id === "number" &&
+		Number.isFinite(p.id) &&
 		typeof p.lat === "number" &&
 		Number.isFinite(p.lat) &&
 		typeof p.lon === "number" &&
@@ -57,6 +58,14 @@ export const readPlaceCache = async (): Promise<Place[] | null> => {
 		console.warn("placeCache: blob is not an array — ignoring corrupt cache");
 		return null;
 	}
+	// A non-empty blob whose rows ALL fail validation is corruption in array
+	// clothing (the literal #1187 shape: a string char-iterated into an
+	// array) — reading it as a warm-but-empty cache would skip the baseline
+	// download and strand the session empty. Cold cache; re-download heals.
+	if (rows.length === 0 && (raw as unknown[]).length > 0) {
+		console.warn("placeCache: no valid rows in blob — ignoring corrupt cache");
+		return null;
+	}
 	return rows;
 };
 
@@ -78,6 +87,13 @@ export const publishPlaces = async (
 	opts: { persist?: boolean } = {},
 ): Promise<PublishResult> => {
 	const valid = sanitizePlaceRows(rows, "publish") ?? [];
+	// Publish BEFORE persisting: the store must never wait on IndexedDB (a
+	// 29k-row blob write can take hundreds of ms, or hang entirely on a
+	// broken backend). Yield first so the store update doesn't extend the
+	// caller's current long task.
+	await yieldToMain();
+	places.set(valid);
+	published.set(true);
 	let persisted = false;
 	if (opts.persist !== false) {
 		try {
@@ -87,9 +103,5 @@ export const publishPlaces = async (
 			console.error("placeCache: could not persist places blob:", error);
 		}
 	}
-	// Yield to main thread before updating the store to prevent UI freeze
-	await yieldToMain();
-	places.set(valid);
-	published.set(true);
 	return { persisted };
 };

--- a/src/lib/sync/placeCache.ts
+++ b/src/lib/sync/placeCache.ts
@@ -58,12 +58,15 @@ export const readPlaceCache = async (): Promise<Place[] | null> => {
 		console.warn("placeCache: blob is not an array — ignoring corrupt cache");
 		return null;
 	}
-	// A non-empty blob whose rows ALL fail validation is corruption in array
-	// clothing (the literal #1187 shape: a string char-iterated into an
-	// array) — reading it as a warm-but-empty cache would skip the baseline
-	// download and strand the session empty. Cold cache; re-download heals.
-	if (rows.length === 0 && (raw as unknown[]).length > 0) {
-		console.warn("placeCache: no valid rows in blob — ignoring corrupt cache");
+	// ANY dropped row means the blob is corrupt — and unlike the publish
+	// boundary (where the source data still exists upstream and dropping
+	// junk is safe), the blob is the only copy at hydrate time: a partial
+	// snapshot would delta-sync forever without ever restoring the lost
+	// rows, then persist the loss. This also covers the literal #1187 shape
+	// (a string char-iterated into an array, zero valid rows). Cold cache;
+	// the baseline re-download heals it.
+	if (rows.length !== (raw as unknown[]).length) {
+		console.warn("placeCache: invalid rows in blob — ignoring corrupt cache");
 		return null;
 	}
 	return rows;

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -384,8 +384,14 @@ export const elementsSync = async () => {
 					mergedUpdateCount === 0 &&
 					get(places).length > 0;
 				if (nothingChanged) {
+					// Best-effort, matching the changed-data branch: a failed
+					// watermark write must not trip the cache-load catch (and its
+					// misleading toast + CDN fallback) — it just widens the next
+					// update window.
 					if (apiSucceeded) {
-						await writePlacesSyncedAt(new Date().toISOString());
+						await writePlacesSyncedAt(new Date().toISOString()).catch((err) =>
+							console.warn("Could not save sync timestamp:", err),
+						);
 					}
 					placesLoadingStatus.set("Complete!");
 					placesLoadingProgress.set(PROGRESS_RANGES.COMPLETE);
@@ -416,6 +422,15 @@ export const elementsSync = async () => {
 						placesLoadingStatus.set("");
 						placesLoadingProgress.set(0);
 					}
+				} else {
+					// placesData ended up empty (failed baseline download, or a
+					// corrupt cache that sanitized away). Finalize instead of
+					// stranding the status at "Finalizing..." with placesPublished
+					// unlatched — but never persist an empty blob over whatever is
+					// on disk; a healthy next sync re-downloads the baseline.
+					await publishPlaces(placesData, { persist: false });
+					placesLoadingStatus.set("Complete!");
+					placesLoadingProgress.set(PROGRESS_RANGES.COMPLETE);
 				}
 			})
 			.catch(async (err) => {

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -1,5 +1,4 @@
 import type { AxiosProgressEvent } from "axios";
-import localforage from "localforage";
 import { get } from "svelte/store";
 
 import { API_BASE } from "$lib/api-base";
@@ -20,8 +19,13 @@ import {
 	verifiedDatesLoaded,
 } from "$lib/store";
 import { clearTables } from "$lib/sync/clearTables";
+import {
+	publishPlaces,
+	readPlaceCache,
+	readPlacesSyncedAt,
+	writePlacesSyncedAt,
+} from "$lib/sync/placeCache";
 import type { Place } from "$lib/types";
-import { yieldToMain } from "$lib/utils";
 import { filterPlaces, parseJSON } from "$lib/workers/sync-worker-manager";
 
 // Concurrency protection to prevent multiple simultaneous syncs
@@ -130,10 +134,11 @@ export const ensureVerifiedDates = async (): Promise<void> => {
 				? { ...p, verified_at }
 				: p;
 		});
-		await yieldToMain();
-		places.set(enriched);
+		// Always publishes (persistence is best-effort inside placeCache), so
+		// the enrichment survives a failed blob write — matching the old
+		// publish-first ordering this replaced.
+		await publishPlaces(enriched);
 		verifiedDatesLoaded.set(true);
-		await localforage.setItem("places_v4", enriched);
 	} catch (error) {
 		console.warn("Could not load verification dates:", error);
 	}
@@ -157,10 +162,10 @@ export const elementsSync = async () => {
 		placesLoadingStatus.set("Initializing...");
 
 		// get places and sync timestamp from local storage
-		const cachedPlaces = await localforage.getItem<Place[]>("places_v4");
-		const cachedSyncedAt = await localforage.getItem<string>(
-			"places_v4_synced_at",
-		);
+		// readPlaceCache sanitizes at the trust boundary: a corrupt blob (the
+		// #1187 class) reads as a cold cache and self-heals via re-download.
+		const cachedPlaces = await readPlaceCache();
+		const cachedSyncedAt = await readPlacesSyncedAt();
 
 		await Promise.resolve(cachedPlaces)
 			.then(async (cachedPlaces) => {
@@ -380,47 +385,37 @@ export const elementsSync = async () => {
 					get(places).length > 0;
 				if (nothingChanged) {
 					if (apiSucceeded) {
-						await localforage.setItem(
-							"places_v4_synced_at",
-							new Date().toISOString(),
-						);
+						await writePlacesSyncedAt(new Date().toISOString());
 					}
 					placesLoadingStatus.set("Complete!");
 					placesLoadingProgress.set(PROGRESS_RANGES.COMPLETE);
 				} else if (placesData.length > 0) {
-					localforage
-						.setItem("places_v4", placesData)
-						.then(async () => {
-							// Only save sync timestamp if API succeeded, to avoid creating gaps
-							// where updates between old and new timestamp are permanently missed
-							if (apiSucceeded) {
-								await localforage.setItem(
-									"places_v4_synced_at",
-									new Date().toISOString(),
-								);
-							}
-
-							// Yield to main thread before updating store to prevent UI freeze
-							await yieldToMain();
-							// set response to store
-							places.set(placesData);
-							placesLoadingStatus.set("Complete!");
-							placesLoadingProgress.set(PROGRESS_RANGES.COMPLETE);
-
-							// Keep progress at 100% - don't reset to avoid confusing loading states
-							// The map component will handle hiding the indicator when elementsLoaded = true
-						})
-						.catch(async (err) => {
-							// Yield to main thread before updating store to prevent UI freeze
-							await yieldToMain();
-							places.set(placesData);
-							placesError.set(
-								"Could not store places locally, please try again or contact BTC Map.",
+					// publishPlaces always updates the store (the session keeps
+					// working on broken storage); persistence failure surfaces via
+					// the sync path's own error toast.
+					const { persisted } = await publishPlaces(placesData);
+					if (persisted) {
+						// Only save sync timestamp if API succeeded, to avoid creating
+						// gaps where updates between old and new timestamp are
+						// permanently missed. Best-effort: a failed watermark write
+						// just re-fetches a wider update window next sync.
+						if (apiSucceeded) {
+							await writePlacesSyncedAt(new Date().toISOString()).catch((err) =>
+								console.warn("Could not save sync timestamp:", err),
 							);
-							placesLoadingStatus.set("");
-							placesLoadingProgress.set(0);
-							console.error(err);
-						});
+						}
+						placesLoadingStatus.set("Complete!");
+						placesLoadingProgress.set(PROGRESS_RANGES.COMPLETE);
+						// Keep progress at 100% - don't reset to avoid confusing
+						// loading states. The map component handles hiding the
+						// indicator when elementsLoaded = true.
+					} else {
+						placesError.set(
+							"Could not store places locally, please try again or contact BTC Map.",
+						);
+						placesLoadingStatus.set("");
+						placesLoadingProgress.set(0);
+					}
 				}
 			})
 			.catch(async (err) => {
@@ -454,9 +449,9 @@ export const elementsSync = async () => {
 					}
 
 					if (parsedPlaces.length > 0) {
-						// Yield to main thread before updating store to prevent UI freeze
-						await yieldToMain();
-						places.set(parsedPlaces);
+						// Publish-only: localforage already failed reading, so don't
+						// bank on writing — matching the pre-existing behavior.
+						await publishPlaces(parsedPlaces, { persist: false });
 					}
 				} catch (error) {
 					placesError.set(
@@ -475,7 +470,7 @@ export const elementsSync = async () => {
 // cache in $lib/placeDetails coherent. Returns the place, or null when it was
 // deleted or no cache exists yet.
 const applyPlaceUpdate = async (place: Place): Promise<Place | null> => {
-	const cachedPlaces = await localforage.getItem<Place[]>("places_v4");
+	const cachedPlaces = await readPlaceCache();
 
 	if (!cachedPlaces) {
 		console.warn("No cached places found, cannot update place");
@@ -489,9 +484,7 @@ const applyPlaceUpdate = async (place: Place): Promise<Place | null> => {
 		evictPlaceDetails(place.id);
 		const updatedPlaces = cachedPlaces.filter((p) => p.id !== place.id);
 		if (updatedPlaces.length !== cachedPlaces.length) {
-			await localforage.setItem("places_v4", updatedPlaces);
-			await yieldToMain();
-			places.set(updatedPlaces);
+			await publishPlaces(updatedPlaces);
 			console.info(`Removed deleted place ${place.id} from cache`);
 		}
 		return null;
@@ -506,16 +499,10 @@ const applyPlaceUpdate = async (place: Place): Promise<Place | null> => {
 		updatedPlaces.push(place);
 	}
 
-	await localforage.setItem("places_v4", updatedPlaces);
-
-	// Yield to main thread before updating store to prevent UI freeze
-	await yieldToMain();
-
-	places.set(updatedPlaces);
-
-	// Prime the details cache only after persistence + store publication
-	// succeed — priming first would leave drawers serving "updated" data
-	// while $places/localforage still hold the old record if setItem threw.
+	// publishPlaces always updates the store, so the session shows the fresh
+	// record even when the blob write fails (it just won't survive a reload)
+	// — and the details cache can safely prime to match what $places shows.
+	await publishPlaces(updatedPlaces);
 	primePlaceDetails(place);
 	return place;
 };


### PR DESCRIPTION
## Summary

Closes #1172 — the final stage, deferred from PR #1195 pending #1191 (long since merged).

**The problem**: the `places_v4` blob and the `$places` store had **three writers with three different persist/publish orderings and error semantics** — `elementsSync` (persist → publish, toast on failure), `ensureVerifiedDates` (publish → persist, silent failure), `applyPlaceUpdate` (persist → publish, update thrown away on failure) — and the hydrate read trusted the blob blindly, the exact boundary the #1187 `"\n"` corruption class exploited.

**What `$lib/sync/placeCache.ts` owns**
- **Row-level validation on both read and write.** A corrupt blob (persisted error page, char-iterated string) reads as a cold cache — the sync re-downloads the baseline and the corruption **self-heals** instead of resurrecting every session. Invalid rows are dropped (and counted) at publish too.
- **One publish path, one policy**: the store *always* updates — a session must keep working when IndexedDB is full or broken — and persistence is best-effort with the result reported, so each caller keeps its own error surface (sync toasts `placesError`; the boost write-through warns).
- The `places_v4_synced_at` watermark read/write.
- **`placesPublished`** — a store distinguishing "still hydrating/downloading" from "legitimately empty", which `$places.length` cannot. This closes the places half of CodeRabbit's completion-state finding on #1212 (the reports half stays declined — it needs `createSyncFactory` changes, a parked seam).

**Deliberate behavior deltas** (each an upgrade, called out for review):
- Corrupt cached blob → baseline re-download, not session-long garbage.
- A failed blob write during boost/comment write-through now **keeps the session fresh** (store publishes, details cache primes to match) instead of discarding the update — the #1195-reviewed prime-after-persist invariant is preserved in its intent: the details cache never shows data `$places` doesn't.
- A failed watermark write just widens the next update window (warn) instead of tripping the full CDN-fallback catch.
- The area page's sweep gate moves from `$places.length` to `$placesPublished`, so an empty-but-complete dataset sweeps to `[]` and completes rather than stranding the skeleton.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean, **565/565** unit tests (8 new: read/write sanitization incl. the `"\n"` class, publish-despite-persist-failure, persist-skip for the CDN fallback, watermark passthrough, `placesPublished` latch)
- [ ] CI — the e2e suite (hermetic map fixtures from #1193) exercises the full rewired boot path: hydrate → publish → pipeline → pins
- [ ] Manual browser QA: /map cold boot and warm reload (pins load both ways), a boost/comment refresh still updates the pin, community page pins fill in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed place loading so legitimately empty datasets are processed correctly.
  * Improved handling of corrupted or invalid cached place data.
  * Prevented sync timestamps from updating when data cannot be saved successfully.
  * Improved fallback behavior when cached data is unavailable.

* **Improvements**
  * Added more reliable place publication and synchronization.
  * Added support for operating without persistence for CDN-sourced data.
  * Improved validation and sanitization of place data before display and storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->