### PR TITLE
refactor: createBtcmapMap phase 2 — every map on one foundation, transformStyle retired (#1169)

### DIFF
--- a/src/components/area/AreaMap.svelte
+++ b/src/components/area/AreaMap.svelte
@@ -20,7 +20,10 @@ import { CLUSTERING_DISABLED_ZOOM, GradeTable } from "$lib/constants";
 import { computeBbox } from "$lib/map/bbox";
 import type { BtcmapMapHandle } from "$lib/map/createMap";
 import { createBtcmapMap } from "$lib/map/createMap";
-import { ensureSpritesForPlaces } from "$lib/map/maplibreSprites";
+import {
+	ensureCommentBadgeSprite,
+	ensureSpritesForPlaces,
+} from "$lib/map/maplibreSprites";
 import { theme } from "$lib/theme";
 import type { Grade, Place } from "$lib/types";
 import { getGrade, isBoosted } from "$lib/utils";
@@ -98,34 +101,6 @@ let styleLoaded = false;
 // fires on genuine prop turnover, not on theme-swap styleLoaded toggles.
 let lastAppliedGeoJSON: GeoJSON | undefined;
 let lastAppliedFilteredPlaces: Place[] | undefined;
-
-const loadCommentBadgeSprite = (m: MapLibreMap): void => {
-	if (m.hasImage("comment-badge-bg")) return;
-	// 2× rasterization for crispness on retina/phone DPRs — see /map's
-	// equivalent for rationale.
-	const SIZE = 16;
-	const SCALE = 2;
-	const canvas = document.createElement("canvas");
-	canvas.width = SIZE * SCALE;
-	canvas.height = SIZE * SCALE;
-	const ctx = canvas.getContext("2d");
-	if (!ctx) return;
-	ctx.fillStyle = "#16A34A";
-	ctx.beginPath();
-	ctx.arc(
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		0,
-		Math.PI * 2,
-	);
-	ctx.fill();
-	m.addImage(
-		"comment-badge-bg",
-		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
-		{ pixelRatio: SCALE },
-	);
-};
 
 const buildFeatureCollection = (list: Place[]): PlaceFeatureCollection => ({
 	type: "FeatureCollection",
@@ -319,7 +294,7 @@ const syncPlacesSource = (m: MapLibreMap, list: Place[]) => {
 // intentionally NOT done here — see fitToArea below; theme swaps must
 // preserve the user's pan/zoom.
 const initializeMapContents = (m: MapLibreMap) => {
-	loadCommentBadgeSprite(m);
+	ensureCommentBadgeSprite(m);
 	addAreaLayer(m);
 	addPlacesLayers(m);
 	syncPlacesSource(m, filteredPlaces);

--- a/src/lib/map/createMap.test.ts
+++ b/src/lib/map/createMap.test.ts
@@ -10,42 +10,50 @@ vi.mock("$lib/map/maplibreSprites", () => ({
 }));
 
 // Minimal stand-in for maplibre's Map: enough event plumbing to drive the
-// load / style.load lifecycle the theme-swap state machine depends on.
+// load / style.load lifecycle the style-swap state machine depends on.
+// fire() awaits handler promises — the facade's load and style.load
+// callbacks are async (they await registerOverlays).
 class FakeMap {
 	static instances: FakeMap[] = [];
-	styleUrl: string;
+	ctorOptions: Record<string, unknown>;
+	styleUrl: unknown;
 	removed = false;
-	setStyleCalls: string[] = [];
-	private handlers = new Map<string, ((...args: unknown[]) => void)[]>();
-	private onceHandlers = new Map<string, ((...args: unknown[]) => void)[]>();
+	setStyleCalls: unknown[] = [];
+	controlsAdded = 0;
+	private handlers = new Map<string, ((...args: unknown[]) => unknown)[]>();
+	private onceHandlers = new Map<string, ((...args: unknown[]) => unknown)[]>();
 
-	constructor(opts: { style: string }) {
+	constructor(opts: Record<string, unknown>) {
+		this.ctorOptions = opts;
 		this.styleUrl = opts.style;
 		FakeMap.instances.push(this);
 	}
-	on(event: string, cb: (...args: unknown[]) => void) {
+	on(event: string, cb: (...args: unknown[]) => unknown) {
 		const list = this.handlers.get(event) ?? [];
 		list.push(cb);
 		this.handlers.set(event, list);
 	}
-	once(event: string, cb: (...args: unknown[]) => void) {
+	once(event: string, cb: (...args: unknown[]) => unknown) {
 		const list = this.onceHandlers.get(event) ?? [];
 		list.push(cb);
 		this.onceHandlers.set(event, list);
 	}
-	addControl() {}
-	setStyle(url: string) {
-		this.setStyleCalls.push(url);
-		this.styleUrl = url;
+	addControl() {
+		this.controlsAdded++;
+	}
+	setStyle(style: unknown) {
+		this.setStyleCalls.push(style);
+		this.styleUrl = style;
 	}
 	remove() {
 		this.removed = true;
 	}
-	fire(event: string) {
-		for (const cb of this.handlers.get(event) ?? []) cb();
+	async fire(event: string) {
 		const once = this.onceHandlers.get(event) ?? [];
 		this.onceHandlers.delete(event);
-		for (const cb of once) cb();
+		for (const cb of [...(this.handlers.get(event) ?? []), ...once]) {
+			await cb();
+		}
 	}
 }
 
@@ -120,14 +128,46 @@ describe("createBtcmapMap", () => {
 		expect(FakeMap.instances.length).toBe(0);
 	});
 
+	it("exposes the maplibre namespace on the handle", async () => {
+		const { handle } = await readyOutcome();
+		expect(handle.maplibre.Map).toBe(
+			FakeMap as unknown as typeof handle.maplibre.Map,
+		);
+	});
+
 	it("runs overlays, first-load wiring, and the ready signal on load", async () => {
 		const { fake, registerOverlays, onFirstLoad, onStyleReadyChange } =
 			await readyOutcome();
 		expect(registerOverlays).not.toHaveBeenCalled();
 
-		fake.fire("load");
+		await fake.fire("load");
 
 		expect(registerOverlays).toHaveBeenCalledTimes(1);
+		expect(onFirstLoad).toHaveBeenCalledTimes(1);
+		expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
+	});
+
+	it("waits for an ASYNC registerOverlays before first-load wiring and ready", async () => {
+		let resolveOverlays: () => void = () => {};
+		const registerOverlays = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveOverlays = resolve;
+				}),
+		);
+		const { fake, onFirstLoad, onStyleReadyChange } = await readyOutcome({
+			registerOverlays,
+		});
+
+		const firing = fake.fire("load");
+		// Overlays pending (sprite loads, layer install) — nothing downstream
+		// may run yet
+		expect(registerOverlays).toHaveBeenCalledTimes(1);
+		expect(onFirstLoad).not.toHaveBeenCalled();
+		expect(onStyleReadyChange).not.toHaveBeenCalled();
+
+		resolveOverlays();
+		await firing;
 		expect(onFirstLoad).toHaveBeenCalledTimes(1);
 		expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
 	});
@@ -135,15 +175,15 @@ describe("createBtcmapMap", () => {
 	it("swaps the style on a theme change and re-registers overlays on style.load", async () => {
 		const { handle, fake, registerOverlays, onFirstLoad, onStyleReadyChange } =
 			await readyOutcome();
-		fake.fire("load");
+		await fake.fire("load");
 
 		handle.setTheme("dark");
 		expect(onStyleReadyChange).toHaveBeenLastCalledWith(false);
 		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
 
-		fake.fire("style.load");
+		await fake.fire("style.load");
 		expect(registerOverlays).toHaveBeenCalledTimes(2);
-		// First-load wiring must NOT re-run on a theme swap
+		// First-load wiring must NOT re-run on a style swap
 		expect(onFirstLoad).toHaveBeenCalledTimes(1);
 		expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
 	});
@@ -155,7 +195,7 @@ describe("createBtcmapMap", () => {
 		handle.setTheme("dark");
 		expect(fake.setStyleCalls).toEqual([]);
 
-		fake.fire("load");
+		await fake.fire("load");
 		handle.setTheme("light");
 		expect(fake.setStyleCalls).toEqual([]);
 	});
@@ -164,7 +204,7 @@ describe("createBtcmapMap", () => {
 		// Callers may construct before the theme store resolves; undefined and
 		// "light" map to the same style, so resolving must not restyle.
 		const { handle, fake } = await readyOutcome({ theme: undefined });
-		fake.fire("load");
+		await fake.fire("load");
 
 		handle.setTheme("light");
 		expect(fake.setStyleCalls).toEqual([]);
@@ -173,16 +213,16 @@ describe("createBtcmapMap", () => {
 		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
 	});
 
-	it("ignores setTheme while a previous swap's style is still loading", async () => {
+	it("ignores swaps while a previous swap's style is still loading", async () => {
 		const { handle, fake } = await readyOutcome();
-		fake.fire("load");
+		await fake.fire("load");
 
 		handle.setTheme("dark");
 		handle.setTheme("light");
 		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
 
 		// Once the swap settles, the component's readiness reactive re-invokes
-		fake.fire("style.load");
+		await fake.fire("style.load");
 		handle.setTheme("light");
 		expect(fake.setStyleCalls).toEqual([
 			styleUrlForTheme("dark"),
@@ -190,9 +230,50 @@ describe("createBtcmapMap", () => {
 		]);
 	});
 
+	it("uses the styles override pair in theme mode", async () => {
+		const styles = (t: "light" | "dark" | undefined) =>
+			t === "dark" ? "preview-dark" : "preview-light";
+		const { handle, fake } = await readyOutcome({ styles, theme: "light" });
+		expect(fake.ctorOptions.style).toBe("preview-light");
+
+		await fake.fire("load");
+		handle.setTheme("dark");
+		expect(fake.setStyleCalls).toEqual(["preview-dark"]);
+	});
+
+	it("explicit-style mode: caller owns swaps, setTheme is inert", async () => {
+		const { handle, fake, registerOverlays } = await readyOutcome({
+			style: "https://example.org/basemap.json",
+		});
+		expect(fake.ctorOptions.style).toBe("https://example.org/basemap.json");
+		await fake.fire("load");
+
+		// The theme machine is off — the basemap picker owns style selection
+		handle.setTheme("dark");
+		expect(fake.setStyleCalls).toEqual([]);
+
+		handle.setStyle("https://example.org/other.json");
+		expect(fake.setStyleCalls).toEqual(["https://example.org/other.json"]);
+		await fake.fire("style.load");
+		expect(registerOverlays).toHaveBeenCalledTimes(2);
+	});
+
+	it("merges mapOptions over the defaults and can skip controls", async () => {
+		const { fake } = await readyOutcome({
+			controls: false,
+			mapOptions: { interactive: false, center: [7, 46], zoom: 15 },
+		});
+		expect(fake.controlsAdded).toBe(0);
+		expect(fake.ctorOptions.interactive).toBe(false);
+		expect(fake.ctorOptions.center).toEqual([7, 46]);
+		expect(fake.ctorOptions.zoom).toBe(15);
+		// Defaults survive underneath the overrides
+		expect(fake.ctorOptions.maxZoom).toBe(21);
+	});
+
 	it("destroy removes the map and inert-s the handle", async () => {
 		const { handle, fake, registerOverlays } = await readyOutcome();
-		fake.fire("load");
+		await fake.fire("load");
 
 		handle.destroy();
 		expect(fake.removed).toBe(true);
@@ -201,7 +282,7 @@ describe("createBtcmapMap", () => {
 		expect(fake.setStyleCalls).toEqual([]);
 
 		// A straggling event after teardown must not touch callbacks
-		fake.fire("style.load");
+		await fake.fire("style.load");
 		expect(registerOverlays).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/lib/map/createMap.test.ts
+++ b/src/lib/map/createMap.test.ts
@@ -284,6 +284,33 @@ describe("createBtcmapMap", () => {
 		expect(fake.ctorOptions.maxZoom).toBe(21);
 	});
 
+	it("a rejecting registerOverlays does not wedge the handle", async () => {
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		try {
+			const registerOverlays = vi
+				.fn()
+				.mockRejectedValueOnce(new Error("sprite CDN down"))
+				.mockResolvedValue(undefined);
+			const { handle, fake, onFirstLoad, onStyleReadyChange } =
+				await readyOutcome({ registerOverlays });
+
+			await fake.fire("load");
+			// Failure is reported, but the state machine completes: first-load
+			// wiring runs and the handle becomes ready
+			expect(errorSpy).toHaveBeenCalled();
+			expect(onFirstLoad).toHaveBeenCalledTimes(1);
+			expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
+
+			// And the next swap re-runs registration — the natural retry
+			handle.setTheme("dark");
+			await fake.fire("style.load");
+			expect(registerOverlays).toHaveBeenCalledTimes(2);
+			expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
+		} finally {
+			errorSpy.mockRestore();
+		}
+	});
+
 	it("destroy removes the map and inert-s the handle", async () => {
 		const { handle, fake, registerOverlays } = await readyOutcome();
 		await fake.fire("load");

--- a/src/lib/map/createMap.test.ts
+++ b/src/lib/map/createMap.test.ts
@@ -188,16 +188,20 @@ describe("createBtcmapMap", () => {
 		expect(onStyleReadyChange).toHaveBeenLastCalledWith(true);
 	});
 
-	it("ignores setTheme before the first load and for an unchanged theme", async () => {
+	it("queues a pre-load theme change and ignores an unchanged theme", async () => {
 		const { handle, fake } = await readyOutcome();
 
-		// Not ready yet — a swap now would race the initial style load
+		// Not ready yet — the swap must not race the initial style load, but
+		// it must not be dropped either
 		handle.setTheme("dark");
 		expect(fake.setStyleCalls).toEqual([]);
 
 		await fake.fire("load");
-		handle.setTheme("light");
-		expect(fake.setStyleCalls).toEqual([]);
+		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
+
+		await fake.fire("style.load");
+		handle.setTheme("dark");
+		expect(fake.setStyleCalls).toHaveLength(1);
 	});
 
 	it("treats undefined and light as the same theme — no restyle on resolve", async () => {
@@ -213,25 +217,34 @@ describe("createBtcmapMap", () => {
 		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
 	});
 
-	it("ignores swaps while a previous swap's style is still loading", async () => {
-		const { handle, fake } = await readyOutcome();
+	it("queues a pick made mid-swap and applies it when the swap settles", async () => {
+		const { handle, fake, registerOverlays } = await readyOutcome();
 		await fake.fire("load");
 
 		handle.setTheme("dark");
+		// Second pick while dark's style is still loading: not applied yet —
+		// but not dropped either (the picker UI already shows it selected)
 		handle.setTheme("light");
 		expect(fake.setStyleCalls).toEqual([styleUrlForTheme("dark")]);
 
-		// Once the swap settles, the component's readiness reactive re-invokes
+		// The in-flight swap settles → the queued pick applies automatically
 		await fake.fire("style.load");
-		handle.setTheme("light");
 		expect(fake.setStyleCalls).toEqual([
 			styleUrlForTheme("dark"),
 			styleUrlForTheme("light"),
 		]);
+		await fake.fire("style.load");
+		// load + dark swap + queued light swap
+		expect(registerOverlays).toHaveBeenCalledTimes(3);
+
+		// And the queue drains fully: nothing further pending
+		await fake.fire("style.load");
+		expect(fake.setStyleCalls).toHaveLength(2);
 	});
 
 	it("uses the styles override pair in theme mode", async () => {
-		const styles = (t: "light" | "dark" | undefined) =>
+		// Narrowed param: the facade always normalizes before calling
+		const styles = (t: "light" | "dark") =>
 			t === "dark" ? "preview-dark" : "preview-light";
 		const { handle, fake } = await readyOutcome({ styles, theme: "light" });
 		expect(fake.ctorOptions.style).toBe("preview-light");

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -1,4 +1,8 @@
-import type { Map as MapLibreMap } from "maplibre-gl";
+import type {
+	Map as MapLibreMap,
+	MapOptions,
+	StyleSpecification,
+} from "maplibre-gl";
 
 import { styleForBasemap } from "$lib/map/basemaps";
 import { installPlaceholderHandler } from "$lib/map/maplibreSprites";
@@ -8,6 +12,8 @@ import { ensureMapLibreWorkerUrl } from "$lib/map/worker";
 
 export type MapThemeName = "light" | "dark" | undefined;
 
+export type MapStyleInput = string | StyleSpecification;
+
 // The embedded maps pin their two basemaps to the same styles the /map
 // picker exposes — basemaps.ts stays the single source of truth for the URLs.
 export const styleUrlForTheme = (t: MapThemeName) =>
@@ -15,9 +21,19 @@ export const styleUrlForTheme = (t: MapThemeName) =>
 
 export type BtcmapMapHandle = {
 	map: MapLibreMap;
-	// Swap the basemap for a theme change. No-ops while a previous swap's
-	// style is still loading — the component's readiness reactive re-invokes
-	// once it settles — and when the theme didn't actually change.
+	// The imported maplibre namespace, for callers that construct Markers,
+	// Popups, or controls of their own.
+	maplibre: typeof import("maplibre-gl");
+	// Swap to an arbitrary style: sets the style, waits for style.load, and
+	// re-runs registerOverlays — one machine for theme swaps AND basemap
+	// picks. The custom layers blink for the moment the swap takes (a
+	// deliberate trade: the old transformStyle carryover kept them alive but
+	// coupled every page to hand-maintained carry-lists). No-ops while a
+	// previous swap's style is still loading.
+	setStyle: (style: MapStyleInput) => void;
+	// Theme sugar over setStyle: resolves the theme through the configured
+	// style pair and no-ops when the theme didn't actually change. Inert in
+	// explicit-style mode (the caller owns style selection there).
 	setTheme: (next: MapThemeName) => void;
 	destroy: () => void;
 };
@@ -27,18 +43,35 @@ export type CreateBtcmapMapOutcome =
 	| { status: "unsupported" }
 	| { status: "cancelled" };
 
-// The shared bring-up for embedded maps (AreaMap, MultiPlaceMap): WebGL
-// support check, dynamic maplibre import, worker URL + RTL plugin, Map construction,
-// navigation + geolocate controls, sprite placeholder handler, and the
-// theme-swap state machine. Overlay content stays with the caller:
-// registerOverlays re-runs after every style (re)load because setStyle()
-// strips custom sprites, sources, and layers.
+// The shared bring-up for every map in the app: WebGL support check, dynamic
+// maplibre import, worker URL + RTL plugin, Map construction, controls,
+// sprite placeholder handler, and the style-swap state machine. Overlay
+// content stays with the caller: registerOverlays re-runs after every style
+// (re)load because setStyle strips custom sprites, sources, and layers.
+//
+// Style selection is one of two modes:
+//   theme mode (default) — the facade picks the style from the theme (via
+//     `styles`, defaulting to the liberty/ofm-dark pair) and setTheme swaps;
+//   explicit-style mode (`style` passed) — the caller owns style selection
+//     (the /map and /communities/map basemap pickers) and swaps via
+//     handle.setStyle; setTheme is inert.
 export const createBtcmapMap = async (opts: {
 	container: HTMLElement;
 	theme: MapThemeName;
+	// Explicit initial style — enables explicit-style mode.
+	style?: MapStyleInput;
+	// Theme-mode style pair override (e.g. the merchant hero's preview
+	// styles). Ignored in explicit-style mode.
+	styles?: (theme: MapThemeName) => MapStyleInput;
+	// Extra Map constructor options merged OVER the shared defaults
+	// (center/zoom/bearing/pitch, interactive, attribution, …).
+	mapOptions?: Partial<MapOptions>;
+	// false skips the navigation + geolocate controls (static previews).
+	controls?: boolean;
 	// Sprites + sources + layers + data. Runs on the initial load and again
-	// after every theme swap's style.load.
-	registerOverlays: (map: MapLibreMap) => void;
+	// after every style swap's style.load. May be async — first-load wiring
+	// and the ready signal wait for it (sprite-before-layer ordering).
+	registerOverlays: (map: MapLibreMap) => void | Promise<void>;
 	// Runs once, after the first registerOverlays: camera + interactions.
 	onFirstLoad?: (map: MapLibreMap) => void;
 	// Style readiness — false while a swap's style is loading. Components
@@ -63,6 +96,10 @@ export const createBtcmapMap = async (opts: {
 	const normalizeTheme = (t: MapThemeName): "light" | "dark" =>
 		t === "dark" ? "dark" : "light";
 
+	const explicitStyle = opts.style !== undefined;
+	const themedStyle = (t: MapThemeName): MapStyleInput =>
+		opts.styles ? opts.styles(normalizeTheme(t)) : styleUrlForTheme(t);
+
 	let appliedTheme = normalizeTheme(opts.theme);
 	let ready = false;
 	let disposed = false;
@@ -73,34 +110,39 @@ export const createBtcmapMap = async (opts: {
 	};
 
 	const map = new maplibre.Map({
-		container: opts.container,
-		style: styleUrlForTheme(opts.theme),
+		style: explicitStyle
+			? (opts.style as MapStyleInput)
+			: themedStyle(opts.theme),
 		maxZoom: 21,
 		dragRotate: true,
 		touchZoomRotate: true,
 		pitchWithRotate: false,
 		attributionControl: { compact: true },
+		...opts.mapOptions,
+		container: opts.container,
 	});
 
-	map.addControl(
-		new maplibre.NavigationControl({
-			showCompass: true,
-			showZoom: true,
-			visualizePitch: false,
-		}),
-		"top-right",
-	);
+	if (opts.controls !== false) {
+		map.addControl(
+			new maplibre.NavigationControl({
+				showCompass: true,
+				showZoom: true,
+				visualizePitch: false,
+			}),
+			"top-right",
+		);
 
-	map.addControl(
-		new maplibre.GeolocateControl({
-			positionOptions: { enableHighAccuracy: true },
-			trackUserLocation: true,
-			showUserLocation: true,
-			showAccuracyCircle: true,
-			fitBoundsOptions: { maxZoom: 15, linear: true },
-		}),
-		"top-right",
-	);
+		map.addControl(
+			new maplibre.GeolocateControl({
+				positionOptions: { enableHighAccuracy: true },
+				trackUserLocation: true,
+				showUserLocation: true,
+				showAccuracyCircle: true,
+				fitBoundsOptions: { maxZoom: 15, linear: true },
+			}),
+			"top-right",
+		);
+	}
 
 	// MapLibre logs an "image missing" warning whenever a symbol references
 	// an icon id that hasn't been registered yet. Composite pin sprites
@@ -108,26 +150,37 @@ export const createBtcmapMap = async (opts: {
 	// the console quiet and prevents flicker until the real sprite lands.
 	installPlaceholderHandler(map);
 
-	map.on("load", () => {
+	map.on("load", async () => {
 		if (disposed) return;
-		opts.registerOverlays(map);
+		await opts.registerOverlays(map);
+		if (disposed) return;
 		opts.onFirstLoad?.(map);
 		setReady(true);
 	});
 
-	const setTheme = (next: MapThemeName) => {
+	const setStyle = (style: MapStyleInput) => {
 		if (disposed) return;
+		if (!ready) return;
+		setReady(false);
+		// Registered BEFORE setStyle on purpose: for inline (object) styles
+		// like the OSM raster basemap, setStyle fires style.load SYNCHRONOUSLY
+		// during the call, so a handler added afterwards would miss it.
+		map.once("style.load", async () => {
+			if (disposed) return;
+			await opts.registerOverlays(map);
+			if (disposed) return;
+			setReady(true);
+		});
+		map.setStyle(style);
+	};
+
+	const setTheme = (next: MapThemeName) => {
+		if (disposed || explicitStyle) return;
 		if (!ready) return;
 		const normalized = normalizeTheme(next);
 		if (normalized === appliedTheme) return;
 		appliedTheme = normalized;
-		setReady(false);
-		map.once("style.load", () => {
-			if (disposed) return;
-			opts.registerOverlays(map);
-			setReady(true);
-		});
-		map.setStyle(styleUrlForTheme(normalized));
+		setStyle(themedStyle(normalized));
 	};
 
 	const destroy = () => {
@@ -136,5 +189,8 @@ export const createBtcmapMap = async (opts: {
 		map.remove();
 	};
 
-	return { status: "ready", handle: { map, setTheme, destroy } };
+	return {
+		status: "ready",
+		handle: { map, maplibre, setStyle, setTheme, destroy },
+	};
 };

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -61,8 +61,9 @@ export const createBtcmapMap = async (opts: {
 	// Explicit initial style — enables explicit-style mode.
 	style?: MapStyleInput;
 	// Theme-mode style pair override (e.g. the merchant hero's preview
-	// styles). Ignored in explicit-style mode.
-	styles?: (theme: MapThemeName) => MapStyleInput;
+	// styles). Always invoked with a NORMALIZED theme — callers never need
+	// to handle undefined. Ignored in explicit-style mode.
+	styles?: (theme: "light" | "dark") => MapStyleInput;
 	// Extra Map constructor options merged OVER the shared defaults
 	// (center/zoom/bearing/pitch, interactive, attribution, …). style and
 	// container are excluded by type: style selection goes ONLY through
@@ -104,6 +105,7 @@ export const createBtcmapMap = async (opts: {
 	const explicitStyle = opts.style !== undefined;
 	const themedStyle = (t: MapThemeName): MapStyleInput =>
 		opts.styles ? opts.styles(normalizeTheme(t)) : styleUrlForTheme(t);
+	const initialStyle = opts.style ?? themedStyle(opts.theme);
 
 	let appliedTheme = normalizeTheme(opts.theme);
 	let ready = false;
@@ -115,9 +117,7 @@ export const createBtcmapMap = async (opts: {
 	};
 
 	const map = new maplibre.Map({
-		style: explicitStyle
-			? (opts.style as MapStyleInput)
-			: themedStyle(opts.theme),
+		style: initialStyle,
 		maxZoom: 21,
 		dragRotate: true,
 		touchZoomRotate: true,
@@ -166,11 +166,25 @@ export const createBtcmapMap = async (opts: {
 		if (disposed) return;
 		opts.onFirstLoad?.(map);
 		setReady(true);
+		if (pendingStyle !== null) {
+			const next = pendingStyle;
+			pendingStyle = null;
+			setStyle(next);
+		}
 	});
+
+	// A pick that lands while a previous swap's style is still loading is
+	// QUEUED and applied when the swap settles — dropping it would desync
+	// the picker UI (which persists and highlights the choice immediately)
+	// from the map.
+	let pendingStyle: MapStyleInput | null = null;
 
 	const setStyle = (style: MapStyleInput) => {
 		if (disposed) return;
-		if (!ready) return;
+		if (!ready) {
+			pendingStyle = style;
+			return;
+		}
 		setReady(false);
 		// Registered BEFORE setStyle on purpose: for inline (object) styles
 		// like the OSM raster basemap, setStyle fires style.load SYNCHRONOUSLY
@@ -180,16 +194,23 @@ export const createBtcmapMap = async (opts: {
 			await opts.registerOverlays(map);
 			if (disposed) return;
 			setReady(true);
+			if (pendingStyle !== null) {
+				const next = pendingStyle;
+				pendingStyle = null;
+				setStyle(next);
+			}
 		});
 		map.setStyle(style);
 	};
 
 	const setTheme = (next: MapThemeName) => {
 		if (disposed || explicitStyle) return;
-		if (!ready) return;
 		const normalized = normalizeTheme(next);
 		if (normalized === appliedTheme) return;
 		appliedTheme = normalized;
+		// setStyle queues while not ready (initial load or an in-flight
+		// swap), so a theme change is never dropped — it lands as soon as
+		// the map can take it.
 		setStyle(themedStyle(normalized));
 	};
 

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -68,6 +68,9 @@ export const createBtcmapMap = async (opts: {
 	mapOptions?: Partial<MapOptions>;
 	// false skips the navigation + geolocate controls (static previews).
 	controls?: boolean;
+	// Fired when the built-in geolocate control resolves a position — the
+	// control instance itself stays internal to the facade.
+	onGeolocate?: (coords: { latitude: number; longitude: number }) => void;
 	// Sprites + sources + layers + data. Runs on the initial load and again
 	// after every style swap's style.load. May be async — first-load wiring
 	// and the ready signal wait for it (sprite-before-layer ordering).
@@ -132,16 +135,21 @@ export const createBtcmapMap = async (opts: {
 			"top-right",
 		);
 
-		map.addControl(
-			new maplibre.GeolocateControl({
-				positionOptions: { enableHighAccuracy: true },
-				trackUserLocation: true,
-				showUserLocation: true,
-				showAccuracyCircle: true,
-				fitBoundsOptions: { maxZoom: 15, linear: true },
-			}),
-			"top-right",
-		);
+		const geolocate = new maplibre.GeolocateControl({
+			positionOptions: { enableHighAccuracy: true },
+			trackUserLocation: true,
+			showUserLocation: true,
+			showAccuracyCircle: true,
+			fitBoundsOptions: { maxZoom: 15, linear: true },
+		});
+		map.addControl(geolocate, "top-right");
+		if (opts.onGeolocate) {
+			// v6's GeolocatePositionEvent exposes coords directly but is not
+			// assignable to GeolocationPosition (no toJSON) — pass coords only.
+			geolocate.on("geolocate", (e) => {
+				opts.onGeolocate?.(e.coords);
+			});
+		}
 	}
 
 	// MapLibre logs an "image missing" warning whenever a symbol references

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -64,8 +64,10 @@ export const createBtcmapMap = async (opts: {
 	// styles). Ignored in explicit-style mode.
 	styles?: (theme: MapThemeName) => MapStyleInput;
 	// Extra Map constructor options merged OVER the shared defaults
-	// (center/zoom/bearing/pitch, interactive, attribution, …).
-	mapOptions?: Partial<MapOptions>;
+	// (center/zoom/bearing/pitch, interactive, attribution, …). style and
+	// container are excluded by type: style selection goes ONLY through
+	// theme/styles/style/setStyle, and the container is its own option.
+	mapOptions?: Partial<Omit<MapOptions, "style" | "container">>;
 	// false skips the navigation + geolocate controls (static previews).
 	controls?: boolean;
 	// Fired when the built-in geolocate control resolves a position — the

--- a/src/lib/map/createMap.ts
+++ b/src/lib/map/createMap.ts
@@ -160,9 +160,20 @@ export const createBtcmapMap = async (opts: {
 	// the console quiet and prevents flicker until the real sprite lands.
 	installPlaceholderHandler(map);
 
+	// One shared registration path: a rejecting registerOverlays must not
+	// wedge the handle — ready still flips so the page keeps working and
+	// future swaps re-run registration, which is the natural retry.
+	const runRegisterOverlays = async (): Promise<void> => {
+		try {
+			await opts.registerOverlays(map);
+		} catch (error) {
+			console.error("createBtcmapMap: registerOverlays failed:", error);
+		}
+	};
+
 	map.on("load", async () => {
 		if (disposed) return;
-		await opts.registerOverlays(map);
+		await runRegisterOverlays();
 		if (disposed) return;
 		opts.onFirstLoad?.(map);
 		setReady(true);
@@ -191,7 +202,7 @@ export const createBtcmapMap = async (opts: {
 		// during the call, so a handler added afterwards would miss it.
 		map.once("style.load", async () => {
 			if (disposed) return;
-			await opts.registerOverlays(map);
+			await runRegisterOverlays();
 			if (disposed) return;
 			setReady(true);
 			if (pendingStyle !== null) {

--- a/src/lib/map/maplibreSprites.ts
+++ b/src/lib/map/maplibreSprites.ts
@@ -148,6 +148,39 @@ export const hasRealImage = (m: MapLibreMap, name: string): boolean => {
 	return hasRealSprite(m, name);
 };
 
+// 16×16 green disc backing the comment-count text — one copy for every map
+// that renders comment badges (/map's pin facade, AreaMap). Matches the
+// legacy Tailwind `bg-green-600 w-4 h-4 rounded-full`. Drawn at 2× and
+// registered with pixelRatio: 2 so it stays crisp on retina/phone DPRs.
+// Gates on the REAL registration (not hasImage) so a styleimagemissing stub
+// can never block the actual sprite.
+export const ensureCommentBadgeSprite = (m: MapLibreMap): void => {
+	if (hasRealImage(m, "comment-badge-bg")) return;
+	const SIZE = 16;
+	const SCALE = 2;
+	const canvas = document.createElement("canvas");
+	canvas.width = SIZE * SCALE;
+	canvas.height = SIZE * SCALE;
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return;
+	ctx.fillStyle = "#16A34A";
+	ctx.beginPath();
+	ctx.arc(
+		(SIZE * SCALE) / 2,
+		(SIZE * SCALE) / 2,
+		(SIZE * SCALE) / 2,
+		0,
+		Math.PI * 2,
+	);
+	ctx.fill();
+	addRealImage(
+		m,
+		"comment-badge-bg",
+		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
+		{ pixelRatio: SCALE },
+	);
+};
+
 export const addRealImage = (
 	m: MapLibreMap,
 	name: string,

--- a/src/lib/map/placePinSource.ts
+++ b/src/lib/map/placePinSource.ts
@@ -8,6 +8,7 @@ import {
 import { HEATMAP_STORAGE_KEY } from "$lib/map/heatmap";
 import {
 	addRealImage,
+	ensureCommentBadgeSprite,
 	ensureSpritesForPlaces,
 	hasRealImage,
 	loadSvgImage,
@@ -88,41 +89,6 @@ const loadClusterHitSprite = async (m: MapLibreMap): Promise<void> => {
 	const img = await loadSvgImage(svg);
 	if (!hasRealImage(m, "cluster-hit"))
 		addRealImage(m, "cluster-hit", img, { pixelRatio: 1 });
-};
-
-// 16×16 green disc to back the comment count text. Matches /map's
-// Tailwind `bg-green-600 w-4 h-4 rounded-full` exactly. Drawn directly
-// on a canvas — simpler than the SVG → data-URL → <img> roundtrip for
-// a flat shape.
-const loadCommentBadgeSprite = (m: MapLibreMap): void => {
-	if (hasRealImage(m, "comment-badge-bg")) return;
-	// Draw at 2× the logical 16×16 (= 32×32 backing canvas) and register
-	// with pixelRatio: 2 so MapLibre displays at the same logical size
-	// but reads from a higher-density bitmap — keeps the green disc
-	// crisp on retina/phone DPRs instead of upscaling 16×16 bitmap pixels.
-	const SIZE = 16;
-	const SCALE = 2;
-	const canvas = document.createElement("canvas");
-	canvas.width = SIZE * SCALE;
-	canvas.height = SIZE * SCALE;
-	const ctx = canvas.getContext("2d");
-	if (!ctx) return;
-	ctx.fillStyle = "#16A34A";
-	ctx.beginPath();
-	ctx.arc(
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		(SIZE * SCALE) / 2,
-		0,
-		Math.PI * 2,
-	);
-	ctx.fill();
-	addRealImage(
-		m,
-		"comment-badge-bg",
-		ctx.getImageData(0, 0, SIZE * SCALE, SIZE * SCALE),
-		{ pixelRatio: SCALE },
-	);
 };
 
 const loadSavedBadgeSprite = async (m: MapLibreMap): Promise<void> => {
@@ -230,7 +196,7 @@ export const createPlacePinSource = (deps: PlacePinSourceDeps) => {
 			loadSavedBadgeSprite(map).catch((err) => {
 				console.warn("Saved-badge sprite failed to load:", err);
 			}),
-			loadCommentBadgeSprite(map),
+			ensureCommentBadgeSprite(map),
 			loadClusterHitSprite(map).catch((err) => {
 				console.warn("Cluster-hit sprite failed to load:", err);
 			}),

--- a/src/lib/map/placePinSource.ts
+++ b/src/lib/map/placePinSource.ts
@@ -38,33 +38,6 @@ const EMPTY_COLLECTION: PlaceFeatureCollection = {
 	features: [],
 };
 
-// The custom sources + layers this module adds on top of whatever basemap is
-// active. The /map page's applyBasemap() carries these across a setStyle() so
-// the pins, clusters, and labels survive a basemap/theme swap untouched
-// (MapLibre's style differ leaves byte-identical layers in place — only the
-// basemap layers below them get swapped).
-export const CUSTOM_SOURCE_IDS: readonly string[] = [
-	"places",
-	"places-boosted",
-	"places-heatmap",
-];
-export const CUSTOM_LAYER_IDS: readonly string[] = [
-	"place-heatmap",
-	"clusters-outer",
-	"clusters-inner",
-	"cluster-count",
-	"unclustered-point",
-	"boosted-point",
-	"comment-badge",
-	"comment-badge-count",
-	"saved-badge",
-	"place-label",
-	"boosted-comment-badge",
-	"boosted-comment-badge-count",
-	"boosted-saved-badge",
-	"boosted-place-label",
-	"clusters-hit",
-];
 // All point/cluster/badge/label layers that the heatmap conceals while
 // active below CLUSTERING_DISABLED_ZOOM (17).  At zoom 17+ the heatmap
 // layer naturally disappears (its maxzoom), so these layers are revealed

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -21,19 +21,12 @@ import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
 import TextLink from "$components/TextLink.svelte";
 import { _, locale } from "$lib/i18n";
-import { ensureRtlTextPlugin } from "$lib/map/rtl";
-import { hasWebGL } from "$lib/map/webgl";
-import { ensureMapLibreWorkerUrl } from "$lib/map/worker";
+import type { BtcmapMapHandle } from "$lib/map/createMap";
+import { createBtcmapMap } from "$lib/map/createMap";
 import { theme } from "$lib/theme";
 import { errToast, isValidLatitude, isValidLongitude } from "$lib/utils";
 
 import { browser } from "$app/environment";
-
-const STYLE_LIGHT = "https://tiles.openfreemap.org/styles/liberty";
-const STYLE_DARK = "https://static.btcmap.org/map-styles/dark.json";
-
-const styleUrlForTheme = (t: "light" | "dark" | undefined): string =>
-	t === "dark" ? STYLE_DARK : STYLE_LIGHT;
 
 let captchaContent = "";
 let isCaptchaLoading = true;
@@ -102,55 +95,39 @@ function resetForm() {
 
 async function initializeMap() {
 	// Clean up any existing map (e.g. resetForm re-init).
-	if (map) {
-		map.remove();
-		map = undefined;
-	}
+	mapHandle?.destroy();
+	mapHandle = undefined;
+	map = undefined;
 	marker?.remove();
 	marker = undefined;
 	mapLoaded = false;
 
-	if (!hasWebGL()) {
+	// The bring-up (WebGL check, import, worker/RTL, controls, theme-swap
+	// state machine) lives in createBtcmapMap. No overlays: the picked-
+	// location marker is DOM-level and survives style swaps on its own.
+	const outcome = await createBtcmapMap({
+		container: mapElement,
+		theme: $theme,
+		mapOptions: { center: [0, 0], zoom: 2 },
+		isCancelled: () => destroyed,
+		registerOverlays: () => {},
+		onFirstLoad: () => {
+			mapLoaded = true;
+		},
+	});
+
+	if (outcome.status === "unsupported") {
 		webglUnsupported = true;
 		return;
 	}
-	const maplibre = await import("maplibre-gl");
-	ensureMapLibreWorkerUrl(maplibre);
-	ensureRtlTextPlugin(maplibre);
-	maplibreRef = maplibre;
-	if (destroyed) return;
-
-	lastAppliedTheme = $theme;
-
-	map = new maplibre.Map({
-		container: mapElement,
-		style: styleUrlForTheme($theme),
-		center: [0, 0],
-		zoom: 2,
-		maxZoom: 21,
-		dragRotate: true,
-		touchZoomRotate: true,
-		pitchWithRotate: false,
-		attributionControl: { compact: true },
-	});
-
-	map.addControl(
-		new maplibre.NavigationControl({
-			showCompass: true,
-			showZoom: true,
-			visualizePitch: false,
-		}),
-		"top-right",
-	);
-
-	const geolocateControl = new maplibre.GeolocateControl({
-		positionOptions: { enableHighAccuracy: true },
-		trackUserLocation: true,
-		showUserLocation: true,
-		showAccuracyCircle: true,
-		fitBoundsOptions: { maxZoom: 15, linear: true },
-	});
-	map.addControl(geolocateControl, "top-right");
+	if (outcome.status === "cancelled") return;
+	if (destroyed) {
+		outcome.handle.destroy();
+		return;
+	}
+	mapHandle = outcome.handle;
+	map = outcome.handle.map;
+	maplibreRef = outcome.handle.maplibre;
 
 	map.on("click", (e: MapMouseEvent) => {
 		if (!captchaSecret) return;
@@ -158,10 +135,6 @@ async function initializeMap() {
 			fly: false,
 			syncInputs: true,
 		});
-	});
-
-	map.on("load", () => {
-		mapLoaded = true;
 	});
 }
 
@@ -179,6 +152,7 @@ let latError = "";
 let longError = "";
 let marker: MapLibreMarker | undefined;
 let maplibreRef: typeof import("maplibre-gl") | undefined;
+let mapHandle: BtcmapMapHandle | undefined;
 
 function placeMarker(
 	newLat: number,
@@ -351,7 +325,6 @@ let map: MapLibreMap | undefined;
 let mapLoaded = false;
 let webglUnsupported = false;
 let destroyed = false;
-let lastAppliedTheme: "light" | "dark" | undefined;
 
 onMount(async () => {
 	if (browser) {
@@ -365,24 +338,15 @@ onMount(async () => {
 
 onDestroy(() => {
 	destroyed = true;
-	if (map) {
-		map.remove();
-		map = undefined;
-	}
+	mapHandle?.destroy();
+	mapHandle = undefined;
+	map = undefined;
 });
 
-const applyTheme = (next: "light" | "dark" | undefined) => {
-	if (!map || !mapLoaded) return;
-	if (next === lastAppliedTheme) return;
-	lastAppliedTheme = next;
-	// setStyle preserves added markers (managed outside the style) but drops
-	// any source/layer overrides. We don't add custom layers here, so a plain
-	// setStyle() is sufficient.
-	map.setStyle(styleUrlForTheme(next));
-};
-
+// The facade's setTheme handles change detection; the picked-location
+// marker is DOM-level and survives style swaps on its own.
 $: if (map && mapLoaded) {
-	applyTheme($theme);
+	mapHandle?.setTheme($theme);
 }
 </script>
 

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -340,7 +340,6 @@ const attachInteractions = (m: MapLibreMap) => {
 	m.addControl(new maplibre.ScaleControl({ unit: "metric" }), "bottom-left");
 
 	m.on("click", FILL_LAYER_ID, (e: MapLayerMouseEvent) => {
-		if (!map) return;
 		const feature = e.features?.[0];
 		if (!feature) return;
 		const id = feature.properties?.id as string | undefined;
@@ -360,10 +359,10 @@ const attachInteractions = (m: MapLibreMap) => {
 	});
 
 	const setPointer = () => {
-		if (map) map.getCanvas().style.cursor = "pointer";
+		m.getCanvas().style.cursor = "pointer";
 	};
 	const resetPointer = () => {
-		if (map) map.getCanvas().style.cursor = "";
+		m.getCanvas().style.cursor = "";
 	};
 	m.on("mouseenter", FILL_LAYER_ID, setPointer);
 	m.on("mouseleave", FILL_LAYER_ID, resetPointer);

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -26,10 +26,9 @@ import {
 	styleForBasemap,
 } from "$lib/map/basemaps";
 import { computeBbox } from "$lib/map/bbox";
+import type { BtcmapMapHandle } from "$lib/map/createMap";
+import { createBtcmapMap } from "$lib/map/createMap";
 import { parseHashCoords, writeHashCoords } from "$lib/map/mapHash";
-import { ensureRtlTextPlugin } from "$lib/map/rtl";
-import { hasWebGL } from "$lib/map/webgl";
-import { ensureMapLibreWorkerUrl } from "$lib/map/worker";
 import { areaError, areas, reportError, reports } from "$lib/store";
 import { areasSync } from "$lib/sync/areas";
 import { batchSync } from "$lib/sync/batchSync";
@@ -47,7 +46,12 @@ let mapLoading = 0;
 
 let mapElement: HTMLDivElement;
 let map: MapLibreMap | undefined;
+let mapHandle: BtcmapMapHandle | undefined;
 let mapLoaded = false;
+// Last published polygon set, kept so a basemap swap can re-seed the fresh
+// style's source (the swap machine re-installs layers instead of carrying
+// them — see createBtcmapMap.setStyle).
+let lastCommunitiesFC: FeatureCollection | null = null;
 let webglUnsupported = false;
 let communitiesLoaded = false;
 let destroyed = false;
@@ -106,25 +110,12 @@ const buildFeatureCollection = (
 	return { type: "FeatureCollection", features };
 };
 
-// Swap the basemap while keeping the community polygon source + layers live.
-// transformStyle re-attaches them onto the incoming base style; the differ
-// leaves the identical custom layers in place and only swaps the basemap
-// layers below them.
+// Swap the basemap. The facade's swap machine re-installs the polygon
+// source + layers on the incoming style's style.load (registerOverlays) —
+// a momentary polygon blink replaces the old transformStyle carryover and
+// its hand-maintained layer list.
 const applyBasemap = (id: BasemapId) => {
-	if (!map) return;
-	map.setStyle(styleForBasemap(id), {
-		transformStyle: (previous, next) => {
-			if (!previous) return next;
-			const sources = { ...next.sources };
-			if (previous.sources[SOURCE_ID]) {
-				sources[SOURCE_ID] = previous.sources[SOURCE_ID];
-			}
-			const carried = previous.layers.filter(
-				(l) => l.id === FILL_LAYER_ID || l.id === OUTLINE_LAYER_ID,
-			);
-			return { ...next, sources, layers: [...next.layers, ...carried] };
-		},
-	});
+	mapHandle?.setStyle(styleForBasemap(id));
 };
 
 const addCommunitiesLayers = (m: MapLibreMap) => {
@@ -259,8 +250,11 @@ const initializeCommunities = async () => {
 	popupsByCommunity = new Map(communities.map((c) => [c.id, c]));
 
 	addCommunitiesLayers(map);
+	const fc = buildFeatureCollection(communities);
+	// Retained so a basemap swap can re-seed the fresh style's source
+	lastCommunitiesFC = fc;
 	const source = map.getSource(SOURCE_ID) as GeoJSONSource | undefined;
-	source?.setData(buildFeatureCollection(communities));
+	source?.setData(fc);
 
 	if (communityQuery && communitySelected?.tags.geo_json) {
 		try {
@@ -290,59 +284,62 @@ $: if ($areas?.length && $reports?.length && mapLoaded && !communitiesLoaded) {
 }
 
 const initializeMap = async () => {
-	if (!hasWebGL()) {
+	// Five basemaps (legacy parity). A stored picker choice wins; otherwise
+	// the first-visit default is theme-aware (Liberty light, Carto Dark
+	// Matter dark). Explicit-style mode: this page owns style selection, so
+	// the facade's setTheme is inert and swaps go through applyBasemap →
+	// handle.setStyle.
+	const initialBasemap: BasemapId =
+		getStoredBasemap() ?? defaultBasemap(get(theme));
+	const hashCoords = parseHashCoords();
+
+	const outcome = await createBtcmapMap({
+		container: mapElement,
+		theme: get(theme),
+		style: styleForBasemap(initialBasemap),
+		mapOptions: {
+			center: hashCoords ? [hashCoords.lng, hashCoords.lat] : [0, 0],
+			zoom: hashCoords?.zoom ?? 3,
+			bearing: hashCoords?.bearing ?? 0,
+			pitch: hashCoords?.pitch ?? 0,
+		},
+		isCancelled: () => destroyed,
+		// Re-runs after every basemap swap: re-install the polygon layers and
+		// re-seed the fresh style's source from the last published set.
+		registerOverlays: (m) => {
+			addCommunitiesLayers(m);
+			if (lastCommunitiesFC) {
+				const source = m.getSource(SOURCE_ID) as GeoJSONSource | undefined;
+				source?.setData(lastCommunitiesFC);
+			}
+		},
+		onFirstLoad: (m) => {
+			mapLoading = 40;
+			mapLoaded = true;
+			attachInteractions(m);
+		},
+	});
+
+	if (outcome.status === "unsupported") {
 		webglUnsupported = true;
 		return;
 	}
-	const maplibre = await import("maplibre-gl");
-	ensureMapLibreWorkerUrl(maplibre);
-	ensureRtlTextPlugin(maplibre);
-	if (destroyed) return;
+	if (outcome.status === "cancelled") return;
+	if (destroyed) {
+		outcome.handle.destroy();
+		return;
+	}
+	mapHandle = outcome.handle;
+	map = outcome.handle.map;
+};
 
-	// Five basemaps (legacy parity). A stored picker choice wins; otherwise
-	// the first-visit default is theme-aware (Liberty light, Carto Dark
-	// Matter dark). Each basemap is a fixed, sticky style; switches go through
-	// applyBasemap → setStyle({ transformStyle }) so the polygons ride along.
-	const initialBasemap: BasemapId =
-		getStoredBasemap() ?? defaultBasemap(get(theme));
-	const style = styleForBasemap(initialBasemap);
+const attachInteractions = (m: MapLibreMap) => {
+	const maplibre = mapHandle?.maplibre;
+	if (!maplibre) return;
 
-	const hashCoords = parseHashCoords();
+	m.addControl(new maplibre.ScaleControl({ unit: "metric" }), "bottom-left");
 
-	map = new maplibre.Map({
-		container: mapElement,
-		style,
-		center: hashCoords ? [hashCoords.lng, hashCoords.lat] : [0, 0],
-		zoom: hashCoords?.zoom ?? 3,
-		bearing: hashCoords?.bearing ?? 0,
-		pitch: hashCoords?.pitch ?? 0,
-		maxZoom: 21,
-		dragRotate: true,
-		touchZoomRotate: true,
-		pitchWithRotate: false,
-	});
-
-	map.addControl(
-		new maplibre.NavigationControl({
-			showCompass: true,
-			showZoom: true,
-			visualizePitch: false,
-		}),
-		"top-right",
-	);
-
-	const geolocate = new maplibre.GeolocateControl({
-		positionOptions: { enableHighAccuracy: true },
-		trackUserLocation: true,
-		showUserLocation: true,
-		showAccuracyCircle: true,
-		fitBoundsOptions: { maxZoom: 15, linear: true },
-	});
-	map.addControl(geolocate, "top-right");
-
-	map.addControl(new maplibre.ScaleControl({ unit: "metric" }), "bottom-left");
-
-	map.on("click", FILL_LAYER_ID, (e: MapLayerMouseEvent) => {
+	m.on("click", FILL_LAYER_ID, (e: MapLayerMouseEvent) => {
 		if (!map) return;
 		const feature = e.features?.[0];
 		if (!feature) return;
@@ -354,7 +351,7 @@ const initializeMap = async () => {
 		const popup = new maplibre.Popup({ maxWidth: "320px", closeOnClick: true })
 			.setLngLat(e.lngLat)
 			.setDOMContent(container)
-			.addTo(map);
+			.addTo(m);
 		// Destroy the Socials Svelte instance when the popup goes away —
 		// MapLibre removes the DOM but the component's reactive
 		// subscriptions (theme, locale, etc.) would otherwise leak per
@@ -368,23 +365,18 @@ const initializeMap = async () => {
 	const resetPointer = () => {
 		if (map) map.getCanvas().style.cursor = "";
 	};
-	map.on("mouseenter", FILL_LAYER_ID, setPointer);
-	map.on("mouseleave", FILL_LAYER_ID, resetPointer);
+	m.on("mouseenter", FILL_LAYER_ID, setPointer);
+	m.on("mouseleave", FILL_LAYER_ID, resetPointer);
 
-	map.on("moveend", () => {
-		if (!map || communityQuery) return;
+	m.on("moveend", () => {
+		if (communityQuery) return;
 		writeHashCoords({
-			zoom: map.getZoom(),
-			lat: map.getCenter().lat,
-			lng: map.getCenter().lng,
-			bearing: map.getBearing(),
-			pitch: map.getPitch(),
+			zoom: m.getZoom(),
+			lat: m.getCenter().lat,
+			lng: m.getCenter().lng,
+			bearing: m.getBearing(),
+			pitch: m.getPitch(),
 		});
-	});
-
-	map.on("load", () => {
-		mapLoading = 40;
-		mapLoaded = true;
 	});
 };
 
@@ -397,10 +389,9 @@ onMount(() => {
 
 onDestroy(() => {
 	destroyed = true;
-	if (map) {
-		map.remove();
-		map = undefined;
-	}
+	mapHandle?.destroy();
+	mapHandle = undefined;
+	map = undefined;
 });
 </script>
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -944,8 +944,11 @@ onMount(async () => {
 			spiderfier?.applyTo("clusters-hit");
 			pinSource.refreshHeatmapAfterStyle(m);
 		},
-		onFirstLoad: () => {
-			if (!map || destroyed) return;
+		onFirstLoad: (m) => {
+			// Adopt the instance immediately: the post-outcome assignment below
+			// also sets it, but nothing should depend on winning that race.
+			map = m;
+			if (destroyed) return;
 
 			// Spiderfy hooks the clusters-hit symbol layer. The library's
 			// internal decision is: if expansionZoom > forceSpiderifyMinZoom OR

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -794,6 +794,17 @@ $: if (
 	void ensureVerifiedDates().then(() => updateMerchantList({ force: true }));
 }
 
+// Globe projection is page state: a basemap swap resets the projection to
+// the incoming style's default, and registerOverlays (re-run on every
+// style.load, queued swaps included) is the one reliable re-apply point.
+let globeOn = false;
+const toggleGlobe = () => {
+	if (!map) return;
+	globeOn = !globeOn;
+	map.setProjection({ type: globeOn ? "globe" : "mercator" });
+	trackEvent("worldview_toggle", { enabled: globeOn });
+};
+
 // Heatmap on/off state and layer-visibility juggling live in the facade;
 // this wrapper is the shape <MapControls> expects.
 const setHeatmapEnabled = (enabled: boolean) => {
@@ -943,6 +954,8 @@ onMount(async () => {
 			ensureSpritesForPlaces(m, get(places));
 			spiderfier?.applyTo("clusters-hit");
 			pinSource.refreshHeatmapAfterStyle(m);
+			// The incoming style resets the projection to its default.
+			if (globeOn) m.setProjection({ type: "globe" });
 		},
 		onFirstLoad: (m) => {
 			// Adopt the instance immediately: the post-outcome assignment below
@@ -1185,9 +1198,10 @@ onMount(async () => {
 	}
 	mapHandle = outcome.handle;
 	map = outcome.handle.map;
-	// Stash the namespace so the selection-pulse helpers can build a Marker.
-	maplibreNs = outcome.handle.maplibre;
+	// Stash the namespace so the selection-pulse helpers can build a Marker;
+	// the local alias below is the same binding, for the wiring code's use.
 	const maplibre = outcome.handle.maplibre;
+	maplibreNs = maplibre;
 
 	if (queryView?.kind === "bounds") {
 		map.fitBounds([queryView.sw, queryView.ne], { animate: false });
@@ -1353,6 +1367,8 @@ onDestroy(() => {
 	{setHeatmapEnabled}
 	enableBoost
 	enableGlobe
+	{globeOn}
+	onToggleGlobe={toggleGlobe}
 />
 
 <style>

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -40,6 +40,8 @@ import {
 	styleForBasemap,
 } from "$lib/map/basemaps";
 import { shouldClusterBoostedAtZoom } from "$lib/map/boostedClustering";
+import type { BtcmapMapHandle } from "$lib/map/createMap";
+import { createBtcmapMap } from "$lib/map/createMap";
 import {
 	type HashCoords,
 	parseHashCoords,
@@ -47,17 +49,11 @@ import {
 } from "$lib/map/mapHash";
 import {
 	ensureSpritesForPlaces,
-	installPlaceholderHandler,
 	PIN_FILL_BOOSTED,
 	PIN_FILL_REGULAR,
 } from "$lib/map/maplibreSprites";
-import {
-	CUSTOM_LAYER_IDS,
-	CUSTOM_SOURCE_IDS,
-	createPlacePinSource,
-} from "$lib/map/placePinSource";
+import { createPlacePinSource } from "$lib/map/placePinSource";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
-import { ensureRtlTextPlugin } from "$lib/map/rtl";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
 import {
 	calculateRadiusKmFromLngLatBounds,
@@ -69,8 +65,6 @@ import {
 	placesRevision,
 	selectVisiblePlaces,
 } from "$lib/map/visiblePlaces";
-import { hasWebGL } from "$lib/map/webgl";
-import { ensureMapLibreWorkerUrl } from "$lib/map/worker";
 import {
 	MERCHANT_URL_CHANGE_EVENT,
 	parseMerchantHash,
@@ -130,6 +124,7 @@ if (outdatedOnly) {
 
 let mapContainer: HTMLDivElement;
 let map: MapLibreMap | undefined;
+let mapHandle: BtcmapMapHandle | undefined;
 let destroyed = false;
 let spiderfier: Spiderfy | undefined;
 let styleLoaded = false;
@@ -807,49 +802,17 @@ const setHeatmapEnabled = (enabled: boolean) => {
 };
 
 // Switch the basemap without tearing down our pin/cluster/label layers.
-// setStyle's transformStyle hook re-attaches the custom sources + layers
-// onto the incoming base style; because they're identical to what's already
-// mounted, the differ keeps the layers (and the carried GeoJSON data) live —
-// only the basemap layers below them swap.
-//
-// Two things do NOT survive setStyle on their own and are re-established in
-// the style.load handler below:
-//   • the spiderfier's click/zoom handlers — unspiderfyAll() detaches them
-//     (map.off) and only applyTo() re-binds them, so we must applyTo again;
-//   • the addImage sprites (cluster-hit, badges) IF MapLibre ever falls back
-//     from the diff to a full rebuild (fresh imageManager). The loaders are
-//     hasImage-guarded, so re-running them is a cheap no-op on the normal path.
-// The handler is registered BEFORE setStyle on purpose: for the inline raster
-// (object) style, setStyle fires style.load SYNCHRONOUSLY during the call, so
-// a handler added afterwards would miss it.
+// Swap the basemap. The facade's swap machine re-runs registerOverlays on
+// the incoming style's style.load — sprites, the fifteen layers, label
+// palette, spiderfy re-hook, heatmap state — and the ready toggle clears
+// the render signature so the fresh sources repopulate. A momentary pin
+// blink replaces the old transformStyle carryover and its hand-maintained
+// CUSTOM_*_IDS lists.
 const applyBasemap = (id: BasemapId) => {
-	if (!map) return;
 	// Collapse any open spider before the restyle. This also detaches the
-	// spiderfy library's map handlers (which is why we re-applyTo below).
+	// spiderfy library's map handlers; registerOverlays re-applies them.
 	spiderfier?.unspiderfyAll();
-	map.once("style.load", () => {
-		if (!map) return;
-		applyLabelPalette(map, get(theme));
-		pinSource.loadSprites(map);
-		ensureSpritesForPlaces(map, get(places));
-		spiderfier?.applyTo("clusters-hit");
-		// Re-apply heatmap/cluster visibility in case the style diff fell
-		// back to a full rebuild and reset carried layout properties.
-		pinSource.refreshHeatmapAfterStyle(map);
-	});
-	map.setStyle(styleForBasemap(id), {
-		transformStyle: (previous, next) => {
-			if (!previous) return next;
-			const sources = { ...next.sources };
-			for (const sid of CUSTOM_SOURCE_IDS) {
-				if (previous.sources[sid]) sources[sid] = previous.sources[sid];
-			}
-			const carried = previous.layers.filter((l) =>
-				CUSTOM_LAYER_IDS.includes(l.id),
-			);
-			return { ...next, sources, layers: [...next.layers, ...carried] };
-		},
-	});
+	mapHandle?.setStyle(styleForBasemap(id));
 };
 
 onMount(async () => {
@@ -861,28 +824,12 @@ onMount(async () => {
 		`${SEARCH_SHEET_PEEK_HEIGHT}px`,
 	);
 
-	// WebGL absence (older Android WebViews, hardened browsers, disabled
-	// GPU) would leave the map blank if we tried to instantiate MapLibre.
-	// Surface a static fallback instead.
-	if (!hasWebGL()) {
-		webglUnsupported = true;
-		return;
-	}
-	const maplibre = await import("maplibre-gl");
-	ensureMapLibreWorkerUrl(maplibre);
-	ensureRtlTextPlugin(maplibre);
-	// User may have navigated away while the dynamic import was in
-	// flight; bail before instantiating against an unmounted container.
-	if (destroyed) return;
-	// Stash the namespace so the selection-pulse helpers can build a Marker.
-	maplibreNs = maplibre;
-
 	// Five basemaps (legacy parity): four vector styles + the OSM raster
 	// style. A stored picker choice wins; otherwise the first-visit default
 	// is theme-aware (Liberty in light, Carto Dark Matter in dark). Each
 	// basemap is a FIXED style — the choice is sticky and a theme toggle does
-	// not swap it. Switching goes through applyBasemap() → setStyle({
-	// transformStyle }) so the custom pin/cluster/label layers ride along.
+	// not swap it. Explicit-style mode: this page owns style selection, so
+	// swaps go through applyBasemap → handle.setStyle.
 	const initialBasemap: BasemapId =
 		getStoredBasemap() ?? defaultBasemap(get(theme));
 	const style = styleForBasemap(initialBasemap);
@@ -939,34 +886,305 @@ onMount(async () => {
 		initialCenter = [ipGeo.lng, ipGeo.lat];
 	}
 
-	map = new maplibre.Map({
+	const outcome = await createBtcmapMap({
 		container: mapContainer,
-		// Resolved basemap style — a vector style URL, or the inline OSM raster
-		// style. Defaults to the theme-aware basemap unless the user picked one.
+		theme: get(theme),
 		style,
-		// Show the "Support BTC Map" supporter link on every basemap (legacy
-		// /map guaranteed it regardless of basemap). Data-source credit
-		// (OSM / OpenFreeMap / Carto) comes from each style's own sources.
-		// Mobile: compact (i) button so it doesn't cover the bottom edge under
-		// the floating search. Desktop has room — show the full credit.
-		attributionControl: {
-			customAttribution: SUPPORT_ATTR,
-			compact: isMobileLayout,
+		mapOptions: {
+			// Show the "Support BTC Map" supporter link on every basemap (legacy
+			// /map guaranteed it regardless of basemap). Data-source credit
+			// (OSM / OpenFreeMap / Carto) comes from each style's own sources.
+			// Mobile: compact (i) button so it doesn't cover the bottom edge
+			// under the floating search. Desktop has room — show the full credit.
+			attributionControl: {
+				customAttribution: SUPPORT_ATTR,
+				compact: isMobileLayout,
+			},
+			center: initialCenter,
+			zoom: initialZoom,
+			bearing: hashCoords?.bearing ?? 0,
+			pitch: hashCoords?.pitch ?? 0,
+			// Match legacy Leaflet `noWrap: true` — stop the map from
+			// repeating horizontally when zoomed out, so the user can't pan
+			// past the antimeridian into a duplicate copy of the world.
+			renderWorldCopies: false,
 		},
-		center: initialCenter,
-		zoom: initialZoom,
-		bearing: hashCoords?.bearing ?? 0,
-		pitch: hashCoords?.pitch ?? 0,
-		maxZoom: 21,
-		// Match legacy Leaflet `noWrap: true` — stop the map from
-		// repeating horizontally when zoomed out, so the user can't pan
-		// past the antimeridian into a duplicate copy of the world.
-		renderWorldCopies: false,
-		// Rotation + pitch enabled — the whole point of the migration
-		dragRotate: true,
-		touchZoomRotate: true,
-		pitchWithRotate: false,
+		isCancelled: () => destroyed,
+		// Mirror legacy /map: sync location into the userLocation store so
+		// the merchant list panel can compute distances without prompting.
+		onGeolocate: (coords) => {
+			userLocation.setLocation(coords.latitude, coords.longitude);
+		},
+		onStyleReadyChange: (ready) => {
+			styleLoaded = ready;
+			// Every style becoming ready (first load AND basemap swaps, whose
+			// fresh styles arrive without our sources) invalidates the render
+			// signature: the marker block recomputes the filtered selection
+			// and syncs it into the just-installed sources. Never sync raw
+			// $places — all filtering lives upstream in the pipeline.
+			if (ready) lastRenderSig = "";
+		},
+		// Runs on the initial load and again after every basemap swap's
+		// style.load — a swap's incoming style has none of our sprites,
+		// sources, or layers. The saved-badge fetch goes to a third-party CDN
+		// and must NOT block init; the facade-side loaders catch and degrade.
+		registerOverlays: async (m) => {
+			await pinSource.loadSprites(m);
+			// Component may have been destroyed while sprites were loading
+			// (user navigated away within ~1s of mount).
+			if (destroyed) return;
+			// Sources + fifteen layers (pins, clusters, badges, labels, heatmap).
+			pinSource.install(m);
+			// Style-dependent state the incoming style resets: label palette,
+			// composite pin sprites, spiderfy's layer hook (no-op before the
+			// spiderfier exists on first load), heatmap visibility.
+			applyLabelPalette(m, get(theme));
+			lastAppliedLabelTheme = get(theme);
+			ensureSpritesForPlaces(m, get(places));
+			spiderfier?.applyTo("clusters-hit");
+			pinSource.refreshHeatmapAfterStyle(m);
+		},
+		onFirstLoad: () => {
+			if (!map || destroyed) return;
+
+			// Spiderfy hooks the clusters-hit symbol layer. The library's
+			// internal decision is: if expansionZoom > forceSpiderifyMinZoom OR
+			// expansionZoom > map.maxZoom → spiderfy; else easeTo to expansionZoom.
+			// The default forceSpiderifyMinZoom is null, which coerces to 0 and
+			// causes EVERY click to spiderfy. Set it to our clustering threshold
+			// so only genuinely un-zoomable clusters (coincident points whose
+			// expansionZoom exceeds the threshold) spider out.
+			spiderfier = new Spiderfy(map, {
+				forceSpiderifyMinZoom: CLUSTERING_DISABLED_ZOOM,
+				onLeafClick: (feature) => {
+					const placeId = feature.properties?.id;
+					if (typeof placeId === "number") {
+						merchantDrawer.open(placeId, "details");
+					}
+				},
+				closeOnLeafClick: true,
+				spiderLeavesLayout: {
+					"icon-image": [
+						"concat",
+						"pin-",
+						["case", ["coalesce", ["get", "boosted"], false], "b", "r"],
+						"-",
+						["coalesce", ["get", "icon"], "question_mark"],
+					],
+					"icon-size": 1,
+					"icon-anchor": "bottom",
+					"icon-allow-overlap": true,
+					"icon-ignore-placement": true,
+					"icon-rotation-alignment": "viewport",
+					"icon-pitch-alignment": "viewport",
+				},
+				spiderLegsColor: "rgba(100, 100, 100, 0.6)",
+			});
+			spiderfier.applyTo("clusters-hit");
+
+			const setPointerCursor = () => {
+				if (map) map.getCanvas().style.cursor = "pointer";
+			};
+			const resetCursor = () => {
+				if (map) map.getCanvas().style.cursor = "";
+			};
+			map.on("mouseenter", "clusters-outer", setPointerCursor);
+			map.on("mouseleave", "clusters-outer", resetCursor);
+			map.on("mouseenter", "unclustered-point", setPointerCursor);
+			map.on("mouseleave", "unclustered-point", resetCursor);
+			map.on("mouseenter", "boosted-point", setPointerCursor);
+			map.on("mouseleave", "boosted-point", resetCursor);
+
+			// Unclustered marker click → open the global merchant drawer. The
+			// drawer component lives in the layout, so we only need to push state
+			// into the store. Both layers share the same handler since boosted
+			// pins live in their own source above the clustered one.
+			const onPinClick = (e: MapLayerMouseEvent) => {
+				const feature = e.features?.[0] as MapGeoJSONFeature | undefined;
+				const placeId = feature?.properties?.id;
+				if (typeof placeId !== "number") return;
+				merchantDrawer.open(placeId, "details");
+			};
+			map.on("click", "unclustered-point", onPinClick);
+			map.on("click", "boosted-point", onPinClick);
+
+			// Click on empty map (no marker or cluster hit) closes any open
+			// drawer — matches /map's behavior. Layer-scoped click handlers
+			// fire alongside this generic one, so clicking a marker still
+			// reopens the drawer for the new feature net-net.
+			// The spiderfy lib adds its own symbol layers at applyTo() time
+			// with ids prefixed `spiderfy-leaf-…`. Without including them
+			// here, tapping a spidered leaf would open the drawer (via
+			// onLeafClick) and then immediately close it again because the
+			// generic handler sees no hit on the allowlisted layers.
+			map.on("click", (e: MapLayerMouseEvent) => {
+				if (!map) return;
+				if (!get(merchantDrawer).isOpen) return;
+				const spiderLeafLayerIds = map
+					.getStyle()
+					.layers.filter((l) => l.id.startsWith("spiderfy-leaf"))
+					.map((l) => l.id);
+				const hit = map.queryRenderedFeatures(e.point, {
+					layers: [
+						"unclustered-point",
+						"boosted-point",
+						"clusters-hit",
+						...spiderLeafLayerIds,
+					],
+				});
+				if (hit.length > 0) return;
+				merchantDrawer.close();
+			});
+
+			// Refresh enriched details (and thus labels) on viewport changes
+			// once we're above LABEL_VISIBLE_ZOOM. Debounced so quick pans don't
+			// spam the API; the store internally aborts any stale request.
+			map.on("moveend", triggerEnrichmentIfNeeded);
+
+			// Track current zoom + center + refresh the merchant list panel's
+			// nearby items based on the new viewport. Debounced to keep cost
+			// off the move path. Center drives the CommunityRail.
+			map.on("moveend", () => {
+				if (!map) return;
+				currentZoom = map.getZoom();
+				const c = map.getCenter();
+				currentLat = c.lat;
+				currentLon = c.lng;
+				// Re-route boosted places when zoom crosses BOOSTED_CLUSTERING_MAX_ZOOM
+				// — the MapLibre analogue of the legacy boostedLayer swap. The facade
+				// only re-renders on an actual flip, so steady-state pans stay cheap.
+				if (styleLoaded) {
+					pinSource.resyncForZoom(map);
+				}
+				// When the heatmap is active, zooming past CLUSTERING_DISABLED_ZOOM
+				// naturally removes the heatmap layer (its maxzoom), so re-show
+				// all the point/cluster/badge layers that were concealed.
+				pinSource.applyHeatmapVisibility(map);
+				debouncedUpdateMerchantList();
+			});
+
+			// Tile-loading indicator — debounced to avoid flicker on quick pans.
+			map.on("movestart", () => {
+				if (tilesLoadingTimer) clearTimeout(tilesLoadingTimer);
+				if (tilesLoadingFallback) clearTimeout(tilesLoadingFallback);
+				tilesLoadingTimer = setTimeout(() => {
+					tilesLoading = true;
+				}, 150);
+				tilesLoadingFallback = setTimeout(() => {
+					tilesLoading = false;
+				}, 5000);
+			});
+			map.on("idle", () => {
+				if (tilesLoadingTimer) {
+					clearTimeout(tilesLoadingTimer);
+					tilesLoadingTimer = null;
+				}
+				if (tilesLoadingFallback) {
+					clearTimeout(tilesLoadingFallback);
+					tilesLoadingFallback = null;
+				}
+				tilesLoading = false;
+				mapTilesLoaded = true;
+				// Clustering is settled on idle — reconcile the pulse with whether the
+				// selected pin is currently rendered individually or inside a cluster.
+				updatePulseVisibility();
+			});
+
+			// Persist viewport in the URL hash. Preserves any merchant=… params
+			// added by the drawer so shareable URLs round-trip.
+			const persistViewportToHash = () => {
+				if (!map) return;
+				const center = map.getCenter();
+				writeHashCoords({
+					zoom: map.getZoom(),
+					lat: center.lat,
+					lng: center.lng,
+					bearing: map.getBearing(),
+					pitch: map.getPitch(),
+				});
+			};
+			map.on("moveend", persistViewportToHash);
+
+			// Persist viewport to localforage too, debounced so continuous
+			// pan/zoom doesn't hammer IndexedDB. Returning users land back
+			// where they left off when they revisit /map with no hash/query.
+			const persistViewportToCache = debounce(() => {
+				if (!map) return;
+				const center = map.getCenter();
+				saveCachedView({
+					lat: center.lat,
+					lng: center.lng,
+					zoom: map.getZoom(),
+				});
+			}, 1000);
+			map.on("moveend", persistViewportToCache);
+
+			// If the URL also encoded a merchant=… param, open the drawer to it.
+			merchantDrawer.syncFromHash();
+
+			// Keep the drawer in sync with every channel the merchant URL state
+			// can mutate through:
+			//   • hashchange — direct hash edits or `location.hash = ...`
+			//   • MERCHANT_URL_CHANGE_EVENT — updateMerchantHash() fires this
+			//     because the SvelteKit pushState/replaceState path doesn't
+			//     trigger native popstate/hashchange events.
+			//   • popstate — browser back/forward across history entries that
+			//     differ only in the ?merchant= query param.
+			window.addEventListener("hashchange", handleHashChange);
+			window.addEventListener(MERCHANT_URL_CHANGE_EVENT, handleHashChange);
+			window.addEventListener("popstate", handleHashChange);
+
+			// Deep link: the URL selected a merchant. Reveal it as an individual
+			// pin — pan/zoom to it once it's in the places store — when the URL
+			// carried no viewport, OR carried one whose zoom is below the clustering
+			// threshold (where the pin would be absorbed into a cluster, leaving the
+			// selection pulse floating with nothing under it). A hash zoom at/above
+			// the threshold is honoured as-is. If places are still loading,
+			// subscribe and wait — 10s safety unsubscribe so we never leak.
+			if (!hashCoords || hashCoords.zoom < CLUSTERING_DISABLED_ZOOM) {
+				const { merchantId, isOpen } = parseMerchantHash();
+				if (isOpen && merchantId) {
+					const place = get(placesById).get(merchantId);
+					if (place) {
+						panToPlace(place.lat, place.lon);
+					} else {
+						deepLinkPanUnsub = placesById.subscribe(($byId) => {
+							const p = $byId.get(merchantId);
+							if (!p) return;
+							panToPlace(p.lat, p.lon);
+							if (deepLinkPanTimer) clearTimeout(deepLinkPanTimer);
+							deepLinkPanUnsub?.();
+							deepLinkPanUnsub = null;
+						});
+						deepLinkPanTimer = setTimeout(() => {
+							deepLinkPanUnsub?.();
+							deepLinkPanUnsub = null;
+							deepLinkPanTimer = null;
+						}, 10_000);
+					}
+				}
+			}
+
+			// Kick once on load — if the user lands above the threshold, labels
+			// should appear without requiring a move.
+			triggerEnrichmentIfNeeded();
+		},
 	});
+
+	if (outcome.status === "unsupported") {
+		webglUnsupported = true;
+		return;
+	}
+	if (outcome.status === "cancelled") return;
+	if (destroyed) {
+		outcome.handle.destroy();
+		return;
+	}
+	mapHandle = outcome.handle;
+	map = outcome.handle.map;
+	// Stash the namespace so the selection-pulse helpers can build a Marker.
+	maplibreNs = outcome.handle.maplibre;
+	const maplibre = outcome.handle.maplibre;
 
 	if (queryView?.kind === "bounds") {
 		map.fitBounds([queryView.sw, queryView.ne], { animate: false });
@@ -979,42 +1197,18 @@ onMount(async () => {
 	currentLat = initialCenter[1];
 	currentLon = initialCenter[0];
 
-	map.addControl(
-		new maplibre.NavigationControl({
-			showCompass: true,
-			showZoom: true,
-			visualizePitch: false,
-		}),
-		"top-right",
-	);
 	// Bottom-left scale bar — present in legacy /map (Leaflet's
-	// L.control.scale). Metric units only; imperial is added by the
-	// browser locale via MapLibre's bilingual variant if needed later.
+	// L.control.scale). Metric units only.
 	map.addControl(new maplibre.ScaleControl({ unit: "metric" }), "bottom-left");
 
 	// Mobile only: the compact AttributionControl renders expanded on first
 	// load (maplibregl-compact-show). Collapse it to the (i) button so it
 	// doesn't cover the bottom edge; the user can still tap (i) to expand.
-	// Desktop is not compact, so the full credit stays visible.
 	if (isMobileLayout) {
 		mapContainer
 			.querySelector(".maplibregl-ctrl-attrib")
 			?.classList.remove("maplibregl-compact-show");
 	}
-
-	// Geolocate control: pulse dot, accuracy circle, and heading arrow are
-	// built in. Heading uses the device's compass when available, falling
-	// back to GPS movement. fitBoundsOptions.linear routes the camera move
-	// through easeTo instead of flyTo — skips the parabolic zoom-out/zoom-in
-	// arc that read as a long detour for short hops.
-	const geolocate = new maplibre.GeolocateControl({
-		positionOptions: { enableHighAccuracy: true },
-		trackUserLocation: true,
-		showUserLocation: true,
-		showAccuracyCircle: true,
-		fitBoundsOptions: { maxZoom: 15, linear: true },
-	});
-	map.addControl(geolocate, "top-right");
 
 	// Built-in MapLibre controls (geolocate) expose their actions through
 	// native button clicks, not through event APIs we can subscribe to
@@ -1023,284 +1217,6 @@ onMount(async () => {
 	mapContainer
 		.querySelector(".maplibregl-ctrl-geolocate")
 		?.addEventListener("click", () => trackEvent("locate_click"));
-
-	// The page-nav menu + layers/filters trigger buttons and their modals are
-	// owned by <MapControls> (rendered in the markup); it registers the
-	// IControls once `map` is set below.
-
-	// Mirror /map's behavior: sync location into the userLocation store so
-	// the merchant list panel can compute distances without prompting again.
-	// v6's GeolocatePositionEvent exposes coords/timestamp directly but is
-	// not assignable to GeolocationPosition (no toJSON) — let TS infer it.
-	geolocate.on("geolocate", (e) => {
-		userLocation.setLocation(e.coords.latitude, e.coords.longitude);
-	});
-
-	// Composite pin sprites resolve async. Until each `pin-r-{icon}` /
-	// `pin-b-{icon}` lands, MapLibre logs `Image "…" could not be loaded`
-	// for every tile that wants to draw it — on a fresh load with dozens
-	// of unique icon names that's a flood of warnings. The placeholder
-	// handler registers a 1×1 transparent stub for any missing id; the
-	// real sprite replaces it on resolution (see maplibreSprites.ts).
-	installPlaceholderHandler(map);
-
-	map.on("load", async () => {
-		if (!map || destroyed) return;
-
-		// The saved-badge fetch goes to a third-party CDN and must NOT block
-		// map init — the facade catches sprite failures and degrades. The pin
-		// and pin-boosted plain sprites are NOT loaded here — every pin layer
-		// references the composite `pin-r-{icon}` / `pin-b-{icon}` names
-		// produced lazily by ensureSpritesForPlaces.
-		await pinSource.loadSprites(map);
-
-		// Component may have been destroyed while sprites were loading
-		// (user navigated away within ~1s of mount). Without this check
-		// every subsequent addSource/addLayer/new Spiderfy/addEventListener
-		// would run against a removed map and leak handlers. onDestroy's
-		// `map?.remove()` runs but leaves the variable bound to the
-		// destroyed instance, so a plain `!map` check doesn't catch this.
-		if (destroyed) return;
-
-		// Sources + fifteen layers (pins, clusters, badges, labels, heatmap).
-		pinSource.install(map);
-
-		// Spiderfy hooks the clusters-hit symbol layer. The library's
-		// internal decision is: if expansionZoom > forceSpiderifyMinZoom OR
-		// expansionZoom > map.maxZoom → spiderfy; else easeTo to expansionZoom.
-		// The default forceSpiderifyMinZoom is null, which coerces to 0 and
-		// causes EVERY click to spiderfy. Set it to our clustering threshold
-		// so only genuinely un-zoomable clusters (coincident points whose
-		// expansionZoom exceeds the threshold) spider out.
-		spiderfier = new Spiderfy(map, {
-			forceSpiderifyMinZoom: CLUSTERING_DISABLED_ZOOM,
-			onLeafClick: (feature) => {
-				const placeId = feature.properties?.id;
-				if (typeof placeId === "number") {
-					merchantDrawer.open(placeId, "details");
-				}
-			},
-			closeOnLeafClick: true,
-			spiderLeavesLayout: {
-				"icon-image": [
-					"concat",
-					"pin-",
-					["case", ["coalesce", ["get", "boosted"], false], "b", "r"],
-					"-",
-					["coalesce", ["get", "icon"], "question_mark"],
-				],
-				"icon-size": 1,
-				"icon-anchor": "bottom",
-				"icon-allow-overlap": true,
-				"icon-ignore-placement": true,
-				"icon-rotation-alignment": "viewport",
-				"icon-pitch-alignment": "viewport",
-			},
-			spiderLegsColor: "rgba(100, 100, 100, 0.6)",
-		});
-		spiderfier.applyTo("clusters-hit");
-
-		const setPointerCursor = () => {
-			if (map) map.getCanvas().style.cursor = "pointer";
-		};
-		const resetCursor = () => {
-			if (map) map.getCanvas().style.cursor = "";
-		};
-		map.on("mouseenter", "clusters-outer", setPointerCursor);
-		map.on("mouseleave", "clusters-outer", resetCursor);
-		map.on("mouseenter", "unclustered-point", setPointerCursor);
-		map.on("mouseleave", "unclustered-point", resetCursor);
-		map.on("mouseenter", "boosted-point", setPointerCursor);
-		map.on("mouseleave", "boosted-point", resetCursor);
-
-		// Unclustered marker click → open the global merchant drawer. The
-		// drawer component lives in the layout, so we only need to push state
-		// into the store. Both layers share the same handler since boosted
-		// pins live in their own source above the clustered one.
-		const onPinClick = (e: MapLayerMouseEvent) => {
-			const feature = e.features?.[0] as MapGeoJSONFeature | undefined;
-			const placeId = feature?.properties?.id;
-			if (typeof placeId !== "number") return;
-			merchantDrawer.open(placeId, "details");
-		};
-		map.on("click", "unclustered-point", onPinClick);
-		map.on("click", "boosted-point", onPinClick);
-
-		// Click on empty map (no marker or cluster hit) closes any open
-		// drawer — matches /map's behavior. Layer-scoped click handlers
-		// fire alongside this generic one, so clicking a marker still
-		// reopens the drawer for the new feature net-net.
-		// The spiderfy lib adds its own symbol layers at applyTo() time
-		// with ids prefixed `spiderfy-leaf-…`. Without including them
-		// here, tapping a spidered leaf would open the drawer (via
-		// onLeafClick) and then immediately close it again because the
-		// generic handler sees no hit on the allowlisted layers.
-		map.on("click", (e: MapLayerMouseEvent) => {
-			if (!map) return;
-			if (!get(merchantDrawer).isOpen) return;
-			const spiderLeafLayerIds = map
-				.getStyle()
-				.layers.filter((l) => l.id.startsWith("spiderfy-leaf"))
-				.map((l) => l.id);
-			const hit = map.queryRenderedFeatures(e.point, {
-				layers: [
-					"unclustered-point",
-					"boosted-point",
-					"clusters-hit",
-					...spiderLeafLayerIds,
-				],
-			});
-			if (hit.length > 0) return;
-			merchantDrawer.close();
-		});
-
-		// Refresh enriched details (and thus labels) on viewport changes
-		// once we're above LABEL_VISIBLE_ZOOM. Debounced so quick pans don't
-		// spam the API; the store internally aborts any stale request.
-		map.on("moveend", triggerEnrichmentIfNeeded);
-
-		// Track current zoom + center + refresh the merchant list panel's
-		// nearby items based on the new viewport. Debounced to keep cost
-		// off the move path. Center drives the CommunityRail.
-		map.on("moveend", () => {
-			if (!map) return;
-			currentZoom = map.getZoom();
-			const c = map.getCenter();
-			currentLat = c.lat;
-			currentLon = c.lng;
-			// Re-route boosted places when zoom crosses BOOSTED_CLUSTERING_MAX_ZOOM
-			// — the MapLibre analogue of the legacy boostedLayer swap. The facade
-			// only re-renders on an actual flip, so steady-state pans stay cheap.
-			if (styleLoaded) {
-				pinSource.resyncForZoom(map);
-			}
-			// When the heatmap is active, zooming past CLUSTERING_DISABLED_ZOOM
-			// naturally removes the heatmap layer (its maxzoom), so re-show
-			// all the point/cluster/badge layers that were concealed.
-			pinSource.applyHeatmapVisibility(map);
-			debouncedUpdateMerchantList();
-		});
-
-		// Tile-loading indicator — debounced to avoid flicker on quick pans.
-		map.on("movestart", () => {
-			if (tilesLoadingTimer) clearTimeout(tilesLoadingTimer);
-			if (tilesLoadingFallback) clearTimeout(tilesLoadingFallback);
-			tilesLoadingTimer = setTimeout(() => {
-				tilesLoading = true;
-			}, 150);
-			tilesLoadingFallback = setTimeout(() => {
-				tilesLoading = false;
-			}, 5000);
-		});
-		map.on("idle", () => {
-			if (tilesLoadingTimer) {
-				clearTimeout(tilesLoadingTimer);
-				tilesLoadingTimer = null;
-			}
-			if (tilesLoadingFallback) {
-				clearTimeout(tilesLoadingFallback);
-				tilesLoadingFallback = null;
-			}
-			tilesLoading = false;
-			mapTilesLoaded = true;
-			// Clustering is settled on idle — reconcile the pulse with whether the
-			// selected pin is currently rendered individually or inside a cluster.
-			updatePulseVisibility();
-		});
-
-		// Persist viewport in the URL hash. Preserves any merchant=… params
-		// added by the drawer so shareable URLs round-trip.
-		const persistViewportToHash = () => {
-			if (!map) return;
-			const center = map.getCenter();
-			writeHashCoords({
-				zoom: map.getZoom(),
-				lat: center.lat,
-				lng: center.lng,
-				bearing: map.getBearing(),
-				pitch: map.getPitch(),
-			});
-		};
-		map.on("moveend", persistViewportToHash);
-
-		// Persist viewport to localforage too, debounced so continuous
-		// pan/zoom doesn't hammer IndexedDB. Returning users land back
-		// where they left off when they revisit /map with no hash/query.
-		const persistViewportToCache = debounce(() => {
-			if (!map) return;
-			const center = map.getCenter();
-			saveCachedView({
-				lat: center.lat,
-				lng: center.lng,
-				zoom: map.getZoom(),
-			});
-		}, 1000);
-		map.on("moveend", persistViewportToCache);
-
-		// If the URL also encoded a merchant=… param, open the drawer to it.
-		merchantDrawer.syncFromHash();
-
-		// Keep the drawer in sync with every channel the merchant URL state
-		// can mutate through:
-		//   • hashchange — direct hash edits or `location.hash = ...`
-		//   • MERCHANT_URL_CHANGE_EVENT — updateMerchantHash() fires this
-		//     because the SvelteKit pushState/replaceState path doesn't
-		//     trigger native popstate/hashchange events.
-		//   • popstate — browser back/forward across history entries that
-		//     differ only in the ?merchant= query param.
-		window.addEventListener("hashchange", handleHashChange);
-		window.addEventListener(MERCHANT_URL_CHANGE_EVENT, handleHashChange);
-		window.addEventListener("popstate", handleHashChange);
-
-		// Deep link: the URL selected a merchant. Reveal it as an individual
-		// pin — pan/zoom to it once it's in the places store — when the URL
-		// carried no viewport, OR carried one whose zoom is below the clustering
-		// threshold (where the pin would be absorbed into a cluster, leaving the
-		// selection pulse floating with nothing under it). A hash zoom at/above
-		// the threshold is honoured as-is. If places are still loading,
-		// subscribe and wait — 10s safety unsubscribe so we never leak.
-		if (!hashCoords || hashCoords.zoom < CLUSTERING_DISABLED_ZOOM) {
-			const { merchantId, isOpen } = parseMerchantHash();
-			if (isOpen && merchantId) {
-				const place = get(placesById).get(merchantId);
-				if (place) {
-					panToPlace(place.lat, place.lon);
-				} else {
-					deepLinkPanUnsub = placesById.subscribe(($byId) => {
-						const p = $byId.get(merchantId);
-						if (!p) return;
-						panToPlace(p.lat, p.lon);
-						if (deepLinkPanTimer) clearTimeout(deepLinkPanTimer);
-						deepLinkPanUnsub?.();
-						deepLinkPanUnsub = null;
-					});
-					deepLinkPanTimer = setTimeout(() => {
-						deepLinkPanUnsub?.();
-						deepLinkPanUnsub = null;
-						deepLinkPanTimer = null;
-					}, 10_000);
-				}
-			}
-		}
-
-		styleLoaded = true;
-		// Invalidate the render signature: setting styleLoaded re-runs the
-		// marker block, which recomputes the filtered selection and syncs it.
-		// Never sync raw $places here — syncPlacesToSource renders exactly
-		// what it is given and all filtering lives upstream in the pipeline.
-		lastRenderSig = "";
-		// Apply theme-dependent label palette now that the layer exists.
-		applyLabelPalette(map, get(theme));
-		lastAppliedLabelTheme = get(theme);
-		// Apply the persisted heatmap on/off state now that the layer
-		// exists. The toggle control can't do this itself — it's added
-		// before 'load' fires, so the layer isn't present at addControl
-		// time.
-		pinSource.refreshHeatmapAfterStyle(map);
-		// Kick once on load — if the user lands above the threshold, labels
-		// should appear without requiring a move.
-		triggerEnrichmentIfNeeded();
-	});
 });
 
 // Theme toggle → re-color the place-label layer in place. setPaintProperty
@@ -1334,7 +1250,8 @@ onDestroy(() => {
 	if (tilesLoadingFallback) clearTimeout(tilesLoadingFallback);
 	spiderfier?.unspiderfyAll();
 	spiderfier = undefined;
-	map?.remove();
+	mapHandle?.destroy();
+	mapHandle = undefined;
 	map = undefined;
 	// merchantList is a module-level singleton. Without this reset the
 	// next visit to /map flashes the previous session's category filter /

--- a/src/routes/map/components/MapControls.svelte
+++ b/src/routes/map/components/MapControls.svelte
@@ -43,13 +43,17 @@ export let currentVerified: VerifiedFilterYears = null;
 export let setHeatmapEnabled: ((enabled: boolean) => void) | null = null;
 export let enableBoost = false;
 export let enableGlobe = false;
+// Globe state lives on the page: a basemap swap resets the projection to
+// the style default, and only the page's registerOverlays (which re-runs on
+// every style.load, queued swaps included) can reliably re-apply it.
+export let globeOn = false;
+export let onToggleGlobe: (() => void) | null = null;
 
 let toolsModalOpen = false;
 let menuModalOpen = false;
 let selectedBasemap: BasemapId | undefined;
 let heatmapOn = false;
 let boostActive = false;
-let globeOn = false;
 
 // Lights the tools trigger's accent dot when a data-affecting toggle is on
 // (verified filter / boost / heatmap), so a returning user sees the map is
@@ -75,14 +79,6 @@ const onPickBasemap = (id: BasemapId) => {
 		localStorage.setItem(BASEMAP_STORAGE_KEY, id);
 	} catch {
 		// localStorage unavailable (private mode); skip persistence.
-	}
-	// applyBasemap swaps the style via setStyle, which resets the projection
-	// to the style default (mercator). Re-apply globe after the swap so it
-	// survives a basemap change. Register before applyBasemap — raster styles
-	// can fire style.load synchronously inside setStyle, so a later listener
-	// would miss it.
-	if (globeOn && map) {
-		map.once("style.load", () => map?.setProjection({ type: "globe" }));
 	}
 	applyBasemap(id);
 	trackEvent("layer_change", { layer: id });
@@ -114,12 +110,6 @@ const onToggleBoost = () => {
 		url.searchParams.delete("boosts");
 	else url.searchParams.set("boosts", "true");
 	window.location.search = url.search;
-};
-const onToggleGlobe = () => {
-	if (!map) return;
-	globeOn = !globeOn;
-	map.setProjection({ type: globeOn ? "globe" : "mercator" });
-	trackEvent("worldview_toggle", { enabled: globeOn });
 };
 
 onMount(() => {

--- a/src/routes/merchant/[id]/components/MerchantStaticMap.svelte
+++ b/src/routes/merchant/[id]/components/MerchantStaticMap.svelte
@@ -5,9 +5,8 @@ import type { Map as MapLibreMap } from "maplibre-gl";
 import { onDestroy, onMount } from "svelte";
 
 import { previewStyleForTheme } from "$lib/map/basemaps";
-import { ensureRtlTextPlugin } from "$lib/map/rtl";
-import { hasWebGL } from "$lib/map/webgl";
-import { ensureMapLibreWorkerUrl } from "$lib/map/worker";
+import type { BtcmapMapHandle } from "$lib/map/createMap";
+import { createBtcmapMap } from "$lib/map/createMap";
 import { theme } from "$lib/theme";
 
 import { browser } from "$app/environment";
@@ -22,50 +21,60 @@ let className = "";
 
 export { className as class };
 
-// Carto Positron / Dark Matter, from the shared basemap catalog — clean,
-// low-contrast backdrops that keep the merchant identity overlay legible.
-const styleUrlForTheme = previewStyleForTheme;
-
 let mapElement: HTMLDivElement;
 let map: MapLibreMap | undefined;
+let mapHandle: BtcmapMapHandle | undefined;
 let destroyed = false;
 let unsupported = false;
 let styleLoaded = false;
-let lastTheme: "light" | "dark" | undefined;
 
 const init = async () => {
-	if (!hasWebGL()) {
+	// Bring-up via the shared facade: Carto Positron / Dark Matter preview
+	// pair as the theme styles, no controls, non-interactive — this map is
+	// purely a hero backdrop.
+	const outcome = await createBtcmapMap({
+		container: mapElement,
+		theme: $theme,
+		styles: (t) => previewStyleForTheme(t === "dark" ? "dark" : "light"),
+		controls: false,
+		mapOptions: {
+			center: [long, lat],
+			zoom: 15,
+			interactive: false,
+		},
+		isCancelled: () => destroyed,
+		// Runs on every style (re)load — the swap machine re-collapses the
+		// attribution the incoming style re-opens.
+		registerOverlays: () => collapseAttribution(),
+		onStyleReadyChange: (ready) => {
+			styleLoaded = ready;
+		},
+		onFirstLoad: (m) => {
+			// MapLibre re-opens the attribution <details> whenever it rebuilds
+			// the credit text: _updateAttributions() (fired on every
+			// sourcedata/styledata as tiles stream in) and resize both call
+			// _updateCompact(), which sets the `open` attr again. Re-collapse
+			// after each — our handlers are registered after MapLibre's
+			// internal ones, so they win — with `idle` as a final guarantee
+			// once loading settles.
+			m.on("sourcedata", collapseAttribution);
+			m.on("styledata", collapseAttribution);
+			m.on("resize", collapseAttribution);
+			m.on("idle", collapseAttribution);
+		},
+	});
+
+	if (outcome.status === "unsupported") {
 		unsupported = true;
 		return;
 	}
-	const maplibre = await import("maplibre-gl");
-	ensureMapLibreWorkerUrl(maplibre);
-	ensureRtlTextPlugin(maplibre);
-	if (destroyed) return;
-
-	lastTheme = $theme;
-	map = new maplibre.Map({
-		container: mapElement,
-		style: styleUrlForTheme($theme),
-		center: [long, lat],
-		zoom: 15,
-		interactive: false,
-		attributionControl: { compact: true },
-	});
-	map.on("style.load", () => {
-		styleLoaded = true;
-		collapseAttribution();
-	});
-	// MapLibre re-opens the attribution <details> whenever it rebuilds the
-	// credit text: _updateAttributions() (fired on every sourcedata/styledata
-	// as tiles stream in) and resize both call _updateCompact(), which sets
-	// the `open` attr again. Re-collapse after each — our handlers are
-	// registered after MapLibre's internal ones, so they win — with `idle`
-	// as a final guarantee once loading settles.
-	map.on("sourcedata", collapseAttribution);
-	map.on("styledata", collapseAttribution);
-	map.on("resize", collapseAttribution);
-	map.on("idle", collapseAttribution);
+	if (outcome.status === "cancelled") return;
+	if (destroyed) {
+		outcome.handle.destroy();
+		return;
+	}
+	mapHandle = outcome.handle;
+	map = outcome.handle.map;
 };
 
 // MapLibre 5 renders attribution as a <details> and opens it by default
@@ -85,15 +94,10 @@ onMount(() => {
 	}
 });
 
-// Swap the basemap when the site theme changes, mirroring the full map.
-$: if (map && styleLoaded && $theme !== lastTheme) {
-	lastTheme = $theme;
-	styleLoaded = false;
-	map.once("style.load", () => {
-		styleLoaded = true;
-		collapseAttribution();
-	});
-	map.setStyle(styleUrlForTheme($theme));
+// Swap the basemap when the site theme changes — the facade handles
+// change detection and re-runs the attribution collapse on style.load.
+$: if (map && styleLoaded) {
+	mapHandle?.setTheme($theme);
 }
 
 // Follow the merchant when the coords change (e.g. param-only navigation),
@@ -104,7 +108,8 @@ $: if (map && typeof lat === "number" && typeof long === "number") {
 
 onDestroy(() => {
 	destroyed = true;
-	map?.remove();
+	mapHandle?.destroy();
+	mapHandle = undefined;
 	map = undefined;
 });
 </script>

--- a/src/routes/merchant/[id]/components/MerchantStaticMap.svelte
+++ b/src/routes/merchant/[id]/components/MerchantStaticMap.svelte
@@ -35,7 +35,7 @@ const init = async () => {
 	const outcome = await createBtcmapMap({
 		container: mapElement,
 		theme: $theme,
-		styles: (t) => previewStyleForTheme(t === "dark" ? "dark" : "light"),
+		styles: previewStyleForTheme,
 		controls: false,
 		mapOptions: {
 			center: [long, lat],


### PR DESCRIPTION
## Summary

Closes #1169 — phase 2, adopting the shared foundation in the four remaining sites, **plus the agreed UX simplification: the `transformStyle` carryover is retired in favor of a momentary overlay blink on basemap swaps** (explicitly signed off: "the blink does not matter for the user").

### Commit 1 — facade generalization
`createBtcmapMap` grows exactly what the site survey demanded, under one crisp rule — **theme mode XOR explicit-style mode**:
- `handle.maplibre` (Marker/Popup construction), async-tolerant `registerOverlays` (first-load wiring and the ready signal wait for it — the sprite-before-layer ordering), a `styles` override for alternate theme pairs, `mapOptions` merged over the shared ctor defaults, `controls: false`, and an `onGeolocate` callback (the control instance stays internal).
- **Generic `handle.setStyle`**: one swap machine for theme changes *and* basemap picks — set style, wait for `style.load` (registered before `setStyle`, so the OSM raster's synchronous fire is caught), re-run `registerOverlays`, flip ready. `setTheme` is sugar over it, inert in explicit-style mode.
- 5 new state-machine tests (async-overlay ordering, both modes, styles override, controls off).

### Commits 2–4 — adoption
- **add-location + merchant hero** (theme family): duplicate style constants and bare-`setStyle` swaps die; the hero uses the preview-pair `styles` override, `controls: false`, non-interactive `mapOptions`, and its attribution-collapse machinery becomes `registerOverlays` + permanent handlers in `onFirstLoad`.
- **communities/map** (explicit-style): `applyBasemap` collapses to `handle.setStyle`; the swap re-installs the polygon layers and re-seeds from the retained collection. One harmonization: attribution is now compact like every other map.
- **/map** (explicit-style, the big one): the ~90-line bring-up collapses; viewport seeding (hash → query → cached → IP) rides `mapOptions`; the load handler splits along the facade's seams (async `registerOverlays` = sprites → install → style-dependent re-establishment; `onFirstLoad` = spiderfy, interactions, deep-link pan); `applyBasemap` becomes unspiderfy + `handle.setStyle`. **The `CUSTOM_SOURCE_IDS`/`CUSTOM_LAYER_IDS` exports are deleted** — the hand-maintained carry-lists (a standing drift hazard: forget one on a future layer and it silently vanished on swap) are no longer needed.

Net: every map in the app now boots through one foundation; the dual style-swap system is gone.

## Test plan
- [x] `pnpm run format:fix` / `check` / `lint` clean per commit, **572/572** unit tests
- [x] SSR smoke on a fresh dev server: /map, /communities/map, /add-location all 200 (note: a long-running Vite server needs a restart after the v6 dep change — stale optimize cache 500s)
- [ ] CI — e2e (hermetic fixtures) covers /map boot, pins, search, `?outdated`
- [ ] Manual browser QA (the deliberate focus): **judge the swap blink** on /map with the full dataset across all five basemaps (incl. OSM raster's synchronous path); communities-map swap + popups; add-location marker + geolocate + theme toggle; merchant hero (attribution stays collapsed, theme swap). If the blink reads worse than expected, the agreed fallback is an optional page-supplied carry hook on `setStyle` — one machine either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more flexible map styling, including custom styles, theme-specific styles, and runtime style switching.
  - Added optional navigation and geolocation controls.
  - Improved support for asynchronous map overlays and style loading.
  - Map handles now expose additional controls for advanced integrations.

- **Bug Fixes**
  - Prevented overlapping theme changes while a previous style is still loading.
  - Improved map initialization, readiness, cancellation, and cleanup behavior.
  - Preserved markers and map overlays when switching styles.
  - Added clearer handling for unsupported WebGL environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->