### PR TITLE
feat(map): add ?issues worklist filter #921

### DIFF
--- a/src/lib/map/visiblePlaces.test.ts
+++ b/src/lib/map/visiblePlaces.test.ts
@@ -38,6 +38,8 @@ const base = {
 	recency: null,
 	recencyReady: true,
 	boostsOnly: false,
+	issuesOnly: false,
+	issuesReady: true,
 };
 
 describe("selectVisiblePlaces", () => {
@@ -134,6 +136,33 @@ describe("selectVisiblePlaces", () => {
 		expect(r.selection[0].boosted_until).toBeTruthy();
 	});
 
+	it("narrows to places with derived issues when asked and ready", () => {
+		// Corpus issue rows: two outdated, one never verified, one missing
+		// its icon (also outdated) — the deleted row never counts.
+		const r = selectVisiblePlaces({
+			...base,
+			places: corpus(),
+			issuesOnly: true,
+		});
+		expect(r.selection.length).toBe(4);
+		expect(r.selection.some((p) => p.verified_at === undefined)).toBe(true);
+		// Chip counts describe the issue set, not the full corpus — selecting
+		// a chip inside the worklist must show exactly its count.
+		expect(r.counts.all).toBe(4);
+	});
+
+	it("keeps the issues filter inert until the dates are ready", () => {
+		// Bulk rows before enrichment would ALL classify as not_verified;
+		// the gate keeps the world visible instead.
+		const r = selectVisiblePlaces({
+			...base,
+			places: corpus(),
+			issuesOnly: true,
+			issuesReady: false,
+		});
+		expect(r.selection.length).toBe(7);
+	});
+
 	it("composes boosts after category (empty intersections are honest)", () => {
 		const r = selectVisiblePlaces({
 			...base,
@@ -169,6 +198,12 @@ describe("computeVisibleSignature", () => {
 		).not.toBe(sig);
 		expect(
 			computeVisibleSignature({ ...inputs, boostsOnly: true }, 7, ""),
+		).not.toBe(sig);
+		expect(
+			computeVisibleSignature({ ...inputs, issuesOnly: true }, 7, ""),
+		).not.toBe(sig);
+		expect(
+			computeVisibleSignature({ ...inputs, issuesReady: false }, 7, ""),
 		).not.toBe(sig);
 		expect(
 			computeVisibleSignature({ ...inputs, mode: "search" }, 7, "1,2"),

--- a/src/lib/map/visiblePlaces.ts
+++ b/src/lib/map/visiblePlaces.ts
@@ -6,6 +6,7 @@ import {
 	placeMatchesCategory,
 } from "$lib/categoryMapping";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
+import { placeHasIssues } from "$lib/placeIssues";
 import { places } from "$lib/store";
 import type { Place } from "$lib/types";
 import { isBoosted } from "$lib/utils";
@@ -33,6 +34,15 @@ export type VisibleSelectionInputs = {
 	// Callers resolve their own boost policy before calling (markers exempt
 	// search mode; the nearby list always filters).
 	boostsOnly: boolean;
+	// The ?issues worklist mode: narrow to places with at least one derived
+	// issue (see $lib/placeIssues). Applied pre-category so chip counts
+	// describe the issue set. Callers resolve search exemption like boosts.
+	issuesOnly: boolean;
+	// Same readiness contract as recencyReady: issue derivation needs
+	// verified_at, so bulk-feed consumers gate on $verifiedDatesLoaded and
+	// the filter stays inert (rather than flagging every row as
+	// not_verified) until enrichment lands.
+	issuesReady: boolean;
 };
 
 export type VisibleSelection = {
@@ -54,9 +64,12 @@ export function selectVisiblePlaces(
 	inputs: VisibleSelectionInputs,
 ): VisibleSelection {
 	const live = inputs.places.filter((p) => !p.deleted_at);
-	const preCategory = inputs.recencyReady
+	let preCategory = inputs.recencyReady
 		? filterPlacesByRecency(live, inputs.recency)
 		: live;
+	if (inputs.issuesOnly && inputs.issuesReady) {
+		preCategory = preCategory.filter((p) => placeHasIssues(p));
+	}
 	const counts = countMerchantsByCategory(preCategory);
 
 	const shouldReset =
@@ -92,6 +105,8 @@ export function computeVisibleSignature(
 		inputs.recency ?? "any",
 		inputs.recencyReady,
 		inputs.boostsOnly,
+		inputs.issuesOnly,
+		inputs.issuesReady,
 		revision,
 		searchResultIds,
 	].join("|");

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -218,6 +218,8 @@ function createMerchantListStore() {
 				recency: verifiedWithinYears,
 				recencyReady: verifiedWithinYears == null || get(verifiedDatesLoaded),
 				boostsOnly: false,
+				issuesOnly: false,
+				issuesReady: true,
 			});
 
 			const sorted = sortMerchants(
@@ -279,6 +281,8 @@ function createMerchantListStore() {
 						recency: verifiedWithinYears,
 						recencyReady: true,
 						boostsOnly: false,
+						issuesOnly: false,
+						issuesReady: true,
 					});
 
 				// Check if we should hide results (too many at low zoom)
@@ -458,6 +462,8 @@ function createMerchantListStore() {
 				recency: verifiedWithinYears,
 				recencyReady: true,
 				boostsOnly: false,
+				issuesOnly: false,
+				issuesReady: true,
 			});
 			update((state) => ({
 				...resetCategoryState(state),
@@ -557,6 +563,8 @@ function createMerchantListStore() {
 						recency: years,
 						recencyReady: true,
 						boostsOnly: false,
+						issuesOnly: false,
+						issuesReady: true,
 					});
 					return {
 						...state,

--- a/src/lib/placeIssues.test.ts
+++ b/src/lib/placeIssues.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { derivePlaceIssues, placeHasIssues } from "./placeIssues";
+
+// Fixed clock so the day-boundary assertions can't flake.
+const NOW = Date.UTC(2026, 0, 1);
+const DAY_MS = 86_400_000;
+const daysAgo = (days: number) => new Date(NOW - days * DAY_MS).toISOString();
+
+describe("derivePlaceIssues", () => {
+	it("returns nothing for a fresh, iconed place", () => {
+		expect(
+			derivePlaceIssues({ verified_at: daysAgo(30), icon: "restaurant" }, NOW),
+		).toEqual([]);
+	});
+
+	it("flags a place without a verification date as not_verified", () => {
+		expect(derivePlaceIssues({ icon: "restaurant" }, NOW)).toEqual([
+			"not_verified",
+		]);
+	});
+
+	it("treats an unparseable date as not_verified", () => {
+		expect(
+			derivePlaceIssues({ verified_at: "not-a-date", icon: "restaurant" }, NOW),
+		).toEqual(["not_verified"]);
+	});
+
+	// The exact boundaries the API oracle confirmed (DE + CH, all codes
+	// matching): outdated strictly past 365 days, outdated_soon strictly
+	// past 275, both day-floored.
+	it("day-floors the outdated boundary at strictly more than 365 days", () => {
+		expect(
+			derivePlaceIssues({ verified_at: daysAgo(366), icon: "cafe" }, NOW),
+		).toEqual(["outdated"]);
+		expect(
+			derivePlaceIssues({ verified_at: daysAgo(365), icon: "cafe" }, NOW),
+		).toEqual(["outdated_soon"]);
+		// 365 days plus a few hours still floors to 365 — not yet outdated.
+		expect(
+			derivePlaceIssues(
+				{
+					verified_at: new Date(NOW - 365.5 * DAY_MS).toISOString(),
+					icon: "cafe",
+				},
+				NOW,
+			),
+		).toEqual(["outdated_soon"]);
+	});
+
+	it("day-floors the outdated_soon boundary at strictly more than 275 days", () => {
+		expect(
+			derivePlaceIssues({ verified_at: daysAgo(276), icon: "cafe" }, NOW),
+		).toEqual(["outdated_soon"]);
+		expect(
+			derivePlaceIssues({ verified_at: daysAgo(275), icon: "cafe" }, NOW),
+		).toEqual([]);
+	});
+
+	it("flags a missing or placeholder icon", () => {
+		expect(derivePlaceIssues({ verified_at: daysAgo(30) }, NOW)).toEqual([
+			"missing_icon",
+		]);
+		expect(
+			derivePlaceIssues({ verified_at: daysAgo(30), icon: "" }, NOW),
+		).toEqual(["missing_icon"]);
+		expect(
+			derivePlaceIssues(
+				{ verified_at: daysAgo(30), icon: "question_mark" },
+				NOW,
+			),
+		).toEqual(["missing_icon"]);
+	});
+
+	it("combines independent codes", () => {
+		expect(
+			derivePlaceIssues(
+				{ verified_at: daysAgo(400), icon: "question_mark" },
+				NOW,
+			),
+		).toEqual(["outdated", "missing_icon"]);
+		expect(derivePlaceIssues({}, NOW)).toEqual([
+			"not_verified",
+			"missing_icon",
+		]);
+	});
+
+	it("never flags a future verification date as outdated", () => {
+		expect(
+			derivePlaceIssues({ verified_at: daysAgo(-10), icon: "cafe" }, NOW),
+		).toEqual([]);
+	});
+});
+
+describe("placeHasIssues", () => {
+	it("mirrors derivePlaceIssues non-emptiness", () => {
+		expect(
+			placeHasIssues({ verified_at: daysAgo(30), icon: "restaurant" }, NOW),
+		).toBe(false);
+		expect(
+			placeHasIssues({ verified_at: daysAgo(400), icon: "cafe" }, NOW),
+		).toBe(true);
+		expect(placeHasIssues({ icon: "cafe" }, NOW)).toBe(true);
+	});
+});

--- a/src/lib/placeIssues.ts
+++ b/src/lib/placeIssues.ts
@@ -23,7 +23,8 @@ const DAY_MS = 86_400_000;
 // Strictly more than a year since verification. Day-floored: a place at
 // exactly 365 days is not yet outdated, matching the server boundary.
 const OUTDATED_AFTER_DAYS = 365;
-// Within 90 days of crossing the outdated boundary.
+// Strictly more than 275 days — day-floored ages 276..365, the last 90
+// days before crossing the outdated boundary.
 const OUTDATED_SOON_AFTER_DAYS = 275;
 
 export function derivePlaceIssues(

--- a/src/lib/placeIssues.ts
+++ b/src/lib/placeIssues.ts
@@ -1,0 +1,57 @@
+import type { Place } from "$lib/types";
+
+// Client-side mirror of btcmap-api's per-place issue generation, for the
+// /map?issues worklist. The server only serves issues per-area (v4
+// place-issues requires area_id, and rows carry OSM identity rather than a
+// place id), so world-scale issue detection derives the same codes from
+// fields the client already syncs: verified_at (lazy-enriched) and icon.
+//
+// Boundaries are calibrated against the API's own per-area output
+// (2026-08: DE and CH match exactly, all four codes — see #921). If counts
+// ever drift from area pages, recalibrate here rather than patching call
+// sites. Tag-lint codes (invalid_tag_value etc.) are server-only knowledge
+// and deliberately out of scope; none appeared in any sampled area. When
+// btcmap-api grows an `issues` field on /v4/places, this module is the
+// single swap point: keep the interface, replace the derivation.
+export type DerivedIssueCode =
+	| "not_verified"
+	| "outdated"
+	| "outdated_soon"
+	| "missing_icon";
+
+const DAY_MS = 86_400_000;
+// Strictly more than a year since verification. Day-floored: a place at
+// exactly 365 days is not yet outdated, matching the server boundary.
+const OUTDATED_AFTER_DAYS = 365;
+// Within 90 days of crossing the outdated boundary.
+const OUTDATED_SOON_AFTER_DAYS = 275;
+
+export function derivePlaceIssues(
+	place: Partial<Pick<Place, "verified_at" | "icon">>,
+	now: number = Date.now(),
+): DerivedIssueCode[] {
+	const codes: DerivedIssueCode[] = [];
+	const parsed = place.verified_at ? Date.parse(place.verified_at) : Number.NaN;
+	if (Number.isNaN(parsed)) {
+		codes.push("not_verified");
+	} else {
+		const ageDays = Math.floor((now - parsed) / DAY_MS);
+		if (ageDays > OUTDATED_AFTER_DAYS) {
+			codes.push("outdated");
+		} else if (ageDays > OUTDATED_SOON_AFTER_DAYS) {
+			codes.push("outdated_soon");
+		}
+	}
+	// The pipeline's placeholder icon is what the server flags as missing.
+	if (!place.icon || place.icon === "question_mark") {
+		codes.push("missing_icon");
+	}
+	return codes;
+}
+
+export function placeHasIssues(
+	place: Partial<Pick<Place, "verified_at" | "icon">>,
+	now?: number,
+): boolean {
+	return derivePlaceIssues(place, now).length > 0;
+}

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -71,6 +71,7 @@ import {
 } from "$lib/merchantDrawerHash";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import { merchantList } from "$lib/merchantListStore";
+import { placeHasIssues } from "$lib/placeIssues";
 import { savedPlaceIds } from "$lib/session";
 import {
 	places,
@@ -121,6 +122,14 @@ const outdatedOnly =
 if (outdatedOnly) {
 	merchantList.setVerifiedFilter("outdated", { persist: false });
 }
+
+// "Issues only" deep link (?issues, presence alone counts, like ?outdated):
+// narrow the map to places with at least one derived issue — the
+// contributor worklist view (#921). Session-only and page-scoped like
+// ?boosts: no persisted state, no store mode; the filter engages once the
+// verified_at enrichment lands.
+const issuesOnly =
+	browser && new URLSearchParams(window.location.search).has("issues");
 
 let mapContainer: HTMLDivElement;
 let map: MapLibreMap | undefined;
@@ -373,10 +382,12 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 
 	const bounds = map.getBounds();
 	const center = map.getCenter();
-	// Boosted-only: the bulk $places feed already holds the tiny boosted set at
-	// every zoom, and the radius API (api-with-limit) has no boost filter, so
-	// force the local path so the list/count stay in sync with the filtered map.
-	const behavior = boostsOnly ? "local-markers" : getZoomBehavior(currentZoom);
+	// Boosted-only / issues-only: the bulk $places feed already holds the
+	// full filtered set at every zoom, and the radius API (api-with-limit)
+	// can filter by neither boost nor issue state, so force the local path
+	// so the list/count stay in sync with the filtered map.
+	const behavior =
+		boostsOnly || issuesOnly ? "local-markers" : getZoomBehavior(currentZoom);
 	const listOpen = get(merchantList).isOpen;
 	const allowHeavyFetch = opts?.force || listOpen;
 
@@ -394,7 +405,13 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 					p.lon >= buffered.west &&
 					p.lon <= buffered.east,
 			);
-			const listed = boostsOnly ? visible.filter(isBoosted) : visible;
+			let listed = boostsOnly ? visible.filter(isBoosted) : visible;
+			// Same readiness gate as the marker pipeline: before the
+			// verified_at enrichment lands, the list stays unfiltered
+			// rather than flagging every bulk row as not_verified.
+			if (issuesOnly && get(verifiedDatesLoaded)) {
+				listed = listed.filter((p) => placeHasIssues(p));
+			}
 			merchantList.setMerchants(listed, center.lat, center.lng);
 			if (listOpen || currentZoom >= LABEL_VISIBLE_ZOOM) {
 				if (allowHeavyFetch || currentZoom >= LABEL_VISIBLE_ZOOM) {
@@ -733,6 +750,12 @@ $: if (map && styleLoaded && $places) {
 		// Markers exempt search mode from the boosted-only narrowing: an
 		// explicit query should surface all matches on the map.
 		boostsOnly: boostsOnly && !inSearch,
+		// Same search exemption for the issues worklist: a searched-for
+		// place must appear even when it has no issues.
+		issuesOnly: issuesOnly && !inSearch,
+		// Trivially ready when the mode is off or exempted, so the dates
+		// landing can't change the signature outside issues mode.
+		issuesReady: !issuesOnly || inSearch || $verifiedDatesLoaded,
 	};
 	const renderSig = [
 		computeVisibleSignature(
@@ -778,9 +801,10 @@ $: if (
 }
 
 // A returning user with a persisted window (or an ?outdated deep link — both
-// land in the store's verifiedWithinYears): load the dates once the bulk
-// places are in (not during map setup, which can win the race and enrich an
-// empty store), so the map + list arrive filtered without a manual toggle.
+// land in the store's verifiedWithinYears — or an ?issues deep link): load
+// the dates once the bulk places are in (not during map setup, which can win
+// the race and enrich an empty store), so the map + list arrive filtered
+// without a manual toggle.
 let didInitialVerifiedLoad = false;
 $: if (
 	browser &&
@@ -788,7 +812,7 @@ $: if (
 	styleLoaded &&
 	$places.length > 0 &&
 	!didInitialVerifiedLoad &&
-	$merchantList.verifiedWithinYears != null
+	($merchantList.verifiedWithinYears != null || issuesOnly)
 ) {
 	didInitialVerifiedLoad = true;
 	void ensureVerifiedDates().then(() => updateMerchantList({ force: true }));

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -365,6 +365,8 @@ $: filteredSearchResults = selectVisiblePlaces({
 	recency: verifiedWithinYears,
 	recencyReady: true,
 	boostsOnly: false,
+	issuesOnly: false,
+	issuesReady: true,
 }).selection;
 
 // Helper function to check if a category has matching merchants

--- a/tests/map-issues-filter.spec.ts
+++ b/tests/map-issues-filter.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { MARKER_LOAD_TIMEOUT, waitForMarkersToLoad } from './helpers';
+
+// Regression guard for the /map?issues deep link (the contributor worklist
+// view, #921): places with at least one derived issue — never verified,
+// verified over a year ago, approaching that boundary, or missing an icon.
+// Mirrors the ?outdated spec's structure: the filter engages only after the
+// one-time verified_at enrichment fetch lands.
+test.describe('Map ?issues filter', () => {
+	const placesCount = (page: import('@playwright/test').Page) =>
+		page.evaluate(
+			() => (window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount ?? 0
+		);
+
+	test('?issues narrows the rendered places once verified dates load', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		// Baseline: unfiltered world view.
+		await page.goto('/map', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		const baseline = await placesCount(page);
+		expect(baseline).toBeGreaterThan(0);
+
+		// Deep link: poll until the count settles below the baseline (the
+		// issue set is a strict subset — roughly half of all places at the
+		// time of writing, so 95% leaves ample headroom for data drift).
+		await page.goto('/map?issues', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => placesCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeLessThan(baseline * 0.95);
+		expect(await placesCount(page)).toBeGreaterThan(0);
+
+		// Deep-link only, session-only: nothing persisted, and the stored
+		// verified-filter preference stays untouched.
+		const stored = await page.evaluate(() =>
+			localStorage.getItem('btcmap-next-verified-filter')
+		);
+		expect(stored).toBeNull();
+	});
+});


### PR DESCRIPTION
First step towards "issues on map"


Refs #921 — step 1 of the ladder sketched there (mode + classifier; per-code chips and drawer fix-hints are follow-up PRs).

## What

`/map?issues` narrows the map to places with at least one **derived issue** — the contributor worklist view:

- `not_verified` — no `verified_at` (or unparseable)
- `outdated` — verified strictly more than 365 days ago
- `outdated_soon` — 275–365 days (within 90 days of the boundary)
- `missing_icon` — no icon or the `question_mark` placeholder

Session-only and page-scoped like `?boosts`: nothing persisted, no store mode, presence of the param alone counts (like `?outdated`).

## Why client-side derivation

`/v4/place-issues` requires `area_id` (400 without) and its rows carry only OSM identity — no place id, no coordinates — so a world-scale issues view can't be fed from it. The spike on #921 showed ~100% of real issue volume decomposes into the four codes above, all derivable from fields the client already syncs (`verified_at` via the existing lazy enrichment, `icon` from the bulk feed).

**Calibration:** boundaries were fitted against the API's own per-area output and match exactly, all four codes:

| | not_verified | outdated | outdated_soon | missing_icon |
|---|---|---|---|---|
| DE — API / derived | 28 / **28** | 397 / **397** | 51 / **51** | 2 / **2** |
| CH — API / derived | 1 / **1** | 426 / **426** | 72 / **72** | 0 / **0** |

`src/lib/placeIssues.ts` is the single swap point if btcmap-api later exposes an `issues` field on `/v4/places` (which would also bring the server-only tag-lint codes — none appeared in any sampled area).

## How

- **Pipeline** (`visiblePlaces.ts`): new `issuesOnly`/`issuesReady` inputs. Applied **pre-category** so chip counts describe the issue set (a chip's count is exactly what selecting it shows). Same readiness contract as `recencyReady`: inert until the `verified_at` enrichment lands, so bulk rows aren't all flagged `not_verified` on first paint.
- **Page**: `?issues` triggers the one-time `ensureVerifiedDates()` (same reactive as `?outdated`); search mode is exempted like boosts (a searched-for place must appear even without issues); the list behavior forces `local-markers` like boosts (the radius API can't filter by issue state), keeping list/count in sync with the pins.
- Composes with the verified-recency filter and category chips (plain AND).

## Verified

- Unit: classifier boundary tests (day-floor semantics at 365/275, unparseable dates, icon variants, code combinations) + pipeline narrowing/readiness/signature tests — 584 pass.
- e2e: `tests/map-issues-filter.spec.ts` guards the deep link (mirrors the `?outdated` spec).
- Live: `/map?issues` renders 14,954 of 29,105 places (51%); an independent offline derivation from `/v4/places` gives 14,945 — data drift only. Nothing persisted to localStorage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an issues-only map view accessible through the `?issues` link.
  * Identifies places with unverified, outdated, soon-to-expire, or missing-icon information.
  * Filters map markers and nearby lists after issue data is ready.
  * Search results remain unaffected by issue filtering.

* **Bug Fixes**
  * Visibility updates now respond correctly when issue status changes.
  * Issue filtering does not alter saved verified-filter preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->