### PR TITLE
chore(deps): remove unused svelte-preprocess #1202

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
 		"postcss": "^8.5.19",
 		"svelte": "^4.2.20",
 		"svelte-check": "^4.7.2",
-		"svelte-preprocess": "^6.0.3",
 		"tailwindcss": "^4.3.0",
 		"typescript": "^6.0.3",
 		"vite": "^5.4.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,9 +141,6 @@ importers:
       svelte-check:
         specifier: ^4.7.2
         version: 4.7.4(picomatch@4.0.5)(svelte@4.2.20)(typescript@6.0.3)
-      svelte-preprocess:
-        specifier: ^6.0.3
-        version: 6.0.5(postcss@8.5.25)(svelte@4.2.20)(typescript@6.0.3)
       tailwindcss:
         specifier: ^4.3.0
         version: 4.3.3
@@ -2120,43 +2117,6 @@ packages:
     peerDependencies:
       svelte: '>= 4.2.12'
 
-  svelte-preprocess@6.0.5:
-    resolution: {integrity: sha512-sgwew5yV/2eMeQobIWgAxCNarKwiTUDIc3siAUbq3sp0G6ONtzk0W+wJihMdqjbYb3iGU3ubpGv0usnnuXT3qg==}
-    engines: {node: '>= 18.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.10.2
-      coffeescript: ^2.5.1
-      less: ^3.11.3 || ^4.0.0
-      postcss: ^7 || ^8
-      postcss-load-config: '>=3'
-      pug: ^3.0.0
-      sass: ^1.26.8
-      stylus: '>=0.55'
-      sugarss: ^2.0.0 || ^3.0.0 || ^4.0.0
-      svelte: ^4.0.0 || ^5.0.0-next.100 || ^5.0.0
-      typescript: ^5.0.0 || ^6.0.0
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      coffeescript:
-        optional: true
-      less:
-        optional: true
-      postcss:
-        optional: true
-      postcss-load-config:
-        optional: true
-      pug:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      typescript:
-        optional: true
-
   svelte-time@1.1.0:
     resolution: {integrity: sha512-QmjmlS62+9t+no/xHOEYz1Oics+VUu1lk3RZbnnOGmqK2rCRUedktLhIoB0/3GSGg98+UJb4Pe4h7El+OHquYg==}
 
@@ -4102,13 +4062,6 @@ snapshots:
   svelte-outclick@3.7.1(svelte@4.2.20):
     dependencies:
       svelte: 4.2.20
-
-  svelte-preprocess@6.0.5(postcss@8.5.25)(svelte@4.2.20)(typescript@6.0.3):
-    dependencies:
-      svelte: 4.2.20
-    optionalDependencies:
-      postcss: 8.5.25
-      typescript: 6.0.3
 
   svelte-time@1.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

Removes `svelte-preprocess` from devDependencies — it is installed but completely unused.

**Evidence:**
- `svelte.config.js` uses `vitePreprocess` from `@sveltejs/vite-plugin-svelte`, not `svelte-preprocess`
- Zero references anywhere in the repo outside `package.json` and the lockfile (checked all source, config, and docs)
- No transitive consumers: the lockfile shows it only as a root devDependency — no other package depends on it

This is Stage 0 of the Svelte 5 migration plan (#1201). Landing it first pre-shrinks the lockfile diff for the atomic Svelte 5 + TanStack v9 PR (#1203). It also removes a package whose Svelte-5 peer story we'd otherwise have to evaluate for nothing.

## Verification

- `pnpm run check` — svelte-check over all 1020 files, 0 errors (this runs the real preprocess pipeline over every component, proving nothing resolved the package implicitly)
- `pnpm run lint`, `pnpm run format:fix` — clean
- `pnpm run test --run` — 573/573 pass
- `pnpm run build` — production build succeeds

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->