### PR TITLE
chore(deps): bump svelte-outclick 3 to 4 #1205

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"opening_hours": "^3.13.0",
 		"qrcode": "^1.5.4",
 		"svelte-i18n": "^4.0.1",
-		"svelte-outclick": "^3.7.1",
+		"svelte-outclick": "^4.2.0",
 		"svelte-time": "^1.1.0",
 		"svg-captcha": "^1.4.0",
 		"tippy.js": "^6.3.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1(svelte@5.56.8)
       svelte-outclick:
-        specifier: ^3.7.1
-        version: 3.7.1(svelte@5.56.8)
+        specifier: ^4.2.0
+        version: 4.2.0(svelte@5.56.8)
       svelte-time:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1939,10 +1939,10 @@ packages:
     peerDependencies:
       svelte: ^3 || ^4 || ^5
 
-  svelte-outclick@3.7.1:
-    resolution: {integrity: sha512-+TmDaG8yX4cIhmvflujvgV+NbFHxkUdYfeSczp67UJvkkMO9m6x1ugBQSDnjHD6J1z4tE5alkp5pC5LpoNqOKg==}
+  svelte-outclick@4.2.0:
+    resolution: {integrity: sha512-rQ5u8mSdAAQVfDuxLKMAfoRfwpji1HJksGqiyx8vsjn0z41/GB0Qdqn75sII9WefdwhtjuC6wr7qjFYEqQ/UQw==}
     peerDependencies:
-      svelte: '>= 4.2.12'
+      svelte: '>= 5'
 
   svelte-time@1.1.0:
     resolution: {integrity: sha512-QmjmlS62+9t+no/xHOEYz1Oics+VUu1lk3RZbnnOGmqK2rCRUedktLhIoB0/3GSGg98+UJb4Pe4h7El+OHquYg==}
@@ -3716,7 +3716,7 @@ snapshots:
       svelte: 5.56.8
       tiny-glob: 0.2.9
 
-  svelte-outclick@3.7.1(svelte@5.56.8):
+  svelte-outclick@4.2.0(svelte@5.56.8):
     dependencies:
       svelte: 5.56.8
 

--- a/src/components/Boost.svelte
+++ b/src/components/Boost.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { fly } from "svelte/transition";
-import OutClick from "svelte-outclick";
+import { OutClick } from "svelte-outclick";
 
 import BoostContent from "$components/BoostContent.svelte";
 import CloseButton from "$components/CloseButton.svelte";
@@ -29,7 +29,7 @@ const handleBoostComplete = () => {
 </script>
 
 {#if $boost}
-	<OutClick on:outclick={handleOutClick}>
+	<OutClick onOutClick={handleOutClick}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
 			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:w-[430px] dark:border-white/95 dark:bg-dark"

--- a/src/components/ShowTags.svelte
+++ b/src/components/ShowTags.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { fly } from "svelte/transition";
-import OutClick from "svelte-outclick";
+import { OutClick } from "svelte-outclick";
 
 import CloseButton from "$components/CloseButton.svelte";
 import { showTags } from "$lib/store";
@@ -9,7 +9,7 @@ const closeModal = () => ($showTags = undefined);
 </script>
 
 {#if $showTags}
-	<OutClick excludeQuerySelectorAll="#show-tags" on:outclick={closeModal}>
+	<OutClick excludeQuerySelectorAll="#show-tags" onOutClick={closeModal}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
 			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:h-[400px] md:w-[430px] dark:border-white/95 dark:bg-dark"

--- a/src/components/TaggingIssues.svelte
+++ b/src/components/TaggingIssues.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { fly } from "svelte/transition";
 import { _ } from "svelte-i18n";
-import OutClick from "svelte-outclick";
+import { OutClick } from "svelte-outclick";
 
 import CloseButton from "$components/CloseButton.svelte";
 import Icon from "$components/Icon.svelte";
@@ -14,7 +14,7 @@ const closeModal = () => ($taggingIssues = undefined);
 </script>
 
 {#if $taggingIssues}
-	<OutClick excludeQuerySelectorAll="#tagging-issues" on:outclick={closeModal}>
+	<OutClick excludeQuerySelectorAll="#tagging-issues" onOutClick={closeModal}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
 			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:h-[400px] md:w-[430px] dark:border-white/95 dark:bg-dark"

--- a/src/components/layout/NavDropdownDesktop.svelte
+++ b/src/components/layout/NavDropdownDesktop.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import OutClick from "svelte-outclick";
+import { OutClick } from "svelte-outclick";
 
 import Icon from "$components/Icon.svelte";
 import type { DropdownLink } from "$lib/types";
@@ -35,7 +35,7 @@ afterNavigate(() => {
 	{#if show}
 		<OutClick
 			excludeQuerySelectorAll={`#dropdown-${title.toLowerCase()}`}
-			on:outclick={() => (show = false)}
+			onOutClick={() => (show = false)}
 		>
 			<div class="absolute top-8 right-0 z-50 w-[185px] rounded-2xl shadow-lg">
 				{#each links as link, i (link.url)}

--- a/src/components/layout/NavDropdownMobile.svelte
+++ b/src/components/layout/NavDropdownMobile.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import OutClick from "svelte-outclick";
+import { OutClick } from "svelte-outclick";
 
 import Icon from "$components/Icon.svelte";
 import IconMobileNav from "$lib/icons/IconMobileNav.svelte";
@@ -36,7 +36,7 @@ $: displayIcon = (show ? `${icon}-highlight` : icon) as MobileNavIconName;
 {#if show}
 	<OutClick
 		excludeQuerySelectorAll={`#dropdown-${title.toLowerCase()}-mobile`}
-		on:outclick={() => (show = false)}
+		onOutClick={() => (show = false)}
 	>
 		<div class="ml-7 space-y-2">
 			{#each links as link (link.url)}

--- a/src/components/layout/UserMenu.svelte
+++ b/src/components/layout/UserMenu.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import OutClick from "svelte-outclick";
+import { OutClick } from "svelte-outclick";
 
 import BackupModal from "$components/auth/BackupModal.svelte";
 import Icon from "$components/Icon.svelte";
@@ -83,7 +83,7 @@ afterNavigate(() => {
 	{#if open}
 		<OutClick
 			excludeQuerySelectorAll={`#${triggerId}`}
-			on:outclick={() => (open = false)}
+			onOutClick={() => (open = false)}
 		>
 			<div
 				class="absolute right-0 top-full z-50 mt-2 w-48 rounded-lg border border-gray-300 bg-white py-1 shadow-lg dark:border-white/20 dark:bg-dark"

--- a/src/routes/merchant/[id]/components/CommentAdd.svelte
+++ b/src/routes/merchant/[id]/components/CommentAdd.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import axios from "axios";
 import { fly } from "svelte/transition";
-import OutClick from "svelte-outclick";
+import { OutClick } from "svelte-outclick";
 
 import CloseButton from "$components/CloseButton.svelte";
 import Icon from "$components/Icon.svelte";
@@ -86,7 +86,7 @@ const handleStatusCheckError = (error: unknown) => {
 </script>
 
 {#if open}
-	<OutClick excludeQuerySelectorAll="#boost-button" on:outclick={handleOutClick}>
+	<OutClick excludeQuerySelectorAll="#boost-button" onOutClick={handleOutClick}>
 		<div
 			transition:fly={{ y: 200, duration: 300 }}
 			class="center-fixed z-[2000] max-h-[90dvh] w-[90vw] overflow-auto rounded-xl border border-gray-300 bg-white p-6 text-left shadow-2xl md:w-[430px] dark:border-white/95 dark:bg-dark"


### PR DESCRIPTION
## Summary

`svelte-outclick` ^3.7.1 → **^4.2.0** — the runes-native line (peer `svelte >= 5`, unblocked by #1226). Mechanical migration across all 7 consumers (Boost, NavDropdownDesktop, NavDropdownMobile, UserMenu, ShowTags, TaggingIssues, CommentAdd):

- default import → named `import { OutClick }`
- `on:outclick={...}` → `onOutClick={...}` prop
- `excludeQuerySelectorAll` unchanged; no `e.detail` usage existed in the codebase

## Verified

- `svelte-check` 0/0, Biome clean, 584/584 tests, prod build green
- Prod-build browser QA of the dropdown pattern: opens on trigger, closes on an outside `pointerdown`+`pointerup` sequence, and pointer events on the excluded trigger element do **not** close it via outclick (no double-fire) — v4's full-click semantics match v3 behavior
- Modal pattern (ShowTags/TaggingIssues/CommentAdd) uses identical mechanics; spot-checked on the deploy preview

Closes #1205. Part of #1201's dependency ladder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated outside-click handling across menus, dropdowns, tagging, comments, and other interactive components to maintain expected closing behavior.
  * Improved compatibility with the latest outside-click functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->