### PR TITLE
refactor(app): migrate $app/stores to $app/state #1207

### DIFF
--- a/src/components/area/AreaPage.svelte
+++ b/src/components/area/AreaPage.svelte
@@ -3,13 +3,14 @@ import { _ } from "svelte-i18n";
 
 import { browser } from "$app/environment";
 import { goto } from "$app/navigation";
-import { page } from "$app/stores";
+import { page } from "$app/state";
 
 export let type: "country" | "community";
 export let data: AreaPageProps;
 
 import type { GeoJSON } from "geojson";
 import { onDestroy, onMount } from "svelte";
+import { toStore } from "svelte/store";
 
 import AreaActivity from "$components/area/AreaActivity.svelte";
 import AreaHeader from "$components/area/AreaHeader.svelte";
@@ -50,10 +51,14 @@ type Section = (typeof SECTIONS)[number];
 
 let scrolled = false;
 
-$: activeSection = (SECTIONS as readonly string[]).includes(
-	$page.params.section ?? "",
-)
-	? ($page.params.section as Section)
+// toStore bridges $app/state's rune-backed page into a store this
+// legacy-mode component's $: statement can actually track — a bare
+// page.params read inside $: would run once and tab switching (goto to a
+// sibling section) would stop updating activeSection.
+const pageSection = toStore(() => page.params.section);
+
+$: activeSection = (SECTIONS as readonly string[]).includes($pageSection ?? "")
+	? ($pageSection as Section)
 	: ("merchants" as Section);
 
 const handleSectionChange = (section: Section) => {

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -5,10 +5,10 @@ import Icon from "$components/Icon.svelte";
 import { _ } from "$lib/i18n";
 
 import { resolve } from "$app/paths";
-import { page } from "$app/stores";
+import { page } from "$app/state";
 
 onMount(() => {
-	if ($page.status === 500 && !navigator.onLine) {
+	if (page.status === 500 && !navigator.onLine) {
 		location.reload();
 	}
 });
@@ -35,7 +35,7 @@ onMount(() => {
 				class="text-xl font-semibold text-link transition-colors hover:text-hover"
 				><Icon type="fa" icon="house" w="16" h="16" class="mr-2 inline" /> {$_('errorPage.home')}</a
 			>
-			<h1 class="text-4xl md:text-5xl dark:text-white">{$page.status}: {$page.error?.message}</h1>
+			<h1 class="text-4xl md:text-5xl dark:text-white">{page.status}: {page.error?.message}</h1>
 			<h2 class="text-xl font-semibold text-primary dark:text-white">
 				{$_('errorPage.tryAgain')}
 			</h2>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,17 +25,21 @@ import { isLoading, locale } from "svelte-i18n";
 import Footer from "$components/layout/Footer.svelte";
 import { isSupportedLocale } from "$lib/i18n";
 
-import { page } from "$app/stores";
+import { afterNavigate } from "$app/navigation";
+import { page } from "$app/state";
 
 // Apply language from URL param site-wide (e.g. /map?language=bg for embedded maps).
 // On /communities/map, ?communityLang= filters communities; ?language= sets UI locale.
-$: if (browser) {
-	const langParam = $page.url.searchParams.get("language");
+// afterNavigate fires on mount and after every client-side navigation — the
+// same cadence the old `$: if (browser)` block with its $page store dep had
+// (a bare page.url read in a legacy $: would only ever run once).
+afterNavigate(() => {
+	const langParam = page.url.searchParams.get("language");
 	if (langParam && isSupportedLocale(langParam)) {
 		locale.set(langParam);
 		localStorage.setItem("language", langParam);
 	}
-}
+});
 
 // Update HTML lang attribute dynamically when locale changes
 $: if (browser && $locale) {

--- a/src/routes/communities/map/+page.svelte
+++ b/src/routes/communities/map/+page.svelte
@@ -39,7 +39,7 @@ import { areaIconSrc, errToast } from "$lib/utils";
 
 import { browser } from "$app/environment";
 import { resolve } from "$app/paths";
-import { page } from "$app/stores";
+import { page } from "$app/state";
 import MapControls from "../../map/components/MapControls.svelte";
 
 let mapLoading = 0;
@@ -56,9 +56,9 @@ let webglUnsupported = false;
 let communitiesLoaded = false;
 let destroyed = false;
 
-const communityQuery = $page.url.searchParams.get("community");
-const communityLang = $page.url.searchParams.get("communityLang");
-const organization = $page.url.searchParams.get("organization");
+const communityQuery = page.url.searchParams.get("community");
+const communityLang = page.url.searchParams.get("communityLang");
+const organization = page.url.searchParams.get("organization");
 
 $: $areaError && errToast($areaError);
 $: $reportError && errToast($reportError);

--- a/src/routes/leaderboard/+page.svelte
+++ b/src/routes/leaderboard/+page.svelte
@@ -20,7 +20,7 @@ import { debounce } from "$lib/utils";
 
 import type { PageData } from "./$types";
 import { goto } from "$app/navigation";
-import { page } from "$app/stores";
+import { page } from "$app/state";
 
 type TopEditorItem = {
 	id: number;
@@ -214,7 +214,7 @@ const searchDebounce = debounce((e) => handleKeyUp(e));
 
 const handlePeriodChange = async (event: Event) => {
 	const nextValue = (event.target as HTMLSelectElement).value as PeriodOption;
-	const search = new URLSearchParams($page.url.searchParams);
+	const search = new URLSearchParams(page.url.searchParams);
 	if (nextValue === DEFAULT_PERIOD) {
 		search.delete("period");
 	} else {


### PR DESCRIPTION
## Summary

Migrates all five `$app/stores` consumers to `$app/state` (#1207). The store flavor is deprecated since Kit 2.12; the state flavor is rune-backed — which is exactly why this wasn't a blind find-and-replace: **a bare `page.*` read inside a legacy-mode `$:` statement is not tracked and runs exactly once.** Each file got a per-site audit:

| File | Read context | Treatment |
|---|---|---|
| `communities/map/+page.svelte` | `const` snapshot reads at init | mechanical swap (same snapshot semantics) |
| `leaderboard/+page.svelte` | inside an event handler, runes-mode file | mechanical swap |
| `+error.svelte` | `onMount` + template | mechanical swap |
| `AreaPage.svelte` | **reactive `$:` driving section-tab switching** | `toStore(() => page.params.section)` — Svelte's official bridge gives the legacy `$:` a real store dependency; without it, tab navigation would silently stop updating `activeSection`. Full runes conversion is #1208 scope. |
| `+layout.svelte` | **`$: if (browser)` applying `?language=` on every nav** | `afterNavigate()` — fires on mount + every client-side navigation, the identical cadence the `$page` store dep provided; a bare read would have applied the language param only on initial load |

## Verified

- `svelte-check` 0/0, Biome clean, 584/584 tests, prod build green
- Deploy-preview QA (below): area section-tab switching stays reactive; `?language=` still applies

Closes #1207. Part of #1201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page-state handling across section navigation, error pages, community maps, and leaderboards.
  * Preserved active sections, query parameters, language settings, and leaderboard period changes during navigation.
  * Improved language synchronization when navigating between pages.
  * Maintained offline reload status and error-message display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->