### PR TITLE
refactor(issues-table): adopt shared search and pagination #1234

### DIFF
--- a/src/components/IssuesTable.svelte
+++ b/src/components/IssuesTable.svelte
@@ -9,6 +9,8 @@ import { _ } from "svelte-i18n";
 
 import Icon from "$components/Icon.svelte";
 import IssueCell from "$components/IssueCell.svelte";
+import LeaderboardPagination from "$components/leaderboard/LeaderboardPagination.svelte";
+import LeaderboardSearch from "$components/leaderboard/LeaderboardSearch.svelte";
 import type { BtcmapTableFeatures } from "$lib/tableFeatures";
 import { btcmapTableFeatures } from "$lib/tableFeatures";
 import { theme } from "$lib/theme";
@@ -44,7 +46,6 @@ type IssueCellId =
 const pageSizes = [10, 20, 30, 40, 50];
 
 let globalFilter = $state("");
-let searchInput: HTMLInputElement | undefined = $state();
 
 // Rows re-derive when the issues prop or the locale changes — the table
 // picks them up through its getter option. This replaces the old
@@ -142,8 +143,6 @@ const table = createTable({
 	globalFilterFn: "fuzzy",
 });
 
-const pagination = $derived(table.atoms.pagination.get());
-
 const handleKeyUp = (e: KeyboardEvent) => {
 	table.setGlobalFilter(String((e.target as HTMLInputElement)?.value));
 };
@@ -174,36 +173,7 @@ const searchDebounce = debounce((e) => handleKeyUp(e));
 		{:else if !issues.length}
 			<p class="w-full p-5 text-center text-primary dark:text-white">{$_(`maintain.noTaggingIssues`)}</p>
 		{:else}
-			<div class="relative text-primary dark:text-white">
-				<input
-					type="text"
-					placeholder={$_(`search.placeholder`)}
-					class="w-full bg-primary/5 px-5 py-2.5 text-sm focus:outline-primary dark:bg-white/5 dark:focus:outline-white"
-					bind:value={globalFilter}
-					onkeyup={searchDebounce}
-					bind:this={searchInput}
-				/>
-				{#if globalFilter}
-					<button
-						class="absolute top-1/2 right-3 -translate-y-1/2"
-						onclick={() => {
-							globalFilter = '';
-							table.setGlobalFilter('');
-						}}
-					>
-						<Icon type="fa" icon="circle-xmark" w="16" h="16" />
-					</button>
-				{:else}
-					<button
-						class="absolute top-1/2 right-3 -translate-y-1/2"
-						onclick={() => {
-							searchInput?.focus();
-						}}
-					>
-						<Icon type="fa" icon="magnifying-glass" w="16" h="16" />
-					</button>
-				{/if}
-			</div>
+			<LeaderboardSearch {table} bind:globalFilter {searchDebounce} />
 			{#if table.getFilteredRowModel().rows.length === 0}
 				<p class="w-full p-5 text-center text-primary dark:text-white">{$_(`leaderboard.noResults`)}</p>
 			{:else}
@@ -246,75 +216,7 @@ const searchDebounce = debounce((e) => handleKeyUp(e));
 					</table>
 				</div>
 
-				<div
-					class="flex w-full flex-col gap-5 px-5 pt-2.5 pb-5 text-primary md:flex-row md:items-center md:justify-between dark:text-white"
-				>
-					<select
-						value={pagination.pageSize}
-						onchange={(e) => {
-							table.setPageSize(Number(e.currentTarget.value));
-						}}
-						class="cursor-pointer bg-transparent focus:outline-primary dark:focus:outline-white"
-					>
-						{#each pageSizes as pageSize (pageSize)}
-							<option value={pageSize}>
-								{$_(`leaderboard.show`, { values: { pageSize } })}
-							</option>
-						{/each}
-					</select>
-
-					<div class="flex flex-col gap-5 md:flex-row md:items-center">
-						<div class="flex items-center justify-between gap-5 md:justify-start">
-							<div class="flex items-center gap-5">
-								<button
-									class="text-xl font-bold {!table.getCanPreviousPage()
-										? 'cursor-not-allowed opacity-50'
-										: ''}"
-									onclick={() => table.firstPage()}
-									disabled={!table.getCanPreviousPage()}
-								>
-									&lt;&lt;
-								</button>
-								<button
-									class="text-xl font-bold {!table.getCanPreviousPage()
-										? 'cursor-not-allowed opacity-50'
-										: ''}"
-									onclick={() => table.previousPage()}
-									disabled={!table.getCanPreviousPage()}
-								>
-									&lt;
-								</button>
-							</div>
-							<div class="flex items-center gap-5">
-								<button
-									class="text-xl font-bold {!table.getCanNextPage()
-										? 'cursor-not-allowed opacity-50'
-										: ''}"
-									onclick={() => table.nextPage()}
-									disabled={!table.getCanNextPage()}
-								>
-									&gt;
-								</button>
-								<button
-									class="text-xl font-bold {!table.getCanNextPage()
-										? 'cursor-not-allowed opacity-50'
-										: ''}"
-									onclick={() => table.lastPage()}
-									disabled={!table.getCanNextPage()}
-								>
-									&gt;&gt;
-								</button>
-							</div>
-						</div>
-
-						<span class="flex items-center justify-center gap-1 md:justify-start">
-							<div>{$_(`leaderboard.page`)}</div>
-							<strong>
-								{pagination.pageIndex + 1} {$_(`leaderboard.of`)} {table.getPageCount().toLocaleString()}
-							</strong>
-						</span>
-					</div>
-				</div>
+				<LeaderboardPagination {table} {pageSizes} />
 			{/if}
 		{/if}
 	</div>


### PR DESCRIPTION
## Summary
<img width="2880" height="1800" alt="1-tagging-issues-dark" src="https://github.com/user-attachments/assets/360f826c-3dfe-4d58-9dfc-971f2d6ee89e" />
<img width="2880" height="1800" alt="2-tagging-issues-dark-pagination" src="https://github.com/user-attachments/assets/e9a37cd7-e9c5-4cee-ab2b-3dcbddadb606" />
<img width="2880" height="1800" alt="3-community-munich-maintain-light" src="https://github.com/user-attachments/assets/c9591350-f57a-4825-850d-572002a23f7b" />
<img width="2880" height="1800" alt="4-country-de-maintain-light" src="https://github.com/user-attachments/assets/de2ffe15-24cd-4657-99ab-912c9a5a4168" />

Closes #1234 (follow-up from the #1226 review feedback): `IssuesTable.svelte` drops its hand-rolled search input and pagination block for the shared `LeaderboardSearch` / `LeaderboardPagination` components, which became generic over the row type in #1226.

- **Net −98 lines** in the one file; the duplicated `handleKeyUp` pattern count drops by one
- **A11y gain, not just dedup**: the inline copies lacked the search input's `aria-label`, the clear/focus button labels, `type="button"` + aria-labels on the pagination buttons, and the `aria-live` page indicator — all of which the shared components carry
- Wrapper markup was byte-identical between the inline copy and `LeaderboardSearch`, so the swap is visually lossless
- The dark-mode `select option` style block stays — it's an injected global style that reaches the shared component's select exactly as it already does for AreaLeaderboard

## Verified

- `svelte-check` 0/0, Biome clean, 584/584 tests, prod build green
- Deploy-preview QA + screenshots of every IssuesTable surface (tagging-issues, community maintain, country maintain, dark mode) posted below once the preview builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the issues table to use shared search and pagination controls.
  * Preserved existing search and pagination functionality while improving consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->