### PR TITLE
refactor(tables): extract shared SortableHeaderCell component #1244

### DIFF
--- a/src/components/IssuesTable.svelte
+++ b/src/components/IssuesTable.svelte
@@ -11,8 +11,9 @@ import Icon from "$components/Icon.svelte";
 import IssueCell from "$components/IssueCell.svelte";
 import LeaderboardPagination from "$components/leaderboard/LeaderboardPagination.svelte";
 import LeaderboardSearch from "$components/leaderboard/LeaderboardSearch.svelte";
+import SortableHeaderCell from "$components/leaderboard/SortableHeaderCell.svelte";
 import type { BtcmapTableFeatures } from "$lib/tableFeatures";
-import { btcmapTableFeatures } from "$lib/tableFeatures";
+import { btcmapTableFeatures, resolveAriaSort } from "$lib/tableFeatures";
 import { theme } from "$lib/theme";
 import type { PlaceIssue } from "$lib/types";
 import { debounce, getIssueHelpLink, getIssueIcon, isEven } from "$lib/utils";
@@ -183,20 +184,12 @@ const searchDebounce = debounce((e) => handleKeyUp(e));
 							{#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
 								<tr>
 									{#each headerGroup.headers as header (header.id)}
-										<th colSpan={header.colSpan} class="px-5 pt-5 pb-2.5">
-											{#if !header.isPlaceholder}
-												<button
-													class="flex items-center gap-x-2 select-none"
-													onclick={header.column.getToggleSortingHandler()}
-												>
-													<FlexRender {header} />
-													{#if header.column.getIsSorted().toString() === 'asc'}
-														<Icon type="fa" icon="caret-up" w="8" h="8" />
-													{:else if header.column.getIsSorted().toString() === 'desc'}
-														<Icon type="fa" icon="caret-down" w="8" h="8" />
-													{/if}
-												</button>
-											{/if}
+										<th
+											colSpan={header.colSpan}
+											class="px-5 pt-5 pb-2.5"
+											aria-sort={resolveAriaSort(header)}
+										>
+											<SortableHeaderCell {header} />
 										</th>
 									{/each}
 								</tr>

--- a/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
+++ b/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
@@ -5,9 +5,10 @@ import { FlexRender } from "@tanstack/svelte-table";
 import Icon from "$components/Icon.svelte";
 import AreaLeaderboardItemName from "$components/leaderboard/AreaLeaderboardItemName.svelte";
 import GradeDisplay from "$components/leaderboard/GradeDisplay.svelte";
+import SortableHeaderCell from "$components/leaderboard/SortableHeaderCell.svelte";
 import { _ } from "$lib/i18n";
 import type { BtcmapTableFeatures } from "$lib/tableFeatures";
-import { resolveHeaderLabel } from "$lib/tableFeatures";
+import { resolveAriaSort } from "$lib/tableFeatures";
 import type { AreaLeaderboardRow, AreaType } from "$lib/types";
 import { isEven } from "$lib/utils";
 
@@ -38,59 +39,10 @@ let {
 							colSpan={header.colSpan}
 							class="px-2 pt-5 pb-2.5 md:px-5"
 							class:text-center={header.column.id !== 'name'}
-							aria-sort={header.column.getIsSorted() === 'asc'
-								? 'ascending'
-								: header.column.getIsSorted() === 'desc'
-									? 'descending'
-									: 'none'}
+							aria-sort={resolveAriaSort(header)}
 						>
-							{#if !header.isPlaceholder}
-								{@const headerLabel = resolveHeaderLabel(header)}
-								<!-- Tooltip triggers live OUTSIDE the sort button as siblings:
-								     as descendants their clicks and Enter/Space would bubble
-								     into the sort handler (and interactive content inside a
-								     button is invalid HTML — the parser splits nested buttons,
-								     breaking SSR hydration) -->
-								<div
-									class="flex items-center gap-x-1 md:gap-x-2"
-									class:mx-auto={header.column.id !== 'name'}
-									class:w-fit={header.column.id !== 'name'}
-								>
-									<button
-										type="button"
-										class="flex items-center gap-x-1 leading-tight select-none md:gap-x-2"
-										class:cursor-pointer={header.column.getCanSort()}
-										onclick={header.column.getToggleSortingHandler()}
-										onkeydown={(e) => {
-											if (e.key === 'Enter' || e.key === ' ') {
-												e.preventDefault();
-												header.column.getToggleSortingHandler()?.(e);
-											}
-										}}
-										tabindex={header.column.getCanSort() ? 0 : -1}
-										aria-label={header.column.getCanSort()
-											? header.column.getIsSorted() === 'asc'
-												? $_('leaderboard.sortByCurrentlyAscending', {
-														values: { column: headerLabel },
-													})
-												: header.column.getIsSorted() === 'desc'
-													? $_('leaderboard.sortByCurrentlyDescending', {
-															values: { column: headerLabel },
-														})
-													: $_('leaderboard.sortByCurrentlyUnsorted', {
-															values: { column: headerLabel },
-														})
-											: headerLabel}
-									>
-										<span class="break-words">
-											<FlexRender {header} />
-										</span>
-										{#if header.column.getIsSorted().toString() === 'asc'}
-											<span aria-hidden="true">▲</span>
-										{:else if header.column.getIsSorted().toString() === 'desc'}
-											<span aria-hidden="true">▼</span>
-										{/if}
-									</button>
+							<SortableHeaderCell {header} centered={header.column.id !== 'name'}>
+								{#snippet trailing()}
 									{#if header.column.id === 'total'}
 										<button
 											type="button"
@@ -119,8 +71,8 @@ let {
 											<Icon type="fa" icon="circle-info" w="14" h="14" class="text-sm" />
 										</button>
 									{/if}
-								</div>
-							{/if}
+								{/snippet}
+							</SortableHeaderCell>
 						</th>
 					{/each}
 				</tr>

--- a/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
+++ b/src/components/leaderboard/AreaLeaderboardDesktopTable.svelte
@@ -69,13 +69,17 @@ let {
 										}}
 										tabindex={header.column.getCanSort() ? 0 : -1}
 										aria-label={header.column.getCanSort()
-											? `Sort by ${headerLabel}, currently ${
-													header.column.getIsSorted() === 'asc'
-														? 'ascending'
-														: header.column.getIsSorted() === 'desc'
-															? 'descending'
-															: 'unsorted'
-												}`
+											? header.column.getIsSorted() === 'asc'
+												? $_('leaderboard.sortByCurrentlyAscending', {
+														values: { column: headerLabel },
+													})
+												: header.column.getIsSorted() === 'desc'
+													? $_('leaderboard.sortByCurrentlyDescending', {
+															values: { column: headerLabel },
+														})
+													: $_('leaderboard.sortByCurrentlyUnsorted', {
+															values: { column: headerLabel },
+														})
 											: headerLabel}
 									>
 										<span class="break-words">

--- a/src/components/leaderboard/SortableHeaderCell.svelte
+++ b/src/components/leaderboard/SortableHeaderCell.svelte
@@ -1,0 +1,78 @@
+<script lang="ts" generics="TData extends RowData">
+import type { Header, RowData } from "@tanstack/svelte-table";
+import { FlexRender } from "@tanstack/svelte-table";
+import type { Snippet } from "svelte";
+
+import { _ } from "$lib/i18n";
+import type { BtcmapTableFeatures } from "$lib/tableFeatures";
+import { resolveHeaderLabel } from "$lib/tableFeatures";
+
+type Props = {
+	header: Header<BtcmapTableFeatures, TData, any>;
+	centered?: boolean;
+	trailing?: Snippet;
+};
+
+let { header, centered = false, trailing }: Props = $props();
+</script>
+
+{#if !header.isPlaceholder}
+	{@const headerLabel = resolveHeaderLabel(header)}
+	{#if trailing}
+		<!-- Trailing controls (e.g. tooltip triggers) live OUTSIDE the sort
+		     button as siblings: as descendants their clicks and Enter/Space
+		     would bubble into the sort handler (and interactive content inside
+		     a button is invalid HTML — the parser splits nested buttons,
+		     breaking SSR hydration) -->
+		<div
+			class="flex items-center gap-x-1 md:gap-x-2"
+			class:mx-auto={centered}
+			class:w-fit={centered}
+		>
+			{@render sortButton(headerLabel, false)}
+			{@render trailing()}
+		</div>
+	{:else}
+		{@render sortButton(headerLabel, centered)}
+	{/if}
+{/if}
+
+{#snippet sortButton(headerLabel: string, centerSelf: boolean)}
+	<button
+		type="button"
+		class="flex items-center gap-x-1 leading-tight select-none md:gap-x-2"
+		class:mx-auto={centerSelf}
+		class:justify-center={centerSelf}
+		class:cursor-pointer={header.column.getCanSort()}
+		onclick={header.column.getToggleSortingHandler()}
+		onkeydown={(e) => {
+			if (e.key === 'Enter' || e.key === ' ') {
+				e.preventDefault();
+				header.column.getToggleSortingHandler()?.(e);
+			}
+		}}
+		tabindex={header.column.getCanSort() ? 0 : -1}
+		aria-label={header.column.getCanSort()
+			? header.column.getIsSorted() === 'asc'
+				? $_('leaderboard.sortByCurrentlyAscending', {
+						values: { column: headerLabel },
+					})
+				: header.column.getIsSorted() === 'desc'
+					? $_('leaderboard.sortByCurrentlyDescending', {
+							values: { column: headerLabel },
+						})
+					: $_('leaderboard.sortByCurrentlyUnsorted', {
+							values: { column: headerLabel },
+						})
+			: headerLabel}
+	>
+		<span class="break-words">
+			<FlexRender {header} />
+		</span>
+		{#if header.column.getIsSorted() === 'asc'}
+			<span aria-hidden="true">▲</span>
+		{:else if header.column.getIsSorted() === 'desc'}
+			<span aria-hidden="true">▼</span>
+		{/if}
+	</button>
+{/snippet}

--- a/src/components/leaderboard/SortableHeaderCell.svelte
+++ b/src/components/leaderboard/SortableHeaderCell.svelte
@@ -45,12 +45,6 @@ let { header, centered = false, trailing }: Props = $props();
 		class:justify-center={centerSelf}
 		class:cursor-pointer={header.column.getCanSort()}
 		onclick={header.column.getToggleSortingHandler()}
-		onkeydown={(e) => {
-			if (e.key === 'Enter' || e.key === ' ') {
-				e.preventDefault();
-				header.column.getToggleSortingHandler()?.(e);
-			}
-		}}
 		tabindex={header.column.getCanSort() ? 0 : -1}
 		aria-label={header.column.getCanSort()
 			? header.column.getIsSorted() === 'asc'

--- a/src/components/leaderboard/TaggerLeaderboardDesktopTable.svelte
+++ b/src/components/leaderboard/TaggerLeaderboardDesktopTable.svelte
@@ -2,10 +2,11 @@
 import type { Table } from "@tanstack/svelte-table";
 import { FlexRender } from "@tanstack/svelte-table";
 
+import SortableHeaderCell from "$components/leaderboard/SortableHeaderCell.svelte";
 import Tip from "$components/Tip.svelte";
 import { _ } from "$lib/i18n";
 import type { BtcmapTableFeatures } from "$lib/tableFeatures";
-import { resolveHeaderLabel } from "$lib/tableFeatures";
+import { resolveAriaSort } from "$lib/tableFeatures";
 import type { TaggerLeaderboard } from "$lib/types";
 import { isEven } from "$lib/utils";
 
@@ -29,52 +30,9 @@ let { table }: { table: Table<BtcmapTableFeatures, TaggerRow> } = $props();
 							colSpan={header.colSpan}
 							class="px-2 pt-5 pb-2.5 md:px-5"
 							class:text-center={header.column.id !== 'name'}
-							aria-sort={header.column.getIsSorted() === 'asc'
-								? 'ascending'
-								: header.column.getIsSorted() === 'desc'
-									? 'descending'
-									: 'none'}
+							aria-sort={resolveAriaSort(header)}
 						>
-							{#if !header.isPlaceholder}
-								{@const headerLabel = resolveHeaderLabel(header)}
-								<button
-									type="button"
-									class="flex items-center gap-x-1 leading-tight select-none md:gap-x-2"
-									class:mx-auto={header.column.id !== 'name'}
-									class:cursor-pointer={header.column.getCanSort()}
-									class:justify-center={header.column.id !== 'name'}
-									onclick={header.column.getToggleSortingHandler()}
-									onkeydown={(e) => {
-										if (e.key === 'Enter' || e.key === ' ') {
-											e.preventDefault();
-											header.column.getToggleSortingHandler()?.(e);
-										}
-									}}
-									tabindex={header.column.getCanSort() ? 0 : -1}
-									aria-label={header.column.getCanSort()
-										? header.column.getIsSorted() === 'asc'
-											? $_('leaderboard.sortByCurrentlyAscending', {
-													values: { column: headerLabel },
-												})
-											: header.column.getIsSorted() === 'desc'
-												? $_('leaderboard.sortByCurrentlyDescending', {
-														values: { column: headerLabel },
-													})
-												: $_('leaderboard.sortByCurrentlyUnsorted', {
-														values: { column: headerLabel },
-													})
-										: headerLabel}
-								>
-									<span class="break-words">
-										<FlexRender {header} />
-									</span>
-									{#if header.column.getIsSorted().toString() === 'asc'}
-										<span aria-hidden="true">▲</span>
-									{:else if header.column.getIsSorted().toString() === 'desc'}
-										<span aria-hidden="true">▼</span>
-									{/if}
-								</button>
-							{/if}
+							<SortableHeaderCell {header} centered={header.column.id !== 'name'} />
 						</th>
 					{/each}
 				</tr>

--- a/src/lib/tableFeatures.ts
+++ b/src/lib/tableFeatures.ts
@@ -77,3 +77,13 @@ export const resolveHeaderLabel = <TData extends RowData>(
 	if (typeof def === "function") return String(def(header.getContext()));
 	return typeof def === "string" ? def : header.column.id;
 };
+
+// Maps a column's sort state to the aria-sort value for its <th>
+export const resolveAriaSort = <TData extends RowData>(
+	header: Header<BtcmapTableFeatures, TData, any>,
+): "ascending" | "descending" | "none" => {
+	const sorted = header.column.getIsSorted();
+	if (sorted === "asc") return "ascending";
+	if (sorted === "desc") return "descending";
+	return "none";
+};

--- a/src/lib/tableFeatures.ts
+++ b/src/lib/tableFeatures.ts
@@ -78,10 +78,13 @@ export const resolveHeaderLabel = <TData extends RowData>(
 	return typeof def === "string" ? def : header.column.id;
 };
 
-// Maps a column's sort state to the aria-sort value for its <th>
+// Maps a column's sort state to the aria-sort value for its <th>.
+// Never-sortable columns return undefined so the attribute is omitted —
+// aria-sort belongs only on headers that participate in sorting.
 export const resolveAriaSort = <TData extends RowData>(
 	header: Header<BtcmapTableFeatures, TData, any>,
-): "ascending" | "descending" | "none" => {
+): "ascending" | "descending" | "none" | undefined => {
+	if (!header.column.getCanSort()) return undefined;
 	const sorted = header.column.getIsSorted();
 	if (sorted === "asc") return "ascending";
 	if (sorted === "desc") return "descending";

--- a/src/routes/tagger/[id]/components/ProfileActivity.svelte
+++ b/src/routes/tagger/[id]/components/ProfileActivity.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
 import type { ColumnDef } from "@tanstack/svelte-table";
-import { createTable, FlexRender } from "@tanstack/svelte-table";
+import { createTable } from "@tanstack/svelte-table";
 import { format } from "date-fns/format";
 import { untrack } from "svelte";
 
 import LeaderboardPagination from "$components/leaderboard/LeaderboardPagination.svelte";
 import LeaderboardSearch from "$components/leaderboard/LeaderboardSearch.svelte";
+import SortableHeaderCell from "$components/leaderboard/SortableHeaderCell.svelte";
 import { _ } from "$lib/i18n";
 import type { BtcmapTableFeatures } from "$lib/tableFeatures";
-import { btcmapTableFeatures, resolveHeaderLabel } from "$lib/tableFeatures";
+import { btcmapTableFeatures, resolveAriaSort } from "$lib/tableFeatures";
 import type { ActivityEvent } from "$lib/types";
 import { debounce } from "$lib/utils";
 
@@ -128,50 +129,9 @@ const searchDebounce = debounce((e) => handleKeyUp(e));
 											.column.id === 'location'
 											? 'w-2/3'
 											: 'w-1/6'}"
-										aria-sort={header.column.getIsSorted() === 'asc'
-											? 'ascending'
-											: header.column.getIsSorted() === 'desc'
-												? 'descending'
-												: 'none'}
+										aria-sort={resolveAriaSort(header)}
 									>
-										{#if !header.isPlaceholder}
-											{@const headerLabel = resolveHeaderLabel(header)}
-											<button
-												type="button"
-												class="flex items-center gap-x-1 leading-tight select-none"
-												class:cursor-pointer={header.column.getCanSort()}
-												onclick={header.column.getToggleSortingHandler()}
-												onkeydown={(e) => {
-													if (e.key === 'Enter' || e.key === ' ') {
-														e.preventDefault();
-														header.column.getToggleSortingHandler()?.(e);
-													}
-												}}
-												tabindex={header.column.getCanSort() ? 0 : -1}
-												aria-label={header.column.getCanSort()
-													? header.column.getIsSorted() === 'asc'
-														? $_('leaderboard.sortByCurrentlyAscending', {
-																values: { column: headerLabel },
-															})
-														: header.column.getIsSorted() === 'desc'
-															? $_('leaderboard.sortByCurrentlyDescending', {
-																	values: { column: headerLabel },
-																})
-															: $_('leaderboard.sortByCurrentlyUnsorted', {
-																	values: { column: headerLabel },
-																})
-													: headerLabel}
-											>
-												<span class="break-words">
-													<FlexRender {header} />
-												</span>
-												{#if header.column.getIsSorted().toString() === 'asc'}
-													<span aria-hidden="true">▲</span>
-												{:else if header.column.getIsSorted().toString() === 'desc'}
-													<span aria-hidden="true">▼</span>
-												{/if}
-											</button>
-										{/if}
+										<SortableHeaderCell {header} />
 									</th>
 								{/each}
 							</tr>


### PR DESCRIPTION
## What

Consolidates the sort-header cell that was copy-pasted across the TanStack tables, as flagged by the health review in #1244 (Refactoring Opportunities section).

Two corrections to the health review's premise, for the record: `resolveHeaderLabel` was already shared via `$lib/tableFeatures` (only its call sites were duplicated), and `SortHeaderButton` is the *mobile* sort control — neither desktop table used it. The real duplication was the ~40-line header-cell markup (sort button + keyboard handling + FlexRender label + carets + aria attributes), copied in full in `TaggerLeaderboardDesktopTable`, `AreaLeaderboardDesktopTable` and `ProfileActivity`, plus a degraded fourth copy in `IssuesTable` that was missing all the a11y work.

## Commits

- **fix(area-leaderboard): use i18n sort aria-labels** — the area table hardcoded English `Sort by X, currently ascending` labels while the other tables use the `leaderboard.sortByCurrently*` keys
- **refactor(tables): extract shared SortableHeaderCell** — new runes-mode component; the area table's tooltip triggers pass through an optional `trailing` snippet rendered as a *sibling* of the sort button (preserving the nested-button/bubbling constraint documented in the old markup). Adds `resolveAriaSort` for the `<th>` aria-sort ternary
- **fix(issues-table): adopt accessible sort headers** — IssuesTable gains aria-sort, keyboard handling, aria-labels, and non-sortable header buttons leave the tab order
- **fix(tables): omit aria-sort on never-sortable columns** — `aria-sort="none"` was previously emitted on columns with `enableSorting: false`, which tells AT the column participates in sorting when it cannot

## Intended visible changes

- IssuesTable sort carets: small fa caret icons → the ▲/▼ text carets used everywhere else; cursor is `pointer` only on sortable headers
- ProfileActivity header buttons gain `md:gap-x-2` (the other copies already had it)
- Area desktop table sort buttons are now announced with translated labels

Net: −112/+108 lines with three full duplications removed; future header changes happen in one file.

## Verification

`pnpm run format:fix`, `check` (0 errors), `lint`, `test --run` (584 passing) — all green on every commit. Multi-agent adversarial review of the diff confirmed behavior parity for all columns of all four tables (the items above are the only intended divergences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved table sorting controls with clearer keyboard support and accurate `aria-sort` states.
  - Added accessible ascending and descending sort indicators and labels.

- **Consistency**
  - Standardized sortable headers across issue, leaderboard, and profile activity tables.
  - Preserved centered layouts and support for adjacent tooltip controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->