### PR TITLE
docs(readme): drop Corepack from setup, manage pnpm via mise

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [tools]
 node = "22"
+pnpm = "10"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 1. `git clone`\
    to clone the repo and `cd` into the directory
-2. Enable Corepack (if needed)\
-   If `pnpm` command is not found, run: `corepack enable`
+2. Install [pnpm](https://pnpm.io/installation) (if needed)\
+   If the `pnpm` command is not found, run `mise install` (see note below) or use one of the [standalone installation methods](https://pnpm.io/installation)
 3. `pnpm install`\
    to install the packages
 4. `pnpm dev`\
@@ -39,7 +39,7 @@ Remove or comment out the env var to switch back to the production API.
    Copy `.env.example` and save as `.env`
 1. `pnpm build`
 
-_NOTE:_ BTC Map uses Node 22 LTS. If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to switch to the correct version. This project uses Corepack (bundled with Node 22) to manage pnpm automatically.
+_NOTE:_ BTC Map uses Node 22 LTS. If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to get the correct Node and pnpm versions. Any pnpm ≥ 10 works: pnpm reads the `packageManager` pin in `package.json` and switches to that exact version automatically, so Corepack is not needed (pnpm [no longer recommends it](https://pnpm.io/installation)).
 
 #### Icons
 


### PR DESCRIPTION
## Why

pnpm no longer recommends Corepack — their docs deleted the entire "Using Corepack" install section ([pnpm.io PR #862](https://github.com/pnpm/pnpm.io/pull/862)), for concrete reasons:

- **Corepack cannot install the upcoming pnpm 12** (Rust rewrite, binary-only package — no JS entry point for Corepack to run, [pnpm/pnpm#13018](https://github.com/pnpm/pnpm/issues/13018) closed "not planned")
- **Corepack is no longer part of Node**: Node 25+ doesn't bundle it; Node 24 LTS is the last line that does. Our README currently tells new contributors to `corepack enable`, which stops existing once they're on a newer Node
- **It's redundant**: any pnpm ≥ 10 reads the `packageManager` pin in `package.json` and switches to that exact version by itself — the one thing Corepack did for us

## What changed

- **README**: setup step 2 now says "install pnpm" (via mise or a [standalone method](https://pnpm.io/installation)) instead of `corepack enable`; the Node-version note explains the `packageManager` self-pinning
- **`.mise.toml`**: added `pnpm = "10"` so `mise install` provisions both Node and pnpm in one step (the exact version still comes from the `packageManager` pin)

## Not affected

- **CI** already uses `pnpm/action-setup@v4` (Corepack-free, reads the `packageManager` pin) — no change needed
- **Netlify** provisions pnpm via Corepack on its side and keeps working for pnpm 10/11. Worth remembering: a future bump to `packageManager: pnpm@12` is gated on Netlify changing that, since Corepack can't install pnpm 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)