### PR TITLE
ci(health-review): survive null model content instead of publishing it #1248

### DIFF
--- a/.github/workflows/ai-health-review.yml
+++ b/.github/workflows/ai-health-review.yml
@@ -380,6 +380,10 @@ jobs:
           printf '%s' "$SYSTEM_PROMPT" > /tmp/system-prompt.txt
           printf '%s' "$USER_PROMPT" > /tmp/user-prompt.txt
 
+          # claude-opus-5 reasons by default and max_tokens caps reasoning +
+          # visible content TOGETHER; at 8192 the whole budget went to
+          # reasoning and message.content came back null (#1248). This is a
+          # ceiling, not a target — only generated tokens are billed.
           jq -n \
             --arg model "$MODEL" \
             --rawfile system /tmp/system-prompt.txt \
@@ -390,7 +394,7 @@ jobs:
                 { role: "system", content: $system },
                 { role: "user", content: $user }
               ],
-              max_tokens: 8192
+              max_tokens: 32000
             }' > /tmp/api-request.json
 
           HTTP_STATUS=$(curl -s -w '%{http_code}' -o /tmp/api-response.json \
@@ -406,8 +410,17 @@ jobs:
             exit 1
           fi
 
-          # Extract AI response
-          jq -r '.choices[0].message.content' /tmp/api-response.json > /tmp/review.md
+          # Extract AI response. `// empty` keeps a missing/null content from
+          # becoming the literal string "null" (#1248); the guard below fails
+          # the job with diagnostics instead of publishing a broken report.
+          jq -r '.choices[0].message.content // empty' /tmp/api-response.json > /tmp/review.md
+
+          if [[ ! -s /tmp/review.md ]]; then
+            FINISH=$(jq -r '.choices[0].finish_reason // "unknown"' /tmp/api-response.json 2>/dev/null || echo "unknown")
+            USAGE=$(jq -c '.usage // {}' /tmp/api-response.json 2>/dev/null || echo "{}")
+            echo "::error::AI response had no message content (finish_reason: ${FINISH}, usage: ${USAGE}) — refusing to publish an empty report"
+            exit 1
+          fi
 
           # Append footer with cutoff timestamp for next run's anchor
           CUTOFF="${{ steps.commits.outputs.cutoff_date }}"


### PR DESCRIPTION
## Root cause of #1248

The first `claude-opus-5` run published a report whose entire body was the string `null`. From the [run logs](https://github.com/teambtcmap/btcmap.org/actions/runs/31882062558): HTTP 200, ~108s of generation, then `Review generated (258 bytes)` — which is `null\n` plus the footer.

`claude-opus-5` **reasons by default**, unlike `opus-4.8` where omitting a thinking config meant no thinking, and `max_tokens` caps reasoning **plus** visible content together. The whole 8192-token budget went to reasoning, the OpenAI-compatible relay returned `message.content: null`, and `jq -r` rendered that as the literal string `null` — which then sailed through issue creation and even stamped a cutoff, so the period would have been silently skipped by the next scheduled run.

## Fix

- **`max_tokens` 8192 → 32000** so the report fits after reasoning. It's a ceiling, not a target — only generated tokens are billed, so worst case is well under $1 per biweekly run.
- **Null-content guard**: extraction now uses `// empty`, and an empty `review.md` fails the job with `finish_reason` + `usage` diagnostics instead of publishing garbage. A failed job writes no cutoff, so the period is re-covered by the next run. Verified against a simulated null-content response (fails with diagnostics) and a normal one (passes).

## After merging

Reply `/run-now c53d932f` on #1248 — the null report consumed the whole 2026-08-14→15 window including PRs #1245/#1247, and anchoring at c53d932f (the last good report's HEAD) re-reviews all of it. The new run will auto-close #1248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)