### PR TITLE
chore(deps): update pnpm to 11.21.0

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "22"
-pnpm = "10"
+pnpm = "11"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 1. `git clone`\
    to clone the repo and `cd` into the directory
-2. Install [pnpm](https://pnpm.io/installation) (if needed)\
-   If the `pnpm` command is not found, run `mise install` (see note below) or use one of the [standalone installation methods](https://pnpm.io/installation)
+2. Install [pnpm](https://pnpm.io/installation) ≥ 10 (if needed)\
+   If `pnpm` is not found — or `pnpm --version` reports < 10 — run `mise install` (see note below) or use one of the [standalone installation methods](https://pnpm.io/installation)
 3. `pnpm install`\
    to install the packages
 4. `pnpm dev`\
@@ -39,7 +39,7 @@ Remove or comment out the env var to switch back to the production API.
    Copy `.env.example` and save as `.env`
 1. `pnpm build`
 
-_NOTE:_ BTC Map uses Node 22 LTS. If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to get the correct Node and pnpm versions. Any pnpm ≥ 10 works: pnpm reads the `packageManager` pin in `package.json` and switches to that exact version automatically, so Corepack is not needed (pnpm [no longer recommends it](https://pnpm.io/installation)).
+_NOTE:_ BTC Map requires Node.js ≥ 22.13 (we use Node 22 LTS). If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to get the correct Node and pnpm versions. Any pnpm ≥ 10 works: pnpm reads the `packageManager` pin in `package.json` and switches to that exact version automatically, so Corepack is not needed (pnpm [no longer recommends it](https://pnpm.io/installation)).
 
 #### Icons
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
 	command = "pnpm build"
 	publish = "build"
 
+[build.environment]
+	# pnpm 11 needs Corepack >= 0.34.5, bundled since Node 22.22.1
+	NODE_VERSION = "22"
+
 [images]
   remote_images = ["https://static.btcmap.org/images/.*", "https://www.openstreetmap.org/.*", "https://avatars.githubusercontent.com/.*" ]
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"author": "secondl1ght <secondl1ght@protonmail.com>",
 	"license": "AGPL-3.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=22.13"
 	},
 	"type": "module",
 	"scripts": {
@@ -86,5 +86,5 @@
 		"vite": "^7.3.6",
 		"vitest": "^4.1.10"
 	},
-	"packageManager": "pnpm@10.11.0"
+	"packageManager": "pnpm@11.21.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  es5-ext: false
+  esbuild: true


### PR DESCRIPTION
## What

Bumps the pinned pnpm from **10.11.0** (May 2025) to the current latest, **11.21.0**. Was stacked on #1246 (now merged); rebased onto main.

- `packageManager`: `pnpm@11.21.0` — stays an **exact** pin (Netlify's Corepack provisioning rejects ranges, and Corepack must not see pnpm 11's new `devEngines` field)
- `pnpm-workspace.yaml`: pnpm 11 removed `onlyBuiltDependencies`; migrated to the new `allowBuilds` map. `es5-ext` is explicitly denied — its postinstall was already silently ignored under the old allowlist, this just makes it visible
- `engines.node`: `>=22.13` (pnpm 11's own minimum; it's pure ESM now)
- `.mise.toml`: `pnpm = "11"`

**No lockfile changes**: this repo has none of the constructs (patches, peer-dedupe suffixes, config deps) that trigger pnpm 11's lockfile rewrite. Verified the lockfile stays byte-identical across repeated pnpm 11 installs (the open lockfile-churn bug pnpm/pnpm#11859 does not bite here), and `pnpm install --frozen-lockfile` — the CI path — passes.

## Verified locally under 11.21.0

- `pnpm install --frozen-lockfile` ✓
- `pnpm run format` / `lint` / `check` (0 errors) ✓
- `pnpm run test --run` — 584/584 ✓
- `pnpm run build` (Vite + Netlify adapter) ✓

## Behavior changes to be aware of (pnpm 11 defaults)

- **`minimumReleaseAge` = 24h**: pnpm refuses to resolve package versions published less than a day ago (supply-chain protection). Dependabot PRs that bump to a just-released version will fail CI until the release ages ~1 day — rerun or wait. Can be relaxed per-package via `minimumReleaseAgeExclude` if it gets annoying.\n- **`verifyDepsBeforeRun` = install**: `pnpm run …` auto-verifies node_modules against the lockfile first (may touch the network).\n- Devs need Node ≥ 22.13; any pnpm ≥ 10 on PATH self-switches to 11.21.0 via the pin. Anyone still on Corepack needs ≥ 0.34.5 (bundled in Node 22.22.1+ / 24.12+) — older Corepacks hardcode a `.cjs` bin path pnpm 11 no longer ships.

## Netlify

Netlify installs pnpm via Corepack from the site's pinned Node. pnpm 11 needs Corepack ≥ 0.34.5 (Node 22.22.1+ / 24.12+). **The deploy preview on this PR is the authoritative test** — if it fails at dependency provisioning with `Cannot find module …/bin/pnpm.cjs`, the site's Node pin is too old and needs a bump (e.g. `NODE_VERSION`). Please also click through the preview (SSR pages) before merging, since a green build alone doesn't exercise the SSR function.

For later: pnpm 11 is the **last** major that works on Netlify's current provisioning — pnpm 12 (in RC) ships a native binary Corepack cannot run at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions for installing and managing Node.js and pnpm versions.
  * Clarified automatic use of the project’s specified pnpm version.

* **Chores**
  * Updated the minimum required Node.js version to 22.13.
  * Updated the required pnpm version to 11.21.0.
  * Added pinned pnpm tooling configuration.
  * Improved build-script permissions for supported packages.
  * Updated deployment settings for Node.js 22 and pnpm 11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
