### PR TITLE
chore: act on health review #1253 findings and process feedback

### DIFF
--- a/.github/scripts/validate_findings.py
+++ b/.github/scripts/validate_findings.py
@@ -53,6 +53,22 @@ try:
 except FileNotFoundError:
     pass
 
+# The <review-pipeline> block embeds the workflow's own source in every
+# prompt, and findings about changed pipeline code may quote it — mirror it
+# into the corpus so those quotes verify even when the file is too big for
+# full-file context or only the scripts changed. The corpus should match
+# what the model was actually shown.
+try:
+    with open(
+        ".github/workflows/ai-health-review.yml",
+        "r",
+        encoding="utf-8",
+        errors="replace",
+    ) as f:
+        corpus_parts.append(f.read())
+except FileNotFoundError:
+    pass
+
 corpus = norm("\n".join(corpus_parts))
 
 # Paths that appear as either side of a `diff --git a/x b/y` header.

--- a/.github/workflows/ai-health-review.yml
+++ b/.github/workflows/ai-health-review.yml
@@ -210,7 +210,7 @@ jobs:
           2. "Can we refactor?" — patterns, duplication, or related changes across multiple commits that could be consolidated or improved now that they have all landed.
           3. "Is AGENTS.md outdated?" — compare the AGENTS.md documentation against the actual codebase patterns visible in the diff. Flag any conventions, tooling references, file paths, or project structure notes in AGENTS.md that contradict what the code actually does.
           4. "Is README.md outdated?" — compare the README.md against the actual codebase (commands, setup steps, project structure, dependencies). Flag any instructions, commands, or descriptions that no longer match reality.
-          5. "How should this review process improve?" — you are given the coverage numbers for this run (<pipeline-stats>) and the workflow source that produced this prompt (<review-pipeline>). If something about the pipeline measurably limited THIS run — heavy diff truncation, file contents that did not fit the budget, a prompt instruction that contradicts what you saw in the code, a validation gap — say so concretely. Observations about the pipeline belong in the Process Feedback section, never in Findings.
+          5. "How should this review process improve?" — you are given the coverage numbers for this run (<pipeline-stats>) and the workflow source that produced this prompt (<review-pipeline>). If something about the pipeline measurably limited THIS run — heavy diff truncation, file contents that did not fit the budget, a prompt instruction that contradicts what you saw in the code, a validation gap — say so concretely. Coverage and limitation observations about THIS run belong in the Process Feedback section. Bugs in committed workflow or script code that changed in the period diff are ordinary Findings — quote them from the diff, the file contents, or the <review-pipeline> block.
 
           The project stack and conventions are documented in the <project-conventions> and <agents-md> blocks in the user message — treat those as authoritative and flag new code that contradicts them. Do not assume the stack from memory; this prompt has gone stale on that before (it claimed Svelte 4 and Leaflet long after the Svelte 5 and MapLibre migrations).
 
@@ -319,7 +319,7 @@ jobs:
           ${PIPELINE_STATS}
           </pipeline-stats>
 
-          The workflow source that generated this review, for the Process Feedback section only:
+          The workflow source that generated this review — reference for Process Feedback, and quotable in Findings when the workflow or its scripts are part of the period diff:
 
           ${RP_OPEN}
           ${WORKFLOW_SOURCE}

--- a/.github/workflows/ai-health-review.yml
+++ b/.github/workflows/ai-health-review.yml
@@ -227,7 +227,7 @@ jobs:
           - If nothing significant was missed and there are no refactoring opportunities, say so briefly. Do not invent findings.
 
           Verification rules (mandatory):
-          - ONLY report issues you can directly verify from the provided diff AND full file contents. If you need a file that is not provided, do NOT report the finding.
+          - ONLY report issues you can directly verify from the provided diff, full file contents, or (for changed pipeline code) the <review-pipeline> block. If you need a file that is not provided, do NOT report the finding.
           - For each finding, you must be able to point to specific lines in the diff or file contents that prove the issue exists. If you cannot, drop it.
           - NEVER assume what a module contains based on its name. Read the provided file contents. If a module is not included, do not make claims about its internals.
           - Before flagging a pattern in new code, check whether existing files in the full file contents use the same pattern. If they do, it is an established project convention — do not flag it.

--- a/.github/workflows/ai-health-review.yml
+++ b/.github/workflows/ai-health-review.yml
@@ -107,7 +107,9 @@ jobs:
         run: |
           set -euo pipefail
           MAX_CONTEXT=120000
-          MAX_FILE=20000
+          # 32KB so the 24KB ai-health-review.yml itself fits — at 20000 the
+          # period's most-changed file was skipped from context (#1253)
+          MAX_FILE=32000
 
           # Files changed in the diff (extract b/ path so renames resolve to the new name)
           grep '^diff --git' /tmp/raw-diff.txt \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,11 @@ This file contains project-specific guidelines and commands for Claude Code to f
 **BEFORE EVERY COMMIT, YOU MUST:**
 
 1. **🎨 Format code:** Run `pnpm run format:fix` (REQUIRED - NO EXCEPTIONS)
-2. **🔍 Type check:** Run `pnpm run check`
-3. **🧹 Lint:** Run `pnpm run lint`
-4. **🧪 Unit tests:** Run `pnpm run test --run`
-5. **📝 Commit format:** Use [Conventional Commits](https://www.conventionalcommits.org/) format with issue number
+2. **🔍 Svelte check:** Run `pnpm run check`
+3. **🔎 TS type check:** Run `pnpm run typecheck`
+4. **🧹 Lint:** Run `pnpm run lint`
+5. **🧪 Unit tests:** Run `pnpm run test --run`
+6. **📝 Commit format:** Use [Conventional Commits](https://www.conventionalcommits.org/) format with issue number
 
 **Failure to run `pnpm run format:fix` before committing will result in inconsistent code formatting.**
 
@@ -172,11 +173,12 @@ Use the appropriate tool attribution based on which tool generated the commit:
 
 1. Make your changes
 2. **🎨 MANDATORY:** Run `pnpm run format:fix` ⚠️ **THIS IS REQUIRED BEFORE EVERY COMMIT** ⚠️
-3. Run `pnpm run check` to perform type checking
-4. Run `pnpm run lint` to verify no errors
-5. Verify the commit type matches the change (e.g., `ci` for CI changes, `feat` only for new features, not config/tooling)
-6. Stage and commit with conventional format
-7. Include issue number if applicable (e.g., `#276`)
+3. Run `pnpm run check` to perform Svelte validation
+4. Run `pnpm run typecheck` to perform project-wide TS type checking
+5. Run `pnpm run lint` to verify no errors
+6. Verify the commit type matches the change (e.g., `ci` for CI changes, `feat` only for new features, not config/tooling)
+7. Stage and commit with conventional format
+8. Include issue number if applicable (e.g., `#276`)
 
 **🚨 CRITICAL REMINDER:** You MUST run `pnpm run format:fix` before staging any commit. This is non-negotiable and ensures consistent code formatting across the entire project.
 
@@ -263,7 +265,7 @@ Use [https://nostrhub.io/nips](https://nostrhub.io/nips) as the definitive NIP s
 - Use `Place` type for v4 API data; the remaining v2 surfaces (area/report/event/user crawls via `createSyncFactory`, per-place issues on the merchant page from `/v2/elements`) use their own types (`Area`, `Report`, `Event`, `User`, `Issue`) — there is no `Element` type anymore
 - Prefer editing existing files over creating new ones
 - Only create documentation files when explicitly requested
-- **Svelte 5, mixed-mode → runes** — the app runs Svelte 5; the table cluster (`src/routes/leaderboard`, `src/components/leaderboard/*`, `IssuesTable`, `ProfileActivity`) is runes-mode, most other components are still legacy (Svelte-4 syntax). Write NEW components in runes mode (`$props`, `$state`, `$derived`, `$effect`). **Boy-scout rule: when a PR makes meaningful changes to a legacy component, convert that file to runes mode in the same PR** — as its own commit, so the conversion diff stays separately reviewable from the feature change. Conversions are whole-file (runes and legacy syntax cannot mix within one file) and include the template idioms: `on:` → event attributes, `<svelte:component>` → dynamic components, slots → snippets where practical. Exceptions — do NOT convert as a drive-by: trivial edits (a one-line fix doesn't obligate converting a large file), and the #1208 hotspots that need deliberate hand-conversion (`CommunityCard`, `MerchantListPanel`, `merchant/[id]/+page.svelte`, `Socials`, `area/MerchantCard`, `routes/map/+page.svelte`). Tick converted files/folders off in #1208. Never use the removed imperative component API (`new Component()`/`$destroy`) — use `mount()`/`unmount()` from `svelte`.
-- **TanStack Table v9** — every table shares the feature set from `src/lib/tableFeatures.ts` (`btcmapTableFeatures`, which registers the typed `'fuzzy'` filterFn). Create tables with `createTable({ features: btcmapTableFeatures, get data() { ... } })` getter options in a runes-mode component; read state via `table.atoms.<slice>.get()`; render with `<FlexRender header={header} />` / `<FlexRender cell={cell} />` / `renderComponent()`. No writable-options stores, no `getCoreRowModel()` — those are v8 patterns.
+- **Svelte 5, mixed-mode → runes** — the app runs Svelte 5; the table cluster (`src/routes/leaderboard`, `src/components/leaderboard/*` — except `AreaLeaderboardItemName`, `GradeDisplay`, and `LeaderboardCountryName`, which are still legacy — `IssuesTable`, `ProfileActivity`) is runes-mode, most other components are still legacy (Svelte-4 syntax). Write NEW components in runes mode (`$props`, `$state`, `$derived`, `$effect`). **Boy-scout rule: when a PR makes meaningful changes to a legacy component, convert that file to runes mode in the same PR** — as its own commit, so the conversion diff stays separately reviewable from the feature change. Conversions are whole-file (runes and legacy syntax cannot mix within one file) and include the template idioms: `on:` → event attributes, `<svelte:component>` → dynamic components, slots → snippets where practical. Exceptions — do NOT convert as a drive-by: trivial edits (a one-line fix doesn't obligate converting a large file), and the #1208 hotspots that need deliberate hand-conversion (`CommunityCard`, `MerchantListPanel`, `merchant/[id]/+page.svelte`, `Socials`, `area/MerchantCard`, `routes/map/+page.svelte`). Tick converted files/folders off in #1208. Never use the removed imperative component API (`new Component()`/`$destroy`) — use `mount()`/`unmount()` from `svelte`.
+- **TanStack Table v9** — every table shares the feature set from `src/lib/tableFeatures.ts` (`btcmapTableFeatures`, which registers the typed `'fuzzy'` filterFn). Create tables with `createTable({ features: btcmapTableFeatures, get data() { ... } })` getter options in a runes-mode component; read state via `table.atoms.<slice>.get()`; render header cells with the shared `$components/leaderboard/SortableHeaderCell.svelte` inside `<th aria-sort={resolveAriaSort(header)}>` (don't hand-roll the sort button — that duplication was removed in #1244); render body cells with `<FlexRender cell={cell} />` / `renderComponent()`. No writable-options stores, no `getCoreRowModel()` — those are v8 patterns.
 - **Tailwind v4** — uses `@tailwindcss/vite` plugin, not the v3 PostCSS setup; do not use `theme.extend` patterns from v3 docs
 - **`$components` path alias** resolves to `src/components/` — use it instead of relative paths or `$lib/components`

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Remove or comment out the env var to switch back to the production API.
    Copy `.env.example` and save as `.env`
 1. `pnpm build`
 
-_NOTE:_ BTC Map requires Node.js ≥ 22.13 (we use Node 22 LTS). If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to get the correct Node and pnpm versions. Any pnpm ≥ 10 works: pnpm reads the `packageManager` pin in `package.json` and switches to that exact version automatically, so Corepack is not needed locally (pnpm [no longer recommends it](https://pnpm.io/installation)). Netlify builds are the exception: Netlify still provisions pnpm **via Corepack** from that same `packageManager` field — so keep the field pinned to an exact version, and see the comment in `netlify.toml` for the Node-version floor this implies.
+_NOTE:_ BTC Map requires Node.js ≥ 22.13 (we use Node 22 LTS). If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to get the correct Node and pnpm versions. Any pnpm ≥ 10 works: pnpm reads the `packageManager` pin in `package.json` and switches to that exact version automatically, so Corepack is not needed locally (pnpm [no longer recommends it](https://pnpm.io/installation)). Netlify builds are the exception: Netlify still provisions pnpm [via Corepack](https://docs.netlify.com/build/configure-builds/manage-dependencies/#pnpm) from that same `packageManager` field — so keep the field pinned to an exact version, and see the comment in `netlify.toml` for the Node-version floor this implies.
 
 #### Icons
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Remove or comment out the env var to switch back to the production API.
    Copy `.env.example` and save as `.env`
 1. `pnpm build`
 
-_NOTE:_ BTC Map requires Node.js ≥ 22.13 (we use Node 22 LTS). If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to get the correct Node and pnpm versions. Any pnpm ≥ 10 works: pnpm reads the `packageManager` pin in `package.json` and switches to that exact version automatically, so Corepack is not needed (pnpm [no longer recommends it](https://pnpm.io/installation)).
+_NOTE:_ BTC Map requires Node.js ≥ 22.13 (we use Node 22 LTS). If you have [mise](https://mise.jdx.dev/), run `mise install` in the repo root to get the correct Node and pnpm versions. Any pnpm ≥ 10 works: pnpm reads the `packageManager` pin in `package.json` and switches to that exact version automatically, so Corepack is not needed locally (pnpm [no longer recommends it](https://pnpm.io/installation)). Netlify builds are the exception: Netlify still provisions pnpm **via Corepack** from that same `packageManager` field — so keep the field pinned to an exact version, and see the comment in `netlify.toml` for the Node-version floor this implies.
 
 #### Icons
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,9 +4,11 @@
 
 [build.environment]
 	# Netlify's build image provisions pnpm via Corepack (local dev doesn't
-	# need Corepack — see README). pnpm 11 needs Corepack >= 0.34.5, bundled
-	# since Node 22.22.1 — "22.22" resolves to the newest 22.22.x, which
-	# enforces that floor; a bare "22" could resolve below it.
+	# need Corepack — see README):
+	# https://docs.netlify.com/build/configure-builds/manage-dependencies/#pnpm
+	# pnpm 11 needs Corepack >= 0.34.5, bundled since Node 22.22.1 — "22.22"
+	# resolves to the newest 22.22.x, which enforces that floor; a bare "22"
+	# could resolve below it.
 	NODE_VERSION = "22.22"
 
 [images]

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,8 +3,11 @@
 	publish = "build"
 
 [build.environment]
-	# pnpm 11 needs Corepack >= 0.34.5, bundled since Node 22.22.1
-	NODE_VERSION = "22"
+	# Netlify's build image provisions pnpm via Corepack (local dev doesn't
+	# need Corepack — see README). pnpm 11 needs Corepack >= 0.34.5, bundled
+	# since Node 22.22.1 — "22.22" resolves to the newest 22.22.x, which
+	# enforces that floor; a bare "22" could resolve below it.
+	NODE_VERSION = "22.22"
 
 [images]
   remote_images = ["https://static.btcmap.org/images/.*", "https://www.openstreetmap.org/.*", "https://avatars.githubusercontent.com/.*" ]

--- a/src/components/leaderboard/SortableHeaderCell.svelte
+++ b/src/components/leaderboard/SortableHeaderCell.svelte
@@ -29,25 +29,23 @@ let { header, centered = false, trailing }: Props = $props();
 			class:mx-auto={centered}
 			class:w-fit={centered}
 		>
-			{@render sortButton(headerLabel, false)}
+			{@render headerContent(headerLabel, false)}
 			{@render trailing()}
 		</div>
 	{:else}
-		{@render sortButton(headerLabel, centered)}
+		{@render headerContent(headerLabel, centered)}
 	{/if}
 {/if}
 
-{#snippet sortButton(headerLabel: string, centerSelf: boolean)}
-	<button
-		type="button"
-		class="flex items-center gap-x-1 leading-tight select-none md:gap-x-2"
-		class:mx-auto={centerSelf}
-		class:justify-center={centerSelf}
-		class:cursor-pointer={header.column.getCanSort()}
-		onclick={header.column.getToggleSortingHandler()}
-		tabindex={header.column.getCanSort() ? 0 : -1}
-		aria-label={header.column.getCanSort()
-			? header.column.getIsSorted() === 'asc'
+{#snippet headerContent(headerLabel: string, centerSelf: boolean)}
+	{#if header.column.getCanSort()}
+		<button
+			type="button"
+			class="flex cursor-pointer items-center gap-x-1 leading-tight select-none md:gap-x-2"
+			class:mx-auto={centerSelf}
+			class:justify-center={centerSelf}
+			onclick={header.column.getToggleSortingHandler()}
+			aria-label={header.column.getIsSorted() === 'asc'
 				? $_('leaderboard.sortByCurrentlyAscending', {
 						values: { column: headerLabel },
 					})
@@ -57,16 +55,28 @@ let { header, centered = false, trailing }: Props = $props();
 						})
 					: $_('leaderboard.sortByCurrentlyUnsorted', {
 							values: { column: headerLabel },
-						})
-			: headerLabel}
-	>
-		<span class="break-words">
-			<FlexRender {header} />
+						})}
+		>
+			<span class="break-words">
+				<FlexRender {header} />
+			</span>
+			{#if header.column.getIsSorted() === 'asc'}
+				<span aria-hidden="true">▲</span>
+			{:else if header.column.getIsSorted() === 'desc'}
+				<span aria-hidden="true">▼</span>
+			{/if}
+		</button>
+	{:else}
+		<!-- Not sortable: plain text, no interactive control — a button here
+		     is a nameless no-op in the accessibility tree -->
+		<span
+			class="flex items-center gap-x-1 leading-tight select-none md:gap-x-2"
+			class:mx-auto={centerSelf}
+			class:justify-center={centerSelf}
+		>
+			<span class="break-words">
+				<FlexRender {header} />
+			</span>
 		</span>
-		{#if header.column.getIsSorted() === 'asc'}
-			<span aria-hidden="true">▲</span>
-		{:else if header.column.getIsSorted() === 'desc'}
-			<span aria-hidden="true">▼</span>
-		{/if}
-	</button>
+	{/if}
 {/snippet}


### PR DESCRIPTION
## What

Implements the actionable items from health review #1253, whose claims were fact-checked against the codebase first (13/14 verified exactly). One commit per item:

- **`ci(health-review)`: raise `MAX_FILE` 20000 → 32000** — the 23.8KB workflow file itself was skipped from full-file context, making the period's most-changed file invisible (Process Feedback #1)
- **`ci(health-review)`: rescope "never in Findings"** — coverage observations about the run stay in Process Feedback, but bugs in the now-committed workflow/script code are ordinary Findings, quotable from the review-pipeline block (Process Feedback #2). Quote verification still holds: with the raised `MAX_FILE`, a changed workflow file appears in full-file context
- **`docs(agents)`: three drift fixes** — `pnpm run typecheck` added to the pre-commit checklist and workflow steps; the runes-mode claim now names the three still-legacy files (`AreaLeaderboardItemName`, `GradeDisplay`, `LeaderboardCountryName` — the report found two, verification found the third); the TanStack v9 note now points at `SortableHeaderCell` + `resolveAriaSort` so new tables don't reintroduce the #1244 duplication
- **`ci(netlify)`: `NODE_VERSION` "22" → "22.22"** — enforces the ≥22.22.1 Corepack floor the comment requires while still receiving patch releases; the comment now scopes the Corepack statement to Netlify's build image, resolving the apparent contradiction with README (which is about local dev). Worth a glance at the deploy preview's build log to confirm the resolved Node version
- **`fix(tables)`: non-sortable headers render as plain text** — no more nameless no-op buttons in the accessibility tree for IssuesTable's blank columns (and `tip`/`location`/`position` elsewhere). Sortable headers keep the labeled button, and the split let the `canSort` conditionals for tabindex/cursor/aria-label collapse; centering classes and the tooltip-sibling wrapper are preserved

**Added after review:**

- **`ci(health-review)`: workflow source mirrored into the validator quote corpus** — closes the gap CodeRabbit flagged where a finding quoting the review-pipeline block could be silently dropped
- **`docs(readme)`: Corepack scoping** — "not needed" now says *locally*, with a cross-reference to netlify.toml, since Netlify still provisions pnpm via Corepack from the `packageManager` field (its only documented mechanism) and deleting that pin would silently drop Netlify to the image-default pnpm

## Deliberately deferred

The `$lib/types` → generated-types re-pointing (the report's other refactoring suggestion) is a standalone src refactor — verification showed `ApiLeaderboardArea` is not an exact duplicate (`icon: string` vs generated `string | null`), so consumers need null-handling. Happy to do it as its own PR.

## Verification

`pnpm run format:fix` / `check` / `typecheck` / `lint` / `test --run` (584 passing) all green — including the newly-documented `typecheck` step. Workflow YAML re-validated with `bash -n` on the earlier PRs' harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Usability Improvements**
  - Improved leaderboard table headers so sortable columns clearly appear as interactive controls.
  - Non-sortable columns now display as straightforward text instead of inactive controls.
  - Sorting labels and indicators remain visible and consistent when sorting is available.

- **Reliability**
  - Updated project validation and deployment configuration to support more consistent builds and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
