### PR TITLE
refactor(map): derive nearby list status from one enum #1171

### DIFF
--- a/src/lib/map/nearbyListStatus.test.ts
+++ b/src/lib/map/nearbyListStatus.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveNearbyListStatus } from "./nearbyListStatus";
+import { getZoomBehavior } from "./viewport";
+
+describe("deriveNearbyListStatus", () => {
+	it("returns 'loading' whenever a list fetch is in flight, regardless of residue", () => {
+		// Loading wins over below-floor and over the too-dense residue: the
+		// panel's spinner takes precedence so a stale count-only state can't
+		// flash the zoom-in link (pins the old !isLoadingList guards).
+		expect(
+			deriveNearbyListStatus({
+				behavior: "none",
+				isLoading: true,
+				merchantCount: 0,
+				totalCount: 0,
+			}),
+		).toBe("loading");
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: true,
+				merchantCount: 0,
+				totalCount: 800,
+			}),
+		).toBe("loading");
+		expect(
+			deriveNearbyListStatus({
+				behavior: "local-markers",
+				isLoading: true,
+				merchantCount: 12,
+				totalCount: 12,
+			}),
+		).toBe("loading");
+	});
+
+	it("returns 'below-floor' for behavior 'none' no matter what data lingers", () => {
+		// Stale merchants can linger during the moveend debounce after zooming
+		// out across the floor — the prompt must still show immediately.
+		expect(
+			deriveNearbyListStatus({
+				behavior: "none",
+				isLoading: false,
+				merchantCount: 0,
+				totalCount: 0,
+			}),
+		).toBe("below-floor");
+		expect(
+			deriveNearbyListStatus({
+				behavior: "none",
+				isLoading: false,
+				merchantCount: 0,
+				totalCount: 42,
+			}),
+		).toBe("below-floor");
+		expect(
+			deriveNearbyListStatus({
+				behavior: "none",
+				isLoading: false,
+				merchantCount: 3,
+				totalCount: 5,
+			}),
+		).toBe("below-floor");
+	});
+
+	it("maps the blanked-list residue (no rows, nonzero total) to 'too-dense'", () => {
+		// fetchAndReplaceList's hideIfExceeds branch and fetchCountOnly both
+		// encode "hidden" as merchants=[] with totalCount kept.
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: false,
+				merchantCount: 0,
+				totalCount: 800,
+			}),
+		).toBe("too-dense");
+		expect(
+			deriveNearbyListStatus({
+				behavior: "local-markers",
+				isLoading: false,
+				merchantCount: 0,
+				totalCount: 40,
+			}),
+		).toBe("too-dense");
+	});
+
+	it("never returns 'below-floor' when the boosts/issues override forces local-markers", () => {
+		// ?boosts=true / ?issues pin behavior to 'local-markers' at ANY zoom:
+		// a populated list renders, an empty one falls through to 'empty' —
+		// not to the zoom-in prompt (#1171 re-review constraint).
+		expect(
+			deriveNearbyListStatus({
+				behavior: "local-markers",
+				isLoading: false,
+				merchantCount: 7,
+				totalCount: 7,
+			}),
+		).toBe("ok");
+		expect(
+			deriveNearbyListStatus({
+				behavior: "local-markers",
+				isLoading: false,
+				merchantCount: 0,
+				totalCount: 0,
+			}),
+		).toBe("empty");
+	});
+
+	it("returns 'empty' when nothing is nearby", () => {
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: false,
+				merchantCount: 0,
+				totalCount: 0,
+			}),
+		).toBe("empty");
+	});
+
+	it("returns 'truncated' when the list shows fewer rows than exist", () => {
+		expect(
+			deriveNearbyListStatus({
+				behavior: "local-markers",
+				isLoading: false,
+				merchantCount: 250,
+				totalCount: 400,
+			}),
+		).toBe("truncated");
+	});
+
+	it("returns 'ok' when every match is listed", () => {
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: false,
+				merchantCount: 25,
+				totalCount: 25,
+			}),
+		).toBe("ok");
+	});
+
+	it("keeps the zoom-10 floor boundary exactly where getZoomBehavior puts it", () => {
+		// behavior === "none" ⇔ zoom < MERCHANT_LIST_LOW_ZOOM: composing with
+		// getZoomBehavior pins the boundary the panel used to check directly.
+		const at = (zoom: number) =>
+			deriveNearbyListStatus({
+				behavior: getZoomBehavior(zoom),
+				isLoading: false,
+				merchantCount: 3,
+				totalCount: 3,
+			});
+		expect(at(9.99)).toBe("below-floor");
+		expect(at(10)).toBe("ok");
+	});
+});

--- a/src/lib/map/nearbyListStatus.test.ts
+++ b/src/lib/map/nearbyListStatus.test.ts
@@ -12,6 +12,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "none",
 				isLoading: true,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 0,
 			}),
@@ -20,6 +21,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "api-with-limit",
 				isLoading: true,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 800,
 			}),
@@ -28,6 +30,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "local-markers",
 				isLoading: true,
+				hasError: false,
 				merchantCount: 12,
 				totalCount: 12,
 			}),
@@ -41,6 +44,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "none",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 0,
 			}),
@@ -49,6 +53,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "none",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 42,
 			}),
@@ -57,6 +62,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "none",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 3,
 				totalCount: 5,
 			}),
@@ -70,6 +76,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "api-with-limit",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 800,
 			}),
@@ -78,6 +85,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "local-markers",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 40,
 			}),
@@ -92,6 +100,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "local-markers",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 7,
 				totalCount: 7,
 			}),
@@ -100,6 +109,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "local-markers",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 0,
 			}),
@@ -111,6 +121,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "api-with-limit",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 0,
 				totalCount: 0,
 			}),
@@ -122,6 +133,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "local-markers",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 250,
 				totalCount: 400,
 			}),
@@ -133,6 +145,7 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: "api-with-limit",
 				isLoading: false,
+				hasError: false,
 				merchantCount: 25,
 				totalCount: 25,
 			}),
@@ -146,10 +159,77 @@ describe("deriveNearbyListStatus", () => {
 			deriveNearbyListStatus({
 				behavior: getZoomBehavior(zoom),
 				isLoading: false,
+				hasError: false,
 				merchantCount: 3,
 				totalCount: 3,
 			});
 		expect(at(9.99)).toBe("below-floor");
 		expect(at(10)).toBe("ok");
+	});
+
+	it("returns 'error' when the last fetch failed and nothing is renderable", () => {
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: false,
+				hasError: true,
+				merchantCount: 0,
+				totalCount: 0,
+			}),
+		).toBe("error");
+		// A stale too-dense claim must not outrank a known failure.
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: false,
+				hasError: true,
+				merchantCount: 0,
+				totalCount: 800,
+			}),
+		).toBe("error");
+	});
+
+	it("keeps stale rows visible after a failed refresh", () => {
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: false,
+				hasError: true,
+				merchantCount: 25,
+				totalCount: 25,
+			}),
+		).toBe("ok");
+		expect(
+			deriveNearbyListStatus({
+				behavior: "local-markers",
+				isLoading: false,
+				hasError: true,
+				merchantCount: 250,
+				totalCount: 400,
+			}),
+		).toBe("truncated");
+	});
+
+	it("loading and below-floor take precedence over error", () => {
+		expect(
+			deriveNearbyListStatus({
+				behavior: "api-with-limit",
+				isLoading: true,
+				hasError: true,
+				merchantCount: 0,
+				totalCount: 0,
+			}),
+		).toBe("loading");
+		// The local/none paths clear the flag via setMerchants, but pin the
+		// precedence anyway.
+		expect(
+			deriveNearbyListStatus({
+				behavior: "none",
+				isLoading: false,
+				hasError: true,
+				merchantCount: 0,
+				totalCount: 0,
+			}),
+		).toBe("below-floor");
 	});
 });

--- a/src/lib/map/nearbyListStatus.ts
+++ b/src/lib/map/nearbyListStatus.ts
@@ -1,0 +1,32 @@
+import type { ZoomBehavior } from "$lib/map/viewport";
+
+export type NearbyListStatus =
+	| "loading"
+	| "below-floor"
+	| "too-dense"
+	| "empty"
+	| "truncated"
+	| "ok";
+
+// The one interpretation of the nearby list's state (#1171). The store
+// encodes "hidden because too dense" as residue — merchants blanked while
+// totalCount is kept (fetchAndReplaceList's hideIfExceeds branch,
+// fetchCountOnly) — and this function is the only place that residue is
+// read back into a status. Order matters:
+// - loading first, so a stale residue can't flash the zoom-in prompt
+//   while a fetch is in flight (the old !isLoadingList guards);
+// - behavior (not raw zoom) decides below-floor, because ?boosts/?issues
+//   force local-markers at any zoom and must never see the prompt.
+export function deriveNearbyListStatus(input: {
+	behavior: ZoomBehavior;
+	isLoading: boolean;
+	merchantCount: number;
+	totalCount: number;
+}): NearbyListStatus {
+	if (input.isLoading) return "loading";
+	if (input.behavior === "none") return "below-floor";
+	if (input.merchantCount === 0 && input.totalCount > 0) return "too-dense";
+	if (input.merchantCount === 0) return "empty";
+	if (input.totalCount > input.merchantCount) return "truncated";
+	return "ok";
+}

--- a/src/lib/map/nearbyListStatus.ts
+++ b/src/lib/map/nearbyListStatus.ts
@@ -3,6 +3,7 @@ import type { ZoomBehavior } from "$lib/map/viewport";
 export type NearbyListStatus =
 	| "loading"
 	| "below-floor"
+	| "error"
 	| "too-dense"
 	| "empty"
 	| "truncated"
@@ -17,14 +18,21 @@ export type NearbyListStatus =
 //   while a fetch is in flight (the old !isLoadingList guards);
 // - behavior (not raw zoom) decides below-floor, because ?boosts/?issues
 //   force local-markers at any zoom and must never see the prompt.
+// - error surfaces only when there is nothing to render: a failed refresh
+//   with stale rows still showing stays 'ok'/'truncated' (the toast already
+//   reported the failure; replacing real data with an error card would be
+//   a regression), but a failure with an empty list must not masquerade as
+//   "empty" or as a stale too-dense claim.
 export function deriveNearbyListStatus(input: {
 	behavior: ZoomBehavior;
 	isLoading: boolean;
+	hasError: boolean;
 	merchantCount: number;
 	totalCount: number;
 }): NearbyListStatus {
 	if (input.isLoading) return "loading";
 	if (input.behavior === "none") return "below-floor";
+	if (input.hasError && input.merchantCount === 0) return "error";
 	if (input.merchantCount === 0 && input.totalCount > 0) return "too-dense";
 	if (input.merchantCount === 0) return "empty";
 	if (input.totalCount > input.merchantCount) return "truncated";

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -465,6 +465,9 @@ describe("merchantListStore", () => {
 
 				expect(errToast).not.toHaveBeenCalled();
 				expect(warnSpy).not.toHaveBeenCalled();
+				// The axios-cancel branch of isCancellation must leave
+				// listError untouched, same as the AbortError-name branch.
+				expect(get(merchantList).listError).toBe(false);
 			} finally {
 				warnSpy.mockRestore();
 			}
@@ -527,6 +530,8 @@ describe("merchantListStore", () => {
 				await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
 
 				expect(warnSpy).not.toHaveBeenCalled();
+				// Same pin as the list fetcher: axios-cancel leaves listError alone.
+				expect(get(merchantList).listError).toBe(false);
 			} finally {
 				warnSpy.mockRestore();
 			}

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -180,6 +180,17 @@ describe("merchantListStore", () => {
 			expect(state.merchants.length).toBe(5);
 			expect(state.totalCount).toBe(20);
 		});
+
+		it("should clear listError left over from a failed fetch", async () => {
+			const error = new Error("Network error");
+			(api.get as Mock).mockRejectedValueOnce(error);
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+			expect(get(merchantList).listError).toBe(true);
+
+			merchantList.setMerchants([createMockPlace()], 0, 0);
+
+			expect(get(merchantList).listError).toBe(false);
+		});
 	});
 
 	describe("merchant sorting", () => {
@@ -458,6 +469,53 @@ describe("merchantListStore", () => {
 				warnSpy.mockRestore();
 			}
 		});
+
+		it("should set listError on failure and clear isLoadingList", async () => {
+			const error = new Error("Network error");
+			(api.get as Mock).mockRejectedValueOnce(error);
+
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+			const state = get(merchantList);
+
+			expect(state.listError).toBe(true);
+			expect(state.isLoadingList).toBe(false);
+		});
+
+		it("should clear listError on a subsequent successful fetch", async () => {
+			const error = new Error("Network error");
+			(api.get as Mock).mockRejectedValueOnce(error);
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+			expect(get(merchantList).listError).toBe(true);
+
+			(api.get as Mock).mockResolvedValueOnce({ data: [] });
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).listError).toBe(false);
+		});
+
+		it("should leave listError false after a cancelled fetch (AbortError)", async () => {
+			const abortError = new Error("Aborted");
+			abortError.name = "AbortError";
+			(api.get as Mock).mockRejectedValueOnce(abortError);
+
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).listError).toBe(false);
+		});
+
+		it("should leave listError unchanged (true) after a cancelled fetch that follows a real failure", async () => {
+			const error = new Error("Network error");
+			(api.get as Mock).mockRejectedValueOnce(error);
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+			expect(get(merchantList).listError).toBe(true);
+
+			const abortError = new Error("Aborted");
+			abortError.name = "AbortError";
+			(api.get as Mock).mockRejectedValueOnce(abortError);
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).listError).toBe(true);
+		});
 	});
 
 	describe("fetchCountOnly", () => {
@@ -611,6 +669,27 @@ describe("merchantListStore", () => {
 			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
 
 			expect(errToast).not.toHaveBeenCalled();
+		});
+
+		it("should set listError on failure", async () => {
+			const error = new Error("Network error");
+			(api.get as Mock).mockRejectedValueOnce(error);
+
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).listError).toBe(true);
+		});
+
+		it("should clear listError on success", async () => {
+			const error = new Error("Network error");
+			(api.get as Mock).mockRejectedValueOnce(error);
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+			expect(get(merchantList).listError).toBe(true);
+
+			(api.get as Mock).mockResolvedValueOnce({ data: [] });
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).listError).toBe(false);
 		});
 	});
 

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -4,11 +4,8 @@ import { get, writable } from "svelte/store";
 import { API_BASE } from "$lib/api-base";
 import { buildFieldsParam, PLACE_FIELD_SETS } from "$lib/api-fields";
 import api from "$lib/axios";
-import {
-	type CategoryCounts,
-	type CategoryKey,
-	createEmptyCategoryCounts,
-} from "$lib/categoryMapping";
+import type { CategoryCounts, CategoryKey } from "$lib/categoryMapping";
+import { createEmptyCategoryCounts } from "$lib/categoryMapping";
 import { MERCHANT_LIST_MAX_ITEMS } from "$lib/constants";
 import { _ } from "$lib/i18n";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -37,6 +37,11 @@ export type MerchantListState = {
 	isLoadingList: boolean;
 	// True when fetching enriched details in background (no spinner)
 	isEnrichingDetails: boolean;
+	// True when the last list-shaping fetch (list replace or count) failed
+	// for a non-cancellation reason; cleared by every successful populate
+	// path. Enrichment failures don't set it — they degrade cosmetics
+	// (icons/addresses), not the list itself.
+	listError: boolean;
 	// Panel mode: 'nearby' for location-based list, 'search' for search results
 	mode: MerchantListMode;
 	// Search state
@@ -61,6 +66,7 @@ const initialState: MerchantListState = {
 	placeDetailsCache: new Map(),
 	isLoadingList: false,
 	isEnrichingDetails: false,
+	listError: false,
 	mode: "nearby",
 	searchQuery: "",
 	searchResults: [],
@@ -235,6 +241,7 @@ function createMerchantListStore() {
 				merchants: limited,
 				totalCount: selection.length,
 				isLoadingList: false,
+				listError: false,
 				categoryCounts: counts,
 				selectedCategory: effectiveCategory,
 			}));
@@ -301,6 +308,7 @@ function createMerchantListStore() {
 						merchants: [],
 						totalCount: preCategory.length,
 						isLoadingList: false,
+						listError: false,
 						categoryCounts: counts,
 						selectedCategory: effectiveCategory,
 					}));
@@ -318,16 +326,24 @@ function createMerchantListStore() {
 						totalCount: selection.length,
 						placeDetailsCache,
 						isLoadingList: false,
+						listError: false,
 						categoryCounts: counts,
 						selectedCategory: effectiveCategory,
 					}));
 				}
 			} catch (error) {
-				if (error instanceof Error && !isCancellation(error)) {
+				const failed = error instanceof Error && !isCancellation(error);
+				if (failed) {
 					console.warn("Failed to fetch merchant list:", error.message);
 					errToast(get(_)("errors.loadFailed"));
 				}
-				update((state) => ({ ...state, isLoadingList: false }));
+				// A cancellation is not a failure: the superseding request owns
+				// the flag, so leave whatever it decides untouched.
+				update((state) => ({
+					...state,
+					isLoadingList: false,
+					listError: failed || state.listError,
+				}));
 			}
 		},
 
@@ -386,13 +402,19 @@ function createMerchantListStore() {
 					merchants: [],
 					totalCount: recencyPlaces.length,
 					isLoadingList: false,
+					listError: false,
 					// Preserve existing categoryCounts since we don't have actual merchant data to recalculate them
 				}));
 			} catch (error) {
-				if (error instanceof Error && !isCancellation(error)) {
+				const failed = error instanceof Error && !isCancellation(error);
+				if (failed) {
 					console.warn("Failed to fetch merchant count:", error.message);
 				}
-				update((state) => ({ ...state, isLoadingList: false }));
+				update((state) => ({
+					...state,
+					isLoadingList: false,
+					listError: failed || state.listError,
+				}));
 			}
 		},
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -1369,7 +1369,7 @@ onDestroy(() => {
 	}}
 	onSearch={handlePanelSearch}
 	onRefresh={() => updateMerchantList({ force: true })}
-	{currentZoom}
+	behavior={listBehavior}
 	mapReady={styleLoaded}
 	isMobile={isMobileLayout}
 />

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -371,6 +371,18 @@ const getBufferedBoundsLngLat = (
 	};
 };
 
+// One reactive source for the list fetch behavior. Boosted-only /
+// issues-only: the bulk $places feed already holds the full filtered set
+// at every zoom, and the radius API (api-with-limit) can filter by
+// neither boost nor issue state, so force the local path — the list,
+// count, and panel status stay in sync with the filtered map.
+// MUST stay in source order above every reactive block that calls
+// updateMerchantList() synchronously (the search-exit watcher and the
+// initial-count block): Svelte 4 can't see this dependency through the
+// function body, so ordering falls back to source position.
+$: listBehavior =
+	boostsOnly || issuesOnly ? "local-markers" : getZoomBehavior(currentZoom);
+
 // Refresh the panel's nearby list based on the current viewport. Mirrors
 // /map's `updateMerchantList` minus the panel-offset bookkeeping (out of
 // scope for this commit per the parity plan).
@@ -382,16 +394,10 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 
 	const bounds = map.getBounds();
 	const center = map.getCenter();
-	// Boosted-only / issues-only: the bulk $places feed already holds the
-	// full filtered set at every zoom, and the radius API (api-with-limit)
-	// can filter by neither boost nor issue state, so force the local path
-	// so the list/count stay in sync with the filtered map.
-	const behavior =
-		boostsOnly || issuesOnly ? "local-markers" : getZoomBehavior(currentZoom);
 	const listOpen = get(merchantList).isOpen;
 	const allowHeavyFetch = opts?.force || listOpen;
 
-	switch (behavior) {
+	switch (listBehavior) {
 		case "local-markers": {
 			// Zoom 15+: filter the already-loaded $places by an expanded
 			// viewport, then enrich with names when the panel is open or we're

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -13,10 +13,12 @@ import {
 	type CategoryCounts,
 	type CategoryKey,
 } from "$lib/categoryMapping";
-import { MERCHANT_LIST_LOW_ZOOM } from "$lib/constants";
 import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
 import { createDrawerGestureController } from "$lib/drawerGestureController";
 import { _ } from "$lib/i18n";
+import type { NearbyListStatus } from "$lib/map/nearbyListStatus";
+import { deriveNearbyListStatus } from "$lib/map/nearbyListStatus";
+import type { ZoomBehavior } from "$lib/map/viewport";
 import { selectVisiblePlaces } from "$lib/map/visiblePlaces";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
 import { merchantList } from "$lib/merchantListStore";
@@ -55,8 +57,11 @@ export let onZoomToNearbyLevel: (() => void) | undefined = undefined;
 // Callbacks for hover highlighting
 export let onHoverStart: ((place: Place) => void) | undefined = undefined;
 export let onHoverEnd: ((place: Place) => void) | undefined = undefined;
-// Current zoom level to determine if we should show "zoom in" message
-export let currentZoom: number = 0;
+// Which fetch strategy the page is running for the current view — decides
+// the "zoom in" message. Defaults to "none" (safe: shows the prompt) for
+// any consumer that omits the prop; the map page always passes its
+// reactive listBehavior.
+export let behavior: ZoomBehavior = "none";
 // Search callback - called when user types in search input
 export let onSearch: ((query: string) => void) | undefined = undefined;
 // Refresh callback for category filtering
@@ -394,16 +399,19 @@ function getCategoryButtonClass(
 	return "cursor-not-allowed bg-gray-100 text-gray-400 dark:bg-white/5 dark:text-white/30";
 }
 
-// Show "zoom in" prompt when:
-// 1. Below the list floor (no data fetched at this zoom)
-// 2. Results were blanked because the area is too dense (>fetch ceiling):
-//    an empty list but a non-zero total count
-// A genuinely empty area (totalCount === 0) falls through to the
-// "No merchants visible in current view" body state instead.
-$: showZoomInMessage =
-	currentZoom < MERCHANT_LIST_LOW_ZOOM ||
-	(merchants.length === 0 && totalCount > 0);
-$: isTruncated = totalCount > merchants.length;
+// One status for the nearby list (see deriveNearbyListStatus): the enum
+// already encodes the precedence the old showZoomInMessage/isTruncated/
+// !isLoadingList guard combination spelled out inline.
+// Explicit `let` (rather than relying on Svelte's implicit reactive-var
+// declaration) so this doesn't read as an assignment to the global
+// `window.status` to tooling that doesn't understand Svelte's `$:` sugar.
+let status: NearbyListStatus;
+$: status = deriveNearbyListStatus({
+	behavior,
+	isLoading: isLoadingList,
+	merchantCount: merchants.length,
+	totalCount,
+});
 
 // Body scroll lock on mobile when panel is open
 $: if (browser && isOpen !== undefined) {
@@ -663,15 +671,13 @@ onDestroy(() => {
 						{:else}
 							{$_('search.resultsCount', { values: { count: searchResults.length } })}
 						{/if}
-					{:else if showZoomInMessage && !isLoadingList}
-						<!-- Loading spinner takes precedence so a stale count-only state
-						     can't flash this link (mirrors the body branch below) -->
+					{:else if status === 'below-floor' || status === 'too-dense'}
 						<button
 							on:click={handleZoomToNearbyLevel}
 							class="text-link underline-offset-2 hover:underline dark:text-white"
 							>{$_('search.zoomIn')}</button
 						>
-					{:else if isTruncated}
+					{:else if status === 'truncated'}
 						{$_('search.showingNearest', { values: { count: merchants.length } })}
 					{/if}
 				</p>
@@ -787,9 +793,8 @@ onDestroy(() => {
 						{/each}
 					</ul>
 				{/if}
-			{:else if showZoomInMessage && !isLoadingList}
-				<!-- Nearby mode: clickable zoom in prompt (loading spinner takes
-				     precedence so a stale count-only state can't flash this) -->
+			{:else if status === 'below-floor' || status === 'too-dense'}
+				<!-- Nearby mode: clickable zoom in prompt -->
 				<button
 					type="button"
 					on:click={handleZoomToNearbyLevel}
@@ -809,7 +814,7 @@ onDestroy(() => {
 						</p>
 					</div>
 				</button>
-			{:else if isLoadingList}
+			{:else if status === 'loading'}
 				<div
 					class="flex items-center justify-center py-8"
 					role="status"
@@ -817,26 +822,24 @@ onDestroy(() => {
 				>
 					<LoadingSpinner color="text-link dark:text-white" size="h-6 w-6" />
 				</div>
+			{:else if status === 'empty'}
+				<div class="px-3 py-8 text-center text-sm text-body dark:text-white/70">
+					{$_('search.noVisible')}
+				</div>
 			{:else}
-				<!-- Nearby mode: merchant list -->
-				{#if merchants.length === 0}
-					<div class="px-3 py-8 text-center text-sm text-body dark:text-white/70">
-						{$_('search.noVisible')}
-					</div>
-				{:else}
-					<ul class="flex flex-col gap-2 bg-neutral-50 p-2 dark:bg-white/10">
-						{#each merchants as merchant (merchant.id)}
-							<MerchantListItem
-								{merchant}
-								enrichedData={placeDetailsCache.get(merchant.id) || null}
-								isSelected={selectedId === merchant.id}
-								onclick={handleItemClick}
-								onmouseenter={handleMouseEnter}
-								onmouseleave={handleMouseLeave}
-							/>
-						{/each}
-					</ul>
-				{/if}
+				<!-- Nearby mode: merchant list ('truncated' and 'ok') -->
+				<ul class="flex flex-col gap-2 bg-neutral-50 p-2 dark:bg-white/10">
+					{#each merchants as merchant (merchant.id)}
+						<MerchantListItem
+							{merchant}
+							enrichedData={placeDetailsCache.get(merchant.id) || null}
+							isSelected={selectedId === merchant.id}
+							onclick={handleItemClick}
+							onmouseenter={handleMouseEnter}
+							onmouseleave={handleMouseLeave}
+						/>
+					{/each}
+				</ul>
 			{/if}
 		</div>
 		{:else}

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -309,7 +309,11 @@ $: mode = $merchantList.mode;
 // mobile peek/input pills) has nowhere else to carry it once the floating bar
 // unmounts. Empty in search mode, while loading, or when there's nothing nearby.
 $: nearbyCountLabel =
-	mode === "nearby" && !isLoadingList && totalCount > 0 && pillCount
+	mode === "nearby" &&
+	!isLoadingList &&
+	nearbyStatus !== "error" &&
+	totalCount > 0 &&
+	pillCount
 		? $_("search.nearbyCount", { values: { count: pillCount } })
 		: "";
 $: searchResults = $merchantList.searchResults;

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -16,7 +16,6 @@ import {
 import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
 import { createDrawerGestureController } from "$lib/drawerGestureController";
 import { _ } from "$lib/i18n";
-import type { NearbyListStatus } from "$lib/map/nearbyListStatus";
 import { deriveNearbyListStatus } from "$lib/map/nearbyListStatus";
 import type { ZoomBehavior } from "$lib/map/viewport";
 import { selectVisiblePlaces } from "$lib/map/visiblePlaces";
@@ -402,11 +401,7 @@ function getCategoryButtonClass(
 // One status for the nearby list (see deriveNearbyListStatus): the enum
 // already encodes the precedence the old showZoomInMessage/isTruncated/
 // !isLoadingList guard combination spelled out inline.
-// Explicit `let` (rather than relying on Svelte's implicit reactive-var
-// declaration) so this doesn't read as an assignment to the global
-// `window.status` to tooling that doesn't understand Svelte's `$:` sugar.
-let status: NearbyListStatus;
-$: status = deriveNearbyListStatus({
+$: nearbyStatus = deriveNearbyListStatus({
 	behavior,
 	isLoading: isLoadingList,
 	merchantCount: merchants.length,
@@ -671,13 +666,13 @@ onDestroy(() => {
 						{:else}
 							{$_('search.resultsCount', { values: { count: searchResults.length } })}
 						{/if}
-					{:else if status === 'below-floor' || status === 'too-dense'}
+					{:else if nearbyStatus === 'below-floor' || nearbyStatus === 'too-dense'}
 						<button
 							on:click={handleZoomToNearbyLevel}
 							class="text-link underline-offset-2 hover:underline dark:text-white"
 							>{$_('search.zoomIn')}</button
 						>
-					{:else if status === 'truncated'}
+					{:else if nearbyStatus === 'truncated'}
 						{$_('search.showingNearest', { values: { count: merchants.length } })}
 					{/if}
 				</p>
@@ -793,7 +788,7 @@ onDestroy(() => {
 						{/each}
 					</ul>
 				{/if}
-			{:else if status === 'below-floor' || status === 'too-dense'}
+			{:else if nearbyStatus === 'below-floor' || nearbyStatus === 'too-dense'}
 				<!-- Nearby mode: clickable zoom in prompt -->
 				<button
 					type="button"
@@ -814,7 +809,7 @@ onDestroy(() => {
 						</p>
 					</div>
 				</button>
-			{:else if status === 'loading'}
+			{:else if nearbyStatus === 'loading'}
 				<div
 					class="flex items-center justify-center py-8"
 					role="status"
@@ -822,7 +817,7 @@ onDestroy(() => {
 				>
 					<LoadingSpinner color="text-link dark:text-white" size="h-6 w-6" />
 				</div>
-			{:else if status === 'empty'}
+			{:else if nearbyStatus === 'empty'}
 				<div class="px-3 py-8 text-center text-sm text-body dark:text-white/70">
 					{$_('search.noVisible')}
 				</div>

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -302,6 +302,7 @@ $: if (isMobile && $merchantDrawer.isOpen) {
 $: pillCount = formatNearbyPillCount(totalCount);
 $: placeDetailsCache = $merchantList.placeDetailsCache;
 $: isLoadingList = $merchantList.isLoadingList;
+$: listError = $merchantList.listError;
 $: selectedId = $merchantDrawer.merchantId;
 $: mode = $merchantList.mode;
 // Nearby count line shown inside the open panel on desktop, which (unlike the
@@ -401,6 +402,7 @@ function getCategoryButtonClass(
 $: nearbyStatus = deriveNearbyListStatus({
 	behavior,
 	isLoading: isLoadingList,
+	hasError: listError,
 	merchantCount: merchants.length,
 	totalCount,
 });
@@ -817,6 +819,10 @@ onDestroy(() => {
 					aria-label={$_('aria.loading')}
 				>
 					<LoadingSpinner color="text-link dark:text-white" size="h-6 w-6" />
+				</div>
+			{:else if nearbyStatus === 'error'}
+				<div class="px-3 py-8 text-center text-sm text-body dark:text-white/70">
+					{$_('errors.loadFailed')}
 				</div>
 			{:else if nearbyStatus === 'empty'}
 				<div class="px-3 py-8 text-center text-sm text-body dark:text-white/70">

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -8,11 +8,8 @@ import LoadingSpinner from "$components/LoadingSpinner.svelte";
 import SearchInput from "$components/SearchInput.svelte";
 import { trackEvent } from "$lib/analytics";
 import { lockBodyScroll, unlockBodyScroll } from "$lib/bodyScrollLock";
-import {
-	CATEGORY_ENTRIES,
-	type CategoryCounts,
-	type CategoryKey,
-} from "$lib/categoryMapping";
+import type { CategoryCounts, CategoryKey } from "$lib/categoryMapping";
+import { CATEGORY_ENTRIES } from "$lib/categoryMapping";
 import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
 import { createDrawerGestureController } from "$lib/drawerGestureController";
 import { _ } from "$lib/i18n";

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -404,6 +404,10 @@ $: nearbyStatus = deriveNearbyListStatus({
 	merchantCount: merchants.length,
 	totalCount,
 });
+// The two hidden-behind-the-prompt statuses render identically in the
+// status row and the body — name the condition once.
+$: showsZoomPrompt =
+	nearbyStatus === "below-floor" || nearbyStatus === "too-dense";
 
 // Body scroll lock on mobile when panel is open
 $: if (browser && isOpen !== undefined) {
@@ -663,7 +667,7 @@ onDestroy(() => {
 						{:else}
 							{$_('search.resultsCount', { values: { count: searchResults.length } })}
 						{/if}
-					{:else if nearbyStatus === 'below-floor' || nearbyStatus === 'too-dense'}
+					{:else if showsZoomPrompt}
 						<button
 							on:click={handleZoomToNearbyLevel}
 							class="text-link underline-offset-2 hover:underline dark:text-white"
@@ -785,7 +789,7 @@ onDestroy(() => {
 						{/each}
 					</ul>
 				{/if}
-			{:else if nearbyStatus === 'below-floor' || nearbyStatus === 'too-dense'}
+			{:else if showsZoomPrompt}
 				<!-- Nearby mode: clickable zoom in prompt -->
 				<button
 					type="button"


### PR DESCRIPTION
## Summary

Completes the second half of #1171 (the first half — one private radius fetcher — landed in #1196): the nearby list's status ("zoom in" / too-dense / truncated / empty / **error**) is now one unit-tested enum instead of being decided in three places (store residue, page-private fetch behavior, panel residue-sniffing with duplicated `!isLoadingList` guards).

- **`src/lib/map/nearbyListStatus.ts`** — `deriveNearbyListStatus({behavior, isLoading, hasError, merchantCount, totalCount})` → `'loading' | 'below-floor' | 'error' | 'too-dense' | 'empty' | 'truncated' | 'ok'`; the store's blank-list residue is read back in exactly one place. Table-driven tests pin all seven statuses, precedence (loading and below-floor over error; error over stale too-dense residue), the override cases, and the zoom-10 boundary via `getZoomBehavior`.
- **`map/+page.svelte`** — the fetch behavior (zoom tiers + `?boosts`/`?issues` → local-markers override) is computed in one reactive statement, consumed by both `updateMerchantList` and the panel's `behavior` prop. Placed above the reactive blocks that call `updateMerchantList()` synchronously (Svelte 4 can't see the dependency through the function body).
- **`MerchantListPanel.svelte`** — renders nearby mode purely from the enum (`nearbyStatus`); the `currentZoom` prop and `MERCHANT_LIST_LOW_ZOOM` import are gone (the threshold now lives only in `getZoomBehavior`). Search mode untouched. No runes conversion (#1208 hotspot list).
- **`merchantListStore.ts`** — one new field, `listError`: set when `fetchAndReplaceList`/`fetchCountOnly` fail for a non-cancellation reason, cleared by every successful populate path (`setMerchants` included), untouched by cancellations and by the cosmetic `fetchEnrichedDetails`. The issue scoped the enum as "loading/hidden/empty/error"; error was missing because the store never recorded failure. No other store behavior changed; the existing warn/toast policies are preserved exactly.
- **No i18n changes** — the panel's error state reuses `errors.loadFailed`, the same key as the existing failure toast.

Honors the 2026-08-03 re-review constraints: below-floor derives from the *behavior* (so the `?boosts`/`?issues` override is respected), and the prompt still reacts to the live moveend-maintained zoom, not the debounced refresh.

## Intended behavior deltas (everything else verified pixel-identical)

1. `?boosts=true` / `?issues` at zoom < 10: the populated filtered list (or a genuine empty state) shows instead of a "zoom in" prompt covering it — previously the prompt contradicted the desktop "N nearby" label. Bounded: the list slices at `MERCHANT_LIST_MAX_ITEMS` (250) with a correct "Showing nearest 250" line.
2. While loading, the status row no longer leaks a stale "Showing nearest N" line (previously it could read "Showing nearest 0" when opening the panel at zoom 10-14 from a count-only state).
3. A failed fetch with nothing to render shows the failure message instead of the false "No merchants visible in current view" (or a stale too-dense claim). Stale rows from a previous successful fetch keep rendering after a failed refresh — the toast already reported the failure, matching the old keep-data behavior — and the desktop "N nearby" line is suppressed while the error state shows.

## Post-review commits

The last seven commits act on an external review of the first three: `status` → `nearbyStatus` (deletes the `noGlobalAssign` workaround entirely), type/value import splits in the panel and store, a named `showsZoomPrompt` condition, and the error status above.

## Test plan

- `pnpm run test --run` — 602/602 green; table-driven derivation tests plus 7 new store tests for the `listError` lifecycle (failure sets, success clears, both cancellation branches leave it untouched, `setMerchants` clears).
- Full pre-commit suite green on every commit (`format:fix`, `check`, `typecheck`, `lint`, unit tests).
- e2e checked for exposure: the "Zoom in" locators target the MapLibre nav control at zoom 17, where the panel prompt cannot appear; no spec asserts the changed strings.
- Adversarially reviewed twice: truth-table parity re-derived independently (only the intended deltas diverge); the reactive `listBehavior` read verified stale-free against every call site; the store catch-path rewrite verified to preserve the old warn/toast/loading behavior with `listError` as the only new effect.

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)