### PR TITLE
refactor(map): searchSession — search races behind one interface #1173

### DIFF
--- a/src/lib/merchantListStore.search.test.ts
+++ b/src/lib/merchantListStore.search.test.ts
@@ -1,0 +1,340 @@
+import { get } from "svelte/store";
+import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Place } from "$lib/types";
+
+// Mock the centralized axios instance
+vi.mock("$lib/axios", () => ({
+	default: {
+		get: vi.fn(),
+		post: vi.fn(),
+	},
+}));
+
+import api from "$lib/axios";
+
+// Mock i18n to avoid intl-messageformat module resolution in tests
+vi.mock("$lib/i18n", () => {
+	const { writable } = require("svelte/store");
+	const mockT = (key: string) => key;
+	return { _: writable(mockT) };
+});
+
+// Mock errToast and let calculateDistance/debounce pass through unmocked —
+// the debounce IS the thing under test.
+vi.mock("$lib/utils", async () => {
+	const actual = await vi.importActual("$lib/utils");
+	return {
+		...actual,
+		errToast: vi.fn(),
+	};
+});
+
+// Mock isBoosted from merchantDrawerLogic — merchantListStore imports it
+// unconditionally, and the real module pulls in $app/environment
+// transitively (merchantDrawerHash.ts), which crashes at import time
+// outside a SvelteKit runtime.
+vi.mock("$lib/merchantDrawerLogic", () => ({
+	isBoosted: (place: Place) =>
+		place.boosted_until && new Date(place.boosted_until) > new Date(),
+}));
+
+// Hoisted so the vi.mock factory below can reference it before module init
+const { mockUserLocationStore } = vi.hoisted(() => {
+	const { writable } = require("svelte/store");
+	return {
+		mockUserLocationStore: writable({
+			location: null as { lat: number; lon: number } | null,
+			lastUpdated: null as number | null,
+			usesMetricSystem: null as boolean | null,
+		}),
+	};
+});
+
+// Mock userLocationStore - matches real module shape: { subscribe, getLocationWithCache, setLocation }
+vi.mock("$lib/userLocationStore", () => {
+	return {
+		userLocation: {
+			subscribe: mockUserLocationStore.subscribe,
+			getLocationWithCache: vi.fn().mockResolvedValue(null),
+			setLocation: vi.fn(),
+		},
+	};
+});
+
+vi.mock("$lib/merchantDrawerStore", () => ({
+	merchantDrawer: { close: vi.fn(), open: vi.fn() },
+}));
+vi.mock("$lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+import { trackEvent } from "$lib/analytics";
+import { merchantDrawer } from "$lib/merchantDrawerStore";
+import { errToast } from "$lib/utils";
+
+// Import after mocks are set up
+import { merchantList } from "./merchantListStore";
+
+const okResponse = (places: unknown[], total = places.length) =>
+	new Response(JSON.stringify({ places, total }), { status: 200 });
+
+const place = (id: number, name = `Place ${id}`) =>
+	({ id, name, lat: 1, lon: 2, icon: "store", tags: {} }) as unknown as Place;
+
+// search() arms a 300 ms trailing debounce; dispatch = advance past it and
+// flush the async fetch chain.
+const dispatch = () => vi.advanceTimersByTimeAsync(300);
+
+describe("merchantListStore — searchSession", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.stubGlobal("fetch", vi.fn().mockResolvedValue(okResponse([])));
+		merchantList.reset();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	it("search() writes the raw query synchronously", () => {
+		merchantList.search("  El Zonte");
+
+		expect(get(merchantList).searchQuery).toBe("  El Zonte");
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("short queries fall back to nearby without touching results or isOpen", async () => {
+		merchantList.openWithSearchResults("prev", [place(1)]);
+
+		merchantList.search("ab");
+		const state = get(merchantList);
+
+		expect(state.mode).toBe("nearby");
+		expect(state.searchQuery).toBe("ab");
+		expect(state.searchResults.length).toBe(1);
+		expect(state.searchTotal).toBe(1);
+		expect(state.isOpen).toBe(true);
+
+		await dispatch();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("a short query cancels an armed search", async () => {
+		merchantList.search("El Zonte", {});
+		merchantList.search("El");
+
+		await dispatch();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("dispatch happens once, 300 ms after the last keystroke", async () => {
+		merchantList.search("El Zo");
+		merchantList.search("El Zon");
+		merchantList.search("El Zonte");
+
+		expect(get(merchantList).isSearching).toBe(false);
+		expect(fetch).not.toHaveBeenCalled();
+
+		await dispatch();
+
+		expect(fetch).toHaveBeenCalledTimes(1);
+		const url = (fetch as Mock).mock.calls[0][0] as string;
+		expect(new URL(url, "http://localhost").searchParams.get("name")).toBe(
+			"El Zonte",
+		);
+	});
+
+	it("dispatch-time side effects fire at dispatch, not at the keystroke", async () => {
+		merchantList.search("El Zonte");
+
+		expect(trackEvent).not.toHaveBeenCalled();
+		expect(merchantDrawer.close).not.toHaveBeenCalled();
+		expect(get(merchantList).isSearching).toBe(false);
+
+		await dispatch();
+
+		expect(trackEvent).toHaveBeenCalledTimes(1);
+		expect(merchantDrawer.close).toHaveBeenCalledTimes(1);
+		const state = get(merchantList);
+		expect(state.mode).toBe("search");
+		expect(state.isOpen).toBe(true);
+	});
+
+	it("getCenter is evaluated at dispatch time and omitted when undefined", async () => {
+		let center: { lat: number; lon: number } | undefined;
+		merchantList.search("El Zonte", { getCenter: () => center });
+		center = { lat: 9, lon: -89 };
+
+		await dispatch();
+
+		const firstUrl = (fetch as Mock).mock.calls[0][0] as string;
+		const firstParams = new URL(firstUrl, "http://localhost").searchParams;
+		expect(firstParams.get("lat")).toBe("9");
+		expect(firstParams.get("lon")).toBe("-89");
+
+		merchantList.search("Other query", { getCenter: () => undefined });
+		await dispatch();
+
+		const secondUrl = (fetch as Mock).mock.calls[1][0] as string;
+		const secondParams = new URL(secondUrl, "http://localhost").searchParams;
+		expect(secondParams.has("lat")).toBe(false);
+		expect(secondParams.has("lon")).toBe(false);
+	});
+
+	it("a successful response opens the results", async () => {
+		(fetch as Mock).mockResolvedValue(okResponse([place(1), place(2)], 40));
+
+		merchantList.search("El Zonte");
+		await dispatch();
+
+		const state = get(merchantList);
+		expect(state.searchResults.length).toBe(2);
+		expect(state.searchTotal).toBe(40);
+		expect(state.isSearching).toBe(false);
+		expect(state.mode).toBe("search");
+		expect(state.isOpen).toBe(true);
+	});
+
+	it("a response for a superseded query is dropped", async () => {
+		let resolveFetch!: (value: Response) => void;
+		(fetch as Mock).mockImplementationOnce(
+			() =>
+				new Promise<Response>((resolve) => {
+					resolveFetch = resolve;
+				}),
+		);
+
+		merchantList.search("kiosk");
+		await dispatch(); // request now in flight
+
+		merchantList.search("kiosk hamburg"); // writes new query, arms new debounce
+
+		resolveFetch(okResponse([place(1)], 1));
+		await vi.advanceTimersByTimeAsync(0);
+
+		const state = get(merchantList);
+		expect(state.searchQuery).toBe("kiosk hamburg");
+		expect(state.searchResults).toEqual([]);
+	});
+
+	it("a late response after close cannot reopen the panel", async () => {
+		let resolveFetch!: (value: Response) => void;
+		(fetch as Mock).mockImplementationOnce(
+			() =>
+				new Promise<Response>((resolve) => {
+					resolveFetch = resolve;
+				}),
+		);
+
+		merchantList.search("El Zonte");
+		await dispatch(); // request in flight, abort signal ignored by the mock
+
+		merchantList.close();
+		resolveFetch(okResponse([place(1)], 1));
+		await vi.advanceTimersByTimeAsync(0);
+
+		const state = get(merchantList);
+		expect(state.isOpen).toBe(false);
+		expect(state.mode).toBe("nearby");
+		expect(state.searchResults).toEqual([]);
+	});
+
+	it("abort errors are silent", async () => {
+		// jsdom's DOMException does not extend Error (unlike Node's native
+		// DOMException and real browsers, verified separately) — construct the
+		// rejection the way the rest of this suite already does, so we exercise
+		// the store's `error instanceof Error && error.name === "AbortError"`
+		// guard without that environment artifact.
+		const abortError = new Error("aborted");
+		abortError.name = "AbortError";
+		(fetch as Mock).mockRejectedValue(abortError);
+
+		merchantList.search("El Zonte");
+		await dispatch();
+
+		expect(errToast).not.toHaveBeenCalled();
+		// TODAY's ported behavior: the AbortError branch returns early, before
+		// setSearchModeOpen(false) — the aborting caller owns clearing the
+		// spinner, so isSearching stays true from setSearchModeOpen(true) at
+		// dispatch.
+		expect(get(merchantList).isSearching).toBe(true);
+	});
+
+	it("failures toast and clear the spinner but keep query and mode", async () => {
+		(fetch as Mock).mockResolvedValue(new Response("", { status: 502 }));
+
+		merchantList.search("El Zonte");
+		await dispatch();
+
+		expect(errToast).toHaveBeenCalledTimes(1);
+		const state = get(merchantList);
+		expect(state.isSearching).toBe(false);
+		expect(state.mode).toBe("search");
+		expect(state.searchQuery).toBe("El Zonte");
+		expect(state.isOpen).toBe(true);
+	});
+
+	it("a failure for a superseded query is silent", async () => {
+		let resolveFetch!: (value: Response) => void;
+		(fetch as Mock).mockImplementationOnce(
+			() =>
+				new Promise<Response>((resolve) => {
+					resolveFetch = resolve;
+				}),
+		);
+
+		merchantList.search("kiosk");
+		await dispatch();
+
+		merchantList.search("kiosk hamburg");
+
+		resolveFetch(new Response("", { status: 502 }));
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(errToast).not.toHaveBeenCalled();
+	});
+
+	it("cancelSearch() cancels an armed search", async () => {
+		merchantList.search("El Zonte");
+		merchantList.cancelSearch();
+
+		await dispatch();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("close() cancels the pending search but not the list fetch", async () => {
+		let listAborted = false;
+		(api.get as Mock).mockImplementationOnce(
+			(_url: string, config: { signal: AbortSignal }) =>
+				new Promise((resolve) => {
+					config.signal.addEventListener("abort", () => {
+						listAborted = true;
+					});
+					setTimeout(() => resolve({ data: [] }), 50);
+				}),
+		);
+
+		merchantList.search("El Zonte");
+		const listPromise = merchantList.fetchAndReplaceList(
+			{ lat: 0, lon: 0 },
+			10,
+		);
+		merchantList.close();
+
+		await dispatch();
+		await listPromise;
+
+		expect(fetch).not.toHaveBeenCalled();
+		expect(listAborted).toBe(false);
+	});
+
+	it("reset() cancels an armed search", async () => {
+		merchantList.search("El Zonte");
+		merchantList.reset();
+
+		await dispatch();
+		expect(fetch).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/merchantListStore.search.test.ts
+++ b/src/lib/merchantListStore.search.test.ts
@@ -219,6 +219,27 @@ describe("merchantListStore — searchSession", () => {
 		expect(state.searchResults).toEqual([]);
 	});
 
+	it("a new dispatch aborts the previous in-flight request", async () => {
+		// Two full pause-dispatch cycles: the second dispatch must abort the
+		// first request's signal (executeSearch's opening cancel is the only
+		// thing preventing two concurrent in-flight searches).
+		const signals: AbortSignal[] = [];
+		(fetch as Mock).mockImplementation((_url: string, init: RequestInit) => {
+			signals.push(init.signal as AbortSignal);
+			return new Promise<Response>(() => {});
+		});
+
+		merchantList.search("first query");
+		await dispatch(); // first request in flight
+
+		merchantList.search("second query");
+		await dispatch();
+
+		expect(signals.length).toBe(2);
+		expect(signals[0].aborted).toBe(true);
+		expect(signals[1].aborted).toBe(false);
+	});
+
 	it("a late response after close cannot reopen the panel", async () => {
 		let resolveFetch!: (value: Response) => void;
 		(fetch as Mock).mockImplementationOnce(

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -45,6 +45,14 @@ vi.mock("$lib/merchantDrawerLogic", () => ({
 		place.boosted_until && new Date(place.boosted_until) > new Date(),
 }));
 
+// merchantListStore's new imports (#1173) drag $app/environment into the
+// graph via merchantDrawerStore/merchantDrawerHash, which crashes at import
+// time under vitest without these.
+vi.mock("$lib/merchantDrawerStore", () => ({
+	merchantDrawer: { close: vi.fn(), open: vi.fn() },
+}));
+vi.mock("$lib/analytics", () => ({ trackEvent: vi.fn() }));
+
 // Hoisted so the vi.mock factory below can reference it before module init
 const { mockUserLocationStore } = vi.hoisted(() => {
 	const { writable } = require("svelte/store");

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { get, writable } from "svelte/store";
 
+import { trackEvent } from "$lib/analytics";
 import { API_BASE } from "$lib/api-base";
 import { buildFieldsParam, PLACE_FIELD_SETS } from "$lib/api-fields";
 import api from "$lib/axios";
@@ -15,14 +16,21 @@ import {
 } from "$lib/map/verifiedFilter";
 import { selectVisiblePlaces } from "$lib/map/visiblePlaces";
 import { isBoosted } from "$lib/merchantDrawerLogic";
+import { merchantDrawer } from "$lib/merchantDrawerStore";
 import { verifiedDatesLoaded } from "$lib/store";
 import type { Place } from "$lib/types";
 import type { UserLocation } from "$lib/userLocationStore";
 import { userLocation } from "$lib/userLocationStore";
-import { calculateDistance, errToast } from "$lib/utils";
+import { calculateDistance, debounce, errToast } from "$lib/utils";
 import { filterPlacesByRecency } from "$lib/verification";
 
 export type MerchantListMode = "nearby" | "search";
+
+// The page supplies the live map centre lazily: the session evaluates the
+// getter at dispatch time (the map can pan during the debounce window), and
+// it returns undefined until the map initialises — the search box is
+// reachable before that.
+export type SearchCenterGetter = () => { lat: number; lon: number } | undefined;
 
 export type MerchantListState = {
 	isOpen: boolean;
@@ -182,6 +190,173 @@ function createMerchantListStore() {
 		cancelDetailsRequest();
 	}
 
+	// Open panel with search results (boosted first, then the server's order)
+	function applySearchResults(
+		query: string,
+		results: Place[],
+		total: number = results.length,
+	) {
+		// The server already ordered these by relevance (exact name match, then
+		// prefix, then substring, then a hit on any other tag) with proximity to
+		// the map centre as the tiebreak. Preserve that — re-sorting by distance
+		// or alphabetically, as the nearby list does, would discard it and bury
+		// an exact name match. Only boosted places are promoted above it.
+		// Array.sort is stable, so equal-boost rows keep the server's order.
+		const sortedResults = [...results].sort((a, b) => {
+			if (isBoosted(a) && !isBoosted(b)) return -1;
+			if (!isBoosted(a) && isBoosted(b)) return 1;
+			return 0;
+		});
+		// Counts come from the shared pipeline on the recency-filtered set;
+		// the panel renders the same pipeline's selection
+		// (filteredSearchResults), so chips and rows can never disagree.
+		const { verifiedWithinYears } = get(store);
+		const { counts: categoryCounts } = selectVisiblePlaces({
+			places: sortedResults,
+			mode: "search",
+			category: "all",
+			recency: verifiedWithinYears,
+			recencyReady: true,
+			boostsOnly: false,
+			issuesOnly: false,
+			issuesReady: true,
+		});
+		update((state) => ({
+			...resetCategoryState(state),
+			isOpen: true,
+			mode: "search",
+			searchQuery: query,
+			searchResults: sortedResults,
+			// Total matches on the server, which can exceed what it returned —
+			// the panel shows "N of TOTAL" so truncation isn't silent.
+			searchTotal: total,
+			isSearching: false,
+			categoryCounts,
+		}));
+	}
+
+	// Open panel in search mode, optionally showing spinner
+	// Use setSearchModeOpen() to open panel ready for input (no spinner)
+	// Use setSearchModeOpen(true) when a search is in progress (shows spinner)
+	function setSearchModeOpen(isSearching: boolean = false) {
+		update((state) => ({
+			...state,
+			isSearching,
+			mode: "search",
+			isOpen: true,
+		}));
+	}
+
+	// --- searchSession (#1173) --------------------------------------------
+	// The whole search request lifecycle in one place: the debounce, the
+	// abort, and every staleness/open guard. search() is the single entry
+	// point AND the sole writer of searchQuery — nothing outside the session
+	// can update the query without it knowing (the PR #1126 input-clobber
+	// class this extraction exists to prevent).
+	let searchAbortController: AbortController | null = null;
+
+	function cancelSearchRequest() {
+		if (searchAbortController) {
+			searchAbortController.abort();
+			searchAbortController = null;
+		}
+	}
+
+	// Ported verbatim from map/+page.svelte's executeSearch — abort any
+	// prior request, fetch via the SvelteKit endpoint, hand results to the
+	// store. Errors surface as toasts.
+	const executeSearch = async (
+		query: string,
+		getCenter?: SearchCenterGetter,
+	) => {
+		cancelSearchRequest();
+		// Trim so the request matches the dispatch decision (search() gates
+		// on the trimmed length) — otherwise "  abc" is sent verbatim as
+		// %20%20abc.
+		const trimmed = query.trim();
+		if (trimmed.length < 3) return;
+
+		trackEvent("search_query");
+		searchAbortController = new AbortController();
+
+		// Close any drawer so it doesn't sit on top of the result list.
+		merchantDrawer.close();
+		setSearchModeOpen(true);
+
+		// The server breaks relevance ties by proximity to this point,
+		// mirroring the original client-side search, which ranked purely by
+		// distance from the map centre. Without it, a query like "hamburg" —
+		// which no place is named — leaves every match tied at the lowest
+		// rank, and the result cap selects among them by name length.
+		// getCenter runs HERE, at dispatch time, not at the keystroke that
+		// armed the debounce: the map can pan during the 300 ms window, and
+		// the page-level code this replaces read the live centre at this
+		// exact moment. Undefined (map not initialised) omits both params —
+		// the API rejects a lone coordinate.
+		const searchParams = new URLSearchParams({ name: trimmed });
+		const center = getCenter?.();
+		if (center) {
+			searchParams.set("lat", String(center.lat));
+			searchParams.set("lon", String(center.lon));
+		}
+
+		try {
+			const response = await fetch(`/api/search/places?${searchParams}`, {
+				signal: searchAbortController.signal,
+			});
+			if (!response.ok) throw new Error("Search API error");
+			// `total` is the server's full match count, which can exceed the
+			// rows it returned — the panel reports the gap rather than hiding
+			// the truncation.
+			const { places: results, total }: { places: Place[]; total: number } =
+				await response.json();
+			// The panel/sheet may have been closed while we were awaiting the
+			// response (abort only rejects the fetch, not the json() window).
+			// Don't let a late result reopen it.
+			if (!get(store).isOpen) return;
+			// The user kept typing while this request was in flight, so it
+			// answers a query that is no longer on screen. Continuous typing
+			// keeps re-arming the debounce, so no newer request dispatched to
+			// abort this one. Dropping it here matters beyond stale results:
+			// applySearchResults writes `query` back into searchQuery, which
+			// feeds the search input's `value` prop — applying it would
+			// rewrite the input mid-word and reset the caret.
+			if (get(store).searchQuery !== query) return;
+			applySearchResults(query, results, total);
+		} catch (error) {
+			if (error instanceof Error && error.name === "AbortError") return;
+			// Same staleness check as the success path. The user has typed
+			// past this query, so a newer request is already scheduled or in
+			// flight: toasting would report a failure for a query that is no
+			// longer on screen, and setSearchModeOpen(false) below would clear
+			// the spinner out from under the newer search. That search reports
+			// its own failure if it also fails.
+			if (get(store).searchQuery !== query) return;
+			console.error("Search error:", error);
+			errToast(get(_)("errors.searchUnavailable"));
+			// Mirror the success-path guard: if the panel was closed/collapsed
+			// while the request was in flight, a non-abort failure must not
+			// pop it back open.
+			if (!get(store).isOpen) return;
+			// Keep the user's typed query (and search mode) — a transient
+			// failure shouldn't wipe the input or silently drop them back to
+			// nearby.
+			setSearchModeOpen(false);
+		}
+	};
+
+	const debouncedExecuteSearch = debounce(
+		(query: string, getCenter?: SearchCenterGetter) => {
+			void executeSearch(query, getCenter);
+		},
+		300,
+	);
+
+	function cancelSearchSession() {
+		debouncedExecuteSearch.cancel();
+		cancelSearchRequest();
+	}
+
 	return {
 		subscribe,
 
@@ -191,6 +366,10 @@ function createMerchantListStore() {
 
 		// Hide the panel, reset category filter and search state, but keep merchant data (count visible on button)
 		close() {
+			// Closing/collapsing discards any pending or in-flight worldwide
+			// search — a late response must not pop the panel (or the mobile
+			// sheet) back open on its own.
+			cancelSearchSession();
 			update((state) => ({
 				...resetCategoryState(state),
 				isOpen: false,
@@ -459,60 +638,47 @@ function createMerchantListStore() {
 			results: Place[],
 			total: number = results.length,
 		) {
-			// The server already ordered these by relevance (exact name match, then
-			// prefix, then substring, then a hit on any other tag) with proximity to
-			// the map centre as the tiebreak. Preserve that — re-sorting by distance
-			// or alphabetically, as the nearby list does, would discard it and bury
-			// an exact name match. Only boosted places are promoted above it.
-			// Array.sort is stable, so equal-boost rows keep the server's order.
-			const sortedResults = [...results].sort((a, b) => {
-				if (isBoosted(a) && !isBoosted(b)) return -1;
-				if (!isBoosted(a) && isBoosted(b)) return 1;
-				return 0;
-			});
-			// Counts come from the shared pipeline on the recency-filtered set;
-			// the panel renders the same pipeline's selection
-			// (filteredSearchResults), so chips and rows can never disagree.
-			const { verifiedWithinYears } = get(store);
-			const { counts: categoryCounts } = selectVisiblePlaces({
-				places: sortedResults,
-				mode: "search",
-				category: "all",
-				recency: verifiedWithinYears,
-				recencyReady: true,
-				boostsOnly: false,
-				issuesOnly: false,
-				issuesReady: true,
-			});
-			update((state) => ({
-				...resetCategoryState(state),
-				isOpen: true,
-				mode: "search",
-				searchQuery: query,
-				searchResults: sortedResults,
-				// Total matches on the server, which can exceed what it returned —
-				// the panel shows "N of TOTAL" so truncation isn't silent.
-				searchTotal: total,
-				isSearching: false,
-				categoryCounts,
-			}));
+			applySearchResults(query, results, total);
 		},
 
 		// Open panel in search mode, optionally showing spinner
 		// Use openSearchMode() to open panel ready for input (no spinner)
 		// Use openSearchMode(true) when a search is in progress (shows spinner)
 		openSearchMode(isSearching: boolean = false) {
-			update((state) => ({
-				...state,
-				isSearching,
-				mode: "search",
-				isOpen: true,
-			}));
+			setSearchModeOpen(isSearching);
 		},
 
 		// Update the search query (used when binding input to store)
 		setSearchQuery(query: string) {
 			update((state) => ({ ...state, searchQuery: query }));
+		},
+
+		// Single entry point for the search input (#1173) — and the sole
+		// writer of searchQuery. Writes the RAW query: the staleness guards
+		// compare verbatim, so trimming here would silently drop results for
+		// queries typed with leading whitespace.
+		search(query: string, opts: { getCenter?: SearchCenterGetter } = {}) {
+			update((state) => ({ ...state, searchQuery: query }));
+			if (query.trim().length >= 3) {
+				debouncedExecuteSearch(query, opts.getCenter);
+				return;
+			}
+			// Too short / empty → abort any search and return to nearby
+			// browse, keeping whatever the user has typed so far in the
+			// input. No isOpen guard and no result clearing: the page's
+			// search → nearby watcher owns the refresh, close() owns the
+			// reset.
+			cancelSearchSession();
+			if (get(store).mode !== "nearby") {
+				update((state) => ({ ...state, mode: "nearby" }));
+			}
+		},
+
+		// Discard any pending or in-flight worldwide search without touching
+		// list/details requests (used by the page on teardown paths the
+		// session can't see).
+		cancelSearch() {
+			cancelSearchSession();
 		},
 
 		// Clear search input and results, but stay in search mode
@@ -618,6 +784,7 @@ function createMerchantListStore() {
 
 		reset() {
 			cancelAllRequests();
+			cancelSearchSession();
 			set(initialState);
 		},
 	};

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -648,11 +648,6 @@ function createMerchantListStore() {
 			setSearchModeOpen(isSearching);
 		},
 
-		// Update the search query (used when binding input to store)
-		setSearchQuery(query: string) {
-			update((state) => ({ ...state, searchQuery: query }));
-		},
-
 		// Single entry point for the search input (#1173) — and the sole
 		// writer of searchQuery. Writes the RAW query: the staleness guards
 		// compare verbatim, so trimming here would silently drop results for

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -250,9 +250,11 @@ function createMerchantListStore() {
 	// --- searchSession (#1173) --------------------------------------------
 	// The whole search request lifecycle in one place: the debounce, the
 	// abort, and every staleness/open guard. search() is the single entry
-	// point AND the sole writer of searchQuery — nothing outside the session
-	// can update the query without it knowing (the PR #1126 input-clobber
-	// class this extraction exists to prevent).
+	// point and the sole LIVE writer of searchQuery (the PR #1126
+	// input-clobber class this extraction exists to prevent). The legacy
+	// public writers — openWithSearchResults, clearSearchInput,
+	// exitSearchMode — have no production callers and bypass the session's
+	// cancellation; route new code through search() instead.
 	let searchAbortController: AbortController | null = null;
 
 	function cancelSearchRequest() {
@@ -649,9 +651,10 @@ function createMerchantListStore() {
 		},
 
 		// Single entry point for the search input (#1173) — and the sole
-		// writer of searchQuery. Writes the RAW query: the staleness guards
-		// compare verbatim, so trimming here would silently drop results for
-		// queries typed with leading whitespace.
+		// live writer of searchQuery (see the searchSession note above).
+		// Writes the RAW query: the staleness guards compare verbatim, so
+		// trimming here would silently drop results for queries typed with
+		// leading whitespace.
 		search(query: string, opts: { getCenter?: SearchCenterGetter } = {}) {
 			update((state) => ({ ...state, searchQuery: query }));
 			if (query.trim().length >= 3) {
@@ -670,8 +673,9 @@ function createMerchantListStore() {
 		},
 
 		// Discard any pending or in-flight worldwide search without touching
-		// list/details requests (used by the page on teardown paths the
-		// session can't see).
+		// list/details requests. Escape hatch for teardown paths outside the
+		// session; close() and reset() cancel internally, so today only
+		// tests exercise this directly.
 		cancelSearch() {
 			cancelSearchSession();
 		},

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -347,10 +347,6 @@ $: {
 // doesn't stare at an empty map wondering what happened.
 $: if ($placesError) errToast($placesError);
 
-// Latest in-flight search request; aborted when a new query supersedes
-// it or the component unmounts.
-let searchAbortController: AbortController | null = null;
-
 // Expand a MapLibre LngLatBounds by `bufferPercent` on each edge, mirroring
 // /map's `getBufferedBounds(0.25)` for the local-markers nearby filter.
 const getBufferedBoundsLngLat = (
@@ -571,100 +567,17 @@ const fitSearchResultBounds = (places: Place[]) => {
 	);
 };
 
-// Mirrors /map's `executeSearch` — abort any prior request, fetch via the
-// SvelteKit endpoint, hand results to the store. Errors surface as toasts.
-const executeSearch = async (query: string) => {
-	searchAbortController?.abort();
-	// Trim so the request matches the dispatch decision (handlePanelSearch gates
-	// on the trimmed length) — otherwise "  abc" is sent verbatim as %20%20abc.
-	const trimmed = query.trim();
-	if (trimmed.length < 3) return;
-
-	trackEvent("search_query");
-	searchAbortController = new AbortController();
-
-	// Close any drawer so it doesn't sit on top of the result list.
-	merchantDrawer.close();
-	merchantList.openSearchMode(true);
-
-	// The server breaks relevance ties by proximity to this point, mirroring the
-	// original client-side search, which ranked purely by distance from the map
-	// centre. Without it, a query like "hamburg" — which no place is named —
-	// leaves every match tied at the lowest rank, and the result cap selects
-	// among them by name length. `map` is undefined until the map initialises,
-	// and the search box is reachable before that.
-	const searchParams = new URLSearchParams({ name: trimmed });
-	if (map) {
-		// wrap() normalises longitude into [-180, 180]. Panning across the
-		// antimeridian leaves getCenter().lng unbounded (e.g. 190), and the API
-		// would take that verbatim as the distance origin, ranking by proximity to
-		// a point that doesn't exist.
-		const center = map.getCenter().wrap();
-		searchParams.set("lat", String(center.lat));
-		searchParams.set("lon", String(center.lng));
-	}
-
-	try {
-		const response = await fetch(`/api/search/places?${searchParams}`, {
-			signal: searchAbortController.signal,
-		});
-		if (!response.ok) throw new Error("Search API error");
-		// `total` is the server's full match count, which can exceed the rows it
-		// returned — the panel reports the gap rather than hiding the truncation.
-		const { places: results, total }: { places: Place[]; total: number } =
-			await response.json();
-		// The panel/sheet may have been closed while we were awaiting the
-		// response (abort only rejects the fetch, not the json() window). Don't
-		// let a late result reopen it.
-		if (!get(merchantList).isOpen) return;
-		// The user kept typing while this request was in flight, so it answers a
-		// query that is no longer on screen. Continuous typing keeps re-arming the
-		// debounce, so no newer request dispatched to abort this one. Dropping it
-		// here matters beyond stale results: openWithSearchResults writes `query`
-		// back into searchQuery, which feeds the search input's `value` prop —
-		// applying it would rewrite the input mid-word and reset the caret.
-		if (get(merchantList).searchQuery !== query) return;
-		merchantList.openWithSearchResults(query, results, total);
-	} catch (error) {
-		if (error instanceof Error && error.name === "AbortError") return;
-		// Same staleness check as the success path. The user has typed past this
-		// query, so a newer request is already scheduled or in flight: toasting
-		// would report a failure for a query that is no longer on screen, and
-		// openSearchMode(false) below would clear the spinner out from under the
-		// newer search. That search reports its own failure if it also fails.
-		if (get(merchantList).searchQuery !== query) return;
-		console.error("Search error:", error);
-		errToast(get(_)("errors.searchUnavailable"));
-		// Mirror the success-path guard: if the panel was closed/collapsed while
-		// the request was in flight, a non-abort failure must not pop it back open.
-		if (!get(merchantList).isOpen) return;
-		// Keep the user's typed query (and search mode) — a transient failure
-		// shouldn't wipe the input or silently drop them back to nearby.
-		merchantList.openSearchMode(false);
-	}
-};
-
-const debouncedPanelSearch = debounce(
-	(query: string) => executeSearch(query),
-	300,
-);
-
-// Single-input model: typing ≥3 chars searches worldwide; anything shorter
-// (incl. empty) falls back to the nearby browse list. No mode toggle.
-const handlePanelSearch = (query: string) => {
-	if (query.trim().length >= 3) {
-		debouncedPanelSearch(query);
-		return;
-	}
-	// Too short / empty → abort any search and return to nearby browse,
-	// keeping whatever the user has typed so far in the input
-	debouncedPanelSearch.cancel();
-	searchAbortController?.abort();
-	if (get(merchantList).mode !== "nearby") {
-		// The search → nearby watcher below refreshes the list for the current
-		// viewport; no need to also call updateMerchantList here.
-		merchantList.setMode("nearby");
-	}
+// The search lifecycle (debounce, abort, staleness/open guards) lives in
+// merchantListStore's searchSession (#1173); the page only supplies the
+// dispatch-time map centre. wrap() normalises longitude into [-180, 180]:
+// panning across the antimeridian leaves getCenter().lng unbounded (e.g.
+// 190), and the API would take that verbatim as the distance origin.
+// Undefined until the map initialises — the search box is reachable
+// before that.
+const readSearchCenter = () => {
+	if (!map) return undefined;
+	const center = map.getCenter().wrap();
+	return { lat: center.lat, lon: center.lng };
 };
 
 // The map moves while search mode is active — clicking a result flies to it. But
@@ -682,14 +595,6 @@ $: {
 	const leftSearch = lastListMode === "search" && listMode === "nearby";
 	lastListMode = listMode;
 	if (leftSearch) updateMerchantList({ force: true });
-}
-
-// Closing/collapsing the list discards any pending or in-flight worldwide
-// search — otherwise a late response calls openSearchMode/openWithSearchResults
-// and pops the panel (or the mobile sheet) back open on its own
-$: if (!$merchantList.isOpen) {
-	debouncedPanelSearch.cancel();
-	searchAbortController?.abort();
 }
 
 // Browser back/forward / external hash mutation → re-sync the drawer.
@@ -1280,9 +1185,6 @@ onDestroy(() => {
 	destroyed = true;
 	triggerEnrichmentIfNeeded.cancel();
 	debouncedUpdateMerchantList.cancel();
-	debouncedPanelSearch.cancel();
-	searchAbortController?.abort();
-	searchAbortController = null;
 	if (typeof window !== "undefined") {
 		window.removeEventListener("hashchange", handleHashChange);
 		window.removeEventListener(MERCHANT_URL_CHANGE_EVENT, handleHashChange);
@@ -1367,7 +1269,7 @@ onDestroy(() => {
 	onHoverEnd={() => {
 		// See onHoverStart above.
 	}}
-	onSearch={handlePanelSearch}
+	onSearch={(query) => merchantList.search(query, { getCenter: readSearchCenter })}
 	onRefresh={() => updateMerchantList({ force: true })}
 	behavior={listBehavior}
 	mapReady={styleLoaded}

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -238,9 +238,9 @@ function handleSearchFocus() {
 
 // Single input: typing always drives a worldwide search (the session
 // debounces and, below 3 chars, falls back to the nearby browse list).
-// The session (via onSearch) is the SOLE writer of searchQuery — writing
-// it here too would race the session's staleness guards (the PR #1126
-// input-clobber class).
+// The session (via onSearch) is the sole live writer of searchQuery —
+// writing it here too would race the session's staleness guards (the
+// PR #1126 input-clobber class).
 function handleUnifiedInput(e: Event) {
 	onSearch?.((e.target as HTMLInputElement).value);
 }

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -236,12 +236,13 @@ function handleSearchFocus() {
 	trackEvent("search_input_focus", { source: "panel" });
 }
 
-// Single input: typing always drives a worldwide search (the page debounces
-// and, below 3 chars, falls back to the nearby browse list). No mode toggle.
+// Single input: typing always drives a worldwide search (the session
+// debounces and, below 3 chars, falls back to the nearby browse list).
+// The session (via onSearch) is the SOLE writer of searchQuery — writing
+// it here too would race the session's staleness guards (the PR #1126
+// input-clobber class).
 function handleUnifiedInput(e: Event) {
-	const value = (e.target as HTMLInputElement).value;
-	merchantList.setSearchQuery(value);
-	onSearch?.(value);
+	onSearch?.((e.target as HTMLInputElement).value);
 }
 
 function handleUnifiedKeyDown(event: KeyboardEvent) {
@@ -257,7 +258,6 @@ function handleUnifiedKeyDown(event: KeyboardEvent) {
 }
 
 function handleClearInput() {
-	merchantList.setSearchQuery("");
 	onSearch?.("");
 	searchInputComponent?.focus();
 }


### PR DESCRIPTION
## Summary

Implements #1173 as re-scoped by its 2026-08-03 adversarial re-review: the map search request lifecycle — the 300 ms debounce, the AbortController, and every staleness/open guard — moves from `map/+page.svelte` into `merchantListStore` behind two methods:

```ts
merchantList.search(query, { getCenter })   // sole live writer of searchQuery
merchantList.cancelSearch()
```

- **`search()` is the single entry point and the sole live writer of `searchQuery`** — the panel's input and clear button no longer write the store (`setSearchQuery` is deleted), which structurally prevents the PR #1126 input-clobber class the issue cites as motivation.
- **`close()` and `reset()` cancel the session internally**, replacing the page's close-cancel reactive and `onDestroy` cleanup. Verified equivalent: they are the only `isOpen: false` writers, and an armed-while-closed search is unreachable (the real input only renders inside the open panel). `close()` cancels *only* the search — the list/count fetches still survive a panel close (the closed-badge count depends on it).
- **The page supplies only a dispatch-time `getCenter`** (live `map.getCenter().wrap()`, `undefined` before map init → both params omitted). Evaluated when the debounce fires, not at the keystroke — the map can pan during the window; this preserves the deleted code's exact timing.
- **The leave-search latch stays on the page**, excluded per the re-review (list-refresh concern, #1168 territory).
- `executeSearch` is ported verbatim (guard ordering, comments, toast/spinner policy); ~95 lines of lifecycle code leave the page.

## Zero behavior change

Verified three ways: an adversarial pre-design pass over six candidate parity traps (raw-query staleness comparison, close-scope, getCenter timing, short-query path shape, spinner timing, the dead `<3` gate); per-commit reviews comparing the port line-by-line against the deleted original; and a final whole-branch review that traced store-emission sequences keystroke-to-pixels and proved the cancellation-coverage equivalence. The e2e race specs (`merchant-list-panel.spec.ts:341-459` input-preservation races, `map-search-category-filter.spec.ts`) run through the same endpoint and UI unchanged — they are the regression net.

## Newly testable, now tested

The guards' bugs are silent by nature, and two of them were untestable while they lived on the page. The session ships with a 16-test suite (real `debounce`, stubbed global `fetch`, fake timers): staleness drops on success and failure, **late responses after close cannot reopen the panel**, **close/reset cancel armed and in-flight searches**, dispatch-time `getCenter`/analytics/drawer-close/spinner timing, dispatch-time abort of the previous in-flight request, and the short-query fallback shape.

## Follow-up (out of scope, noted for #1168's next visit)

The legacy public writers `openWithSearchResults`/`clearSearchInput`/`exitSearchMode` have no production callers but still write `searchQuery` without cancelling the session; comments now scope the sole-writer claim accordingly. When the latch territory next changes, folding them into the session (or removing them once their pinning tests are rewritten) would make the invariant structurally total.

## Test plan

- `pnpm run test --run` — 618/618 (16 new session tests; all prior suites untouched and green).
- Full pre-commit suite (`format:fix`, `check`, `typecheck`, `lint`, unit tests) green on every commit.
- No locale, e2e, or `/api/search/places` changes — those files are byte-identical.

Closes #1173

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved merchant search with debounced queries and map-aware results.
  * Search results now display server-provided match totals.
  * Enhanced result ordering promotes relevant boosted places while preserving server relevance.
* **Bug Fixes**
  * Prevented outdated search responses from replacing newer results.
  * Added reliable cancellation when searches are closed, reset, or superseded.
  * Improved handling of short, cleared, and canceled searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->