### PR TITLE
chore(deps): replace @zerodevx/svelte-toast with svelte-sonner #1206

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
 		"@nazka/map-gl-js-spiderfy": "^2.0.0",
 		"@tanstack/match-sorter-utils": "^9.1.2",
 		"@tanstack/svelte-table": "^9.1.2",
-		"@zerodevx/svelte-toast": "^0.9.6",
 		"axios": "^1.15.0",
 		"axios-retry": "^4.5.0",
 		"chart.js": "^4.5.1",
@@ -58,6 +57,7 @@
 		"qrcode": "^1.5.4",
 		"svelte-i18n": "^4.0.1",
 		"svelte-outclick": "^4.2.0",
+		"svelte-sonner": "^1.2.1",
 		"svelte-time": "^2.3.0",
 		"svg-captcha": "^1.4.0",
 		"tippy.js": "^6.3.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,15 +20,12 @@ importers:
       '@tanstack/svelte-table':
         specifier: ^9.1.2
         version: 9.1.2(svelte@5.56.8)
-      '@zerodevx/svelte-toast':
-        specifier: ^0.9.6
-        version: 0.9.6(svelte@5.56.8)
       axios:
         specifier: ^1.15.0
-        version: 1.19.0
+        version: 1.19.0(debug@4.4.3)
       axios-retry:
         specifier: ^4.5.0
-        version: 4.5.0(axios@1.19.0)
+        version: 4.5.0(axios@1.19.0(debug@4.4.3))
       chart.js:
         specifier: ^4.5.1
         version: 4.5.1
@@ -77,6 +74,9 @@ importers:
       svelte-outclick:
         specifier: ^4.2.0
         version: 4.2.0(svelte@5.56.8)
+      svelte-sonner:
+        specifier: ^1.2.1
+        version: 1.2.1(svelte@5.56.8)
       svelte-time:
         specifier: ^2.3.0
         version: 2.3.0
@@ -190,24 +190,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.5.8':
     resolution: {integrity: sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.8':
     resolution: {integrity: sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.5.8':
     resolution: {integrity: sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.8':
     resolution: {integrity: sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA==}
@@ -861,66 +865,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1047,24 +1064,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -1179,11 +1200,6 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
-
-  '@zerodevx/svelte-toast@0.9.6':
-    resolution: {integrity: sha512-nHlTrCjverlPK9yukK6fqbG3e/R+f10ldrc4nJHOe2qNDScuPTuYVSFEk2dDDtzWAwTN5pmdEXgA3M2RbT8jiw==}
-    peerDependencies:
-      svelte: ^3.57.0 || ^4.0.0 || ^5.0.0
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -1643,24 +1659,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1878,6 +1898,11 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  runed@0.28.0:
+    resolution: {integrity: sha512-k2xx7RuO9hWcdd9f+8JoBeqWtYrm5CALfgpkg2YDB80ds/QE4w0qqu34A7fqiAwiBBSBQOid7TLxwxVC27ymWQ==}
+    peerDependencies:
+      svelte: ^5.7.0
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -1943,6 +1968,11 @@ packages:
     resolution: {integrity: sha512-rQ5u8mSdAAQVfDuxLKMAfoRfwpji1HJksGqiyx8vsjn0z41/GB0Qdqn75sII9WefdwhtjuC6wr7qjFYEqQ/UQw==}
     peerDependencies:
       svelte: '>= 5'
+
+  svelte-sonner@1.2.1:
+    resolution: {integrity: sha512-N00LOWb60fjKXULbpngku+7E9Krb16KpNq4/Eax5Vu7o1Dpbca55QpaLPsB+yp82JIEdFhfJuv5cVXLoe0ZtVA==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   svelte-time@2.3.0:
     resolution: {integrity: sha512-XISfzFt1ToijhsaDEH6oDPRSyUGD8eIxGVmpTrKgurCkfVv/H5oopvP7H45j898w5ddauBI4i8KtHGU47Lsr9g==}
@@ -2913,10 +2943,6 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
 
-  '@zerodevx/svelte-toast@0.9.6(svelte@5.56.8)':
-    dependencies:
-      svelte: 5.56.8
-
   acorn@8.16.0: {}
 
   agent-base@6.0.2:
@@ -2937,14 +2963,14 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-retry@4.5.0(axios@1.19.0):
+  axios-retry@4.5.0(axios@1.19.0(debug@4.4.3)):
     dependencies:
-      axios: 1.19.0
+      axios: 1.19.0(debug@4.4.3)
       is-retry-allowed: 2.2.0
 
-  axios@1.19.0:
+  axios@1.19.0(debug@4.4.3):
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
@@ -3240,7 +3266,9 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   form-data@4.0.6:
     dependencies:
@@ -3652,6 +3680,11 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
 
+  runed@0.28.0(svelte@5.56.8):
+    dependencies:
+      esm-env: 1.2.2
+      svelte: 5.56.8
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -3718,6 +3751,11 @@ snapshots:
 
   svelte-outclick@4.2.0(svelte@5.56.8):
     dependencies:
+      svelte: 5.56.8
+
+  svelte-sonner@1.2.1(svelte@5.56.8):
+    dependencies:
+      runed: 0.28.0(svelte@5.56.8)
       svelte: 5.56.8
 
   svelte-time@2.3.0:

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,4 @@
 import rewind from "@mapbox/geojson-rewind";
-import { toast } from "@zerodevx/svelte-toast";
 import type { Chart } from "chart.js";
 import { geoBounds, geoContains } from "d3-geo";
 import { format } from "date-fns/format";
@@ -10,6 +9,7 @@ import { isToday } from "date-fns/isToday";
 import { parseISO } from "date-fns/parseISO";
 import { subDays } from "date-fns/subDays";
 import { get } from "svelte/store";
+import { toast } from "svelte-sonner";
 
 import { API_BASE } from "$lib/api-base";
 import api from "$lib/axios";
@@ -88,28 +88,15 @@ export function yieldToMain(): Promise<void> {
 }
 
 export const errToast = (m: string) => {
-	toast.push(m, {
-		theme: {
-			"--toastBarBackground": "#DF3C3C",
-		},
-	});
+	toast.error(m);
 };
 
 export const warningToast = (m: string) => {
-	toast.push(m, {
-		theme: {
-			"--toastBarBackground": "#FACA15",
-		},
-		duration: 10000,
-	});
+	toast.warning(m, { duration: 10000 });
 };
 
 export const successToast = (m: string) => {
-	toast.push(m, {
-		theme: {
-			"--toastBarBackground": "#22C55E",
-		},
-	});
+	toast.success(m);
 };
 
 export function getRandomColor() {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-import { SvelteToast } from "@zerodevx/svelte-toast";
 import localforage from "localforage";
 import { onDestroy, onMount } from "svelte";
+import { Toaster } from "svelte-sonner";
 
 import LoadingIndicator from "$components/LoadingIndicator.svelte";
 import Header from "$components/layout/Header.svelte";
@@ -45,12 +45,6 @@ afterNavigate(() => {
 $: if (browser && $locale) {
 	document.documentElement.lang = $locale;
 }
-
-const options = {
-	reversed: true,
-	intro: { y: 192 },
-	pausable: true,
-};
 
 let layoutSyncVisible = false;
 let layoutLoadingStatus = "";
@@ -164,14 +158,17 @@ export let data;
 		</main>
 	{/if}
 
-	<SvelteToast {options} />
+	<!-- 8rem bottom clearance keeps toasts above the map's bottom UI (same
+	     offset the previous svelte-toast container used); expand keeps
+	     concurrent toasts fully readable instead of collapsed behind the
+	     front one — the activity page can fire 3 error toasts at once -->
+	<Toaster
+		position="bottom-center"
+		richColors
+		closeButton
+		expand
+		theme={$theme}
+		offset={{ bottom: "8rem" }}
+		mobileOffset={{ bottom: "8rem" }}
+	/>
 {/if}
-
-<style>
-	:root {
-		--toastContainerTop: auto;
-		--toastContainerRight: auto;
-		--toastContainerBottom: 8rem;
-		--toastContainerLeft: calc(50vw - 8rem);
-	}
-</style>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
 		// to resolve them at runtime and crashes with missing-export /
 		// module-not-found errors. v9 is also ESM-only, so the external
 		// path is unproven on the lambda runtime — inline all of it.
-		noExternal: [/^@tanstack\//, 'remove-accents']
+		// svelte-sonner and its transitive dep runed are Svelte libraries that
+		// vite-plugin-svelte normally inlines on its own — pinned here so the
+		// lambda never depends on that heuristic.
+		noExternal: [/^@tanstack\//, 'remove-accents', 'svelte-sonner', 'runed']
 	},
 	worker: {
 		format: 'es'


### PR DESCRIPTION
Completes #1206 — closes #1206.

## Why a replacement instead of the planned 1.0 bump

The issue's svelte-toast row said to wait for 1.0 stable. That will never come:

- The `next` dist-tag is still `1.0.0-rc.2` from **Feb 2023**, with a `svelte ^3.55.1` peer dep — it predates Svelte 5 and is not the "Svelte-5-native rewrite" the issue assumed (it's the frozen `archived-v1` branch).
- Upstream has published nothing since 0.9.6 (**Sep 2024**); the actual rewrite attempt (zerodevx/svelte-toast#110, `v0.10` branch, still Svelte-4) stalled Oct 2024; the 1.0 effort has been started and abandoned three times (PRs #70 → #87 → #110); last maintainer activity of any kind was Feb 2025.

`svelte-sonner` 1.2.1 is the runes-native replacement: v1 was an explicit Svelte 5 rewrite, it published again this week, ~449k weekly downloads, 2 transitive deps, and it's what shadcn-svelte standardized on.

## What changed

- `errToast` / `warningToast` / `successToast` in `utils.ts` now call `toast.error/warning/success` — the ~30 call sites are untouched. Warning keeps its 10s duration; the 4s default matches the old one.
- `<Toaster>` in `+layout.svelte` preserves the old container behavior: bottom-center with the same 8rem clearance (also set as `mobileOffset` — sonner's mobile default is only 16px), close button, pause-on-hover, newest toast nearest the bottom edge, and `expand` so up to 3 concurrent error toasts (the activity page's worst case) stay fully readable instead of collapsing behind the front one.
- New: toasts follow dark mode via `theme={$theme}` (the old ones were always dark).
- `svelte-sonner` + `runed` added to `ssr.noExternal` — runed has no top-level `node_modules` entry under pnpm, so this pins the known Netlify-lambda externalization trap shut rather than relying on vite-plugin-svelte's auto-inline heuristic.
- Security bonus: svelte-toast rendered messages via `{@html}`; sonner binds them as escaped text, closing an injection sink for API-provided error strings.

## Visual change to accept

The colored bottom bar (which doubled as the countdown) is gone — variants now use sonner's `richColors` styling (green/red/amber toast surfaces) with no countdown indicator. Screenshots on the deploy preview will show the new look.

## Verified

- `svelte-check` 0 errors, Biome clean, 619/619 unit tests, production build with adapter-netlify succeeds
- Adversarial review (3 lenses, each finding independently verified): no blockers. Parity checklist confirmed against the installed dist: durations, hover-pause, dismiss affordance, stacking order, offset types, theme reactivity.

## QA on the deploy preview

- [ ] success / error / warning toasts (e.g. copy-link success on a merchant page, add-location form errors)
- [ ] auto-dismiss timing (4s default, 10s warnings) and pause-on-hover
- [ ] stacking with several toasts, close button, dark mode
- [ ] curl the preview URL — SSR lambda must render (known pnpm/noExternal trap)

## Noted, deliberately not in this PR

- `src/error.html` / `static/offline.html` are baked snapshots that still embed the old toast CSS (inert, and they already drift — Tailwind v3 CSS since #1050); regenerating them is a separate chore.
- Upstream nit: sonner's theme `$effect` registers a no-op `matchMedia` listener per theme toggle (no teardown) — harmless here, candidate for an upstream report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded in-app notifications with improved styling, rich colors, close buttons, theme support, and expandable messages.
  * Notifications now appear at the bottom center with responsive spacing on desktop and mobile.

* **Bug Fixes**
  * Improved notification rendering and reliability across supported environments.
  * Warning notifications continue displaying for 10 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->