### PR TITLE
refactor(svelte5): convert /supporters route to runes mode #1262

### DIFF
--- a/src/routes/supporters/+page.svelte
+++ b/src/routes/supporters/+page.svelte
@@ -10,28 +10,28 @@ import { theme } from "$lib/theme";
 import type { DonationType } from "$lib/types";
 import { warningToast } from "$lib/utils";
 
-import type { PageData } from "./$types";
+import type { PageProps } from "./$types";
 import DonationOption from "./components/DonationOption.svelte";
 import PlebSection from "./components/PlebSection.svelte";
 import SupportSection from "./components/SupportSection.svelte";
 import type { SponsorshipLevel } from "./sponsors";
 import { individualLevels, sponsors, sponsorshipTiers } from "./sponsors";
 
-export let data: PageData;
+let { data }: PageProps = $props();
 
 const PLEB_TIER_CTA = "https://geyser.fund/project/btcmap/leaderboard";
 
 const onchain = "bc1qt4g28vq480ec4ncl4h67qu4q4k2zel7xu0c2wg";
 const lnurlp = "donations@btcmap.org";
 
-let mounted = false;
+let mounted = $state(false);
 onMount(() => {
 	mounted = true;
 });
 
-let showQr = false;
-$: t = $_;
-let network: DonationType;
+let showQr = $state(false);
+let t = $derived($_);
+let network: DonationType | undefined = $state();
 
 const showQrToggle = (type: DonationType) => {
 	network = type;

--- a/src/routes/supporters/components/DonationOption.svelte
+++ b/src/routes/supporters/components/DonationOption.svelte
@@ -4,12 +4,16 @@ import Icon from "$components/Icon.svelte";
 import { _ } from "$lib/i18n";
 import type { DonationType } from "$lib/types";
 
-export let value: string;
-export let textKey: string;
-export let network: DonationType;
-export let showQrToggle: ((type: DonationType) => void) | undefined = undefined;
+type Props = {
+	value: string;
+	textKey: string;
+	network: DonationType;
+	showQrToggle?: (type: DonationType) => void;
+};
 
-$: t = $_;
+let { value, textKey, network, showQrToggle }: Props = $props();
+
+let t = $derived($_);
 </script>
 
 <div>
@@ -42,7 +46,7 @@ $: t = $_;
 					type="button"
 					aria-label={t("supporters.donate.scanOrClick")}
 					class="text-link transition-colors hover:text-hover"
-					on:click={() => showQrToggle(network)}
+					onclick={() => showQrToggle(network)}
 				>
 					<Icon type="fa" icon="qrcode" w="24" h="24" />
 				</button>

--- a/src/routes/supporters/components/PlebSection.svelte
+++ b/src/routes/supporters/components/PlebSection.svelte
@@ -3,20 +3,24 @@ import { _ } from "$lib/i18n";
 
 import type { Pleb, SponsorshipTier } from "../sponsors";
 
-$: t = $_;
+let t = $derived($_);
 
-export let tier: SponsorshipTier;
-export let plebs: Pleb[];
-export let ctaHref: string;
+type Props = {
+	tier: SponsorshipTier;
+	plebs: Pleb[];
+	ctaHref: string;
+};
+
+let { tier, plebs, ctaHref }: Props = $props();
 
 const tierStyles: Partial<Record<SponsorshipTier["level"], string>> = {
 	// Bitcoin orange is an official brand color (#F7931A)
 	Pleb: "border-[#F7931A]/40 bg-[#F7931A]/5 dark:border-[#F7931A]/40 dark:bg-[#F7931A]/[0.08]",
 };
 
-let activeTooltip: string | null = null;
+let activeTooltip: string | null = $state(null);
 // tracks plebs whose avatar and robohash both failed
-let brokenAvatars = new Set<string>();
+let brokenAvatars = $state(new Set<string>());
 
 function onAvatarError(e: Event, pleb: Pleb) {
 	const img = e.currentTarget as HTMLImageElement;
@@ -30,6 +34,10 @@ function onAvatarError(e: Event, pleb: Pleb) {
 }
 
 function onTouchEnd(pleb: Pleb, e: TouchEvent) {
+	// Keep the tap from bubbling to the svelte:window handler below,
+	// which would immediately clear the tooltip this tap just opened
+	// (was the |stopPropagation modifier pre-runes)
+	e.stopPropagation();
 	if (activeTooltip === pleb.id) {
 		// Already showing — let the tap through to follow the link
 		activeTooltip = null;
@@ -42,7 +50,7 @@ function onTouchEnd(pleb: Pleb, e: TouchEvent) {
 </script>
 
 <svelte:window
-	on:touchend={() => {
+	ontouchend={() => {
 		activeTooltip = null;
 	}}
 />
@@ -61,7 +69,7 @@ function onTouchEnd(pleb: Pleb, e: TouchEvent) {
 					target="_blank"
 					rel="noopener noreferrer"
 					class="group relative transition-transform duration-150 hover:-translate-y-0.5"
-					on:touchend|stopPropagation={(e) => onTouchEnd(pleb, e)}
+					ontouchend={(e) => onTouchEnd(pleb, e)}
 				>
 					{#if brokenAvatars.has(pleb.id)}
 						<div
@@ -74,7 +82,7 @@ function onTouchEnd(pleb: Pleb, e: TouchEvent) {
 							src={pleb.avatar ?? `https://robohash.org/${pleb.id}?set=set1&size=64x64`}
 							alt={pleb.name}
 							class="h-16 w-16 rounded-full border-2 border-white/60 object-cover shadow-md group-hover:border-link dark:border-white/20"
-							on:error={(e) => onAvatarError(e, pleb)}
+							onerror={(e) => onAvatarError(e, pleb)}
 						/>
 					{/if}
 					<!-- Desktop: CSS hover. Mobile: controlled by activeTooltip -->
@@ -89,10 +97,10 @@ function onTouchEnd(pleb: Pleb, e: TouchEvent) {
 					</span>
 				</a>
 			{:else}
-				<!-- svelte-ignore a11y-no-static-element-interactions -->
+				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div
 					class="group relative"
-					on:touchend|stopPropagation={(e) => onTouchEnd(pleb, e)}
+					ontouchend={(e) => onTouchEnd(pleb, e)}
 				>
 					{#if brokenAvatars.has(pleb.id)}
 						<div
@@ -105,7 +113,7 @@ function onTouchEnd(pleb: Pleb, e: TouchEvent) {
 							src={pleb.avatar ?? `https://robohash.org/${pleb.id}?set=set1&size=64x64`}
 							alt={pleb.name}
 							class="h-16 w-16 rounded-full border-2 border-white/60 object-cover shadow-md dark:border-white/20"
-							on:error={(e) => onAvatarError(e, pleb)}
+							onerror={(e) => onAvatarError(e, pleb)}
 						/>
 					{/if}
 					<span

--- a/src/routes/supporters/components/SupportSection.svelte
+++ b/src/routes/supporters/components/SupportSection.svelte
@@ -4,9 +4,13 @@ import { theme } from "$lib/theme";
 
 import type { Sponsor, SponsorshipTier } from "../sponsors";
 
-export let tier: SponsorshipTier;
-export let sponsors: Sponsor[];
-export let compact = false;
+type Props = {
+	tier: SponsorshipTier;
+	sponsors: Sponsor[];
+	compact?: boolean;
+};
+
+let { tier, sponsors, compact = false }: Props = $props();
 
 const levelStyles: Partial<Record<SponsorshipTier["level"], string>> = {
 	// Ascending contrast scale — lower tiers blend with the page bg (#E4EBEC / #06171C),
@@ -23,8 +27,8 @@ const levelStyles: Partial<Record<SponsorshipTier["level"], string>> = {
 		"border-[#095D73]/80 bg-[#BDD2D4]/70 shadow-md dark:border-[#095D73]/70 dark:bg-[#095D73]/[0.28]",
 };
 
-$: cardStyle = levelStyles[tier.level] ?? "";
-$: t = $_;
+let cardStyle = $derived(levelStyles[tier.level] ?? "");
+let t = $derived($_);
 </script>
 
 <article class="rounded-2xl border p-6 text-left shadow-sm {cardStyle}">


### PR DESCRIPTION
Closes #1262 — the #1208 pilot: first folder conversion, run to calibrate the migration workflow before the bigger folders.

## What changed

All 4 files under `src/routes/supporters/` are now runes-mode:

- `export let data: PageData` → `let { data }: PageProps = $props()` (Kit's generated type, matching the `community/[area]` pages)
- 10 component props → typed `$props()` destructuring (`type Props`, not `interface`, per repo standard)
- `$:` → `$derived` (incl. the repo-wide `$: t = $_` i18n idiom), mutable locals → `$state`
- `on:click`/`on:error`/`svelte:window on:touchend` → event attributes
- `on:touchend|stopPropagation` → modifiers don't exist in runes; folded into `onTouchEnd` as an explicit `e.stopPropagation()` with a comment (applies to both former call sites identically) — **zero `svelte/legacy` imports left**
- `bind:open` against the still-legacy `Modal` unchanged (mixed-mode binding works)

## Verification

- Adversarial parity review (reactivity lens + template/event lens, findings independently verified): **zero deviations** — includes the subtle cases: `$state(new Set())` reassignment reactivity, img `onerror` (non-bubbling) firing, touch/tooltip event ordering vs the `svelte:window` handler, action closure reading `network` at run time
- `svelte-check` 0 errors, Biome clean, 619/619 unit tests, prod build + adapter green

## Deploy-preview QA (from #1262)

- [x] Hero renders (theme gradient light / white dark)
- [x] QR modal: on-chain + lightning, canvas renders, links work
- [x] Copy buttons
- [x] Pleb avatars: robohash fallback, initials fallback, touch tooltips (tap shows tooltip, second tap follows link)
- [x] Dark mode across sections

## Workflow learnings

Written up as a comment on #1208 — short version: `sv migrate` is interactive/whole-project, so drive `migrate()` from `svelte/compiler` per file for folder-scoped runs; migrator output was clean here (no `run()` wrappers), but always hand-fix `interface Props`→`type`/`PageProps`, `svelte/legacy` wrapper imports from event modifiers, and `| undefined` on no-arg `$state()` annotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the supporters page and donation-related components to use the latest Svelte framework patterns.
  * Preserved existing donation options, supporter tiers, translations, compact layouts, and interactive behavior.
  * Improved event handling for touch interactions, QR toggles, and image loading while maintaining accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->