### PR TITLE
feat(apps): switch Bull Bitcoin Wallet to live

### DIFF
--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -395,7 +395,7 @@ export const appConfigs: AppConfig[] = [
 		id: "bull-bitcoin",
 		name: "Bull Bitcoin Wallet",
 		logo: "/images/apps/bull-bitcoin.png",
-		tag: "coming-soon",
+		tag: "powered-by-btcmap",
 		sponsor: false,
 		stores: [
 			{


### PR DESCRIPTION
## Summary
- Moves the Bull Bitcoin Wallet app on the /apps page from the `coming-soon` tag to `powered-by-btcmap` now that it is live

## Test plan
- [x] `pnpm run check` / `pnpm run typecheck`
- [x] `pnpm run lint` + `pnpm run format:fix`
- [x] `pnpm run test --run` (641 passed)

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Bull Bitcoin app listing to indicate it is powered by BTCMap.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->