### PR TITLE
fix(map): restore payment method URL filters #1269

### DIFF
--- a/src/lib/api-fields.ts
+++ b/src/lib/api-fields.ts
@@ -49,14 +49,30 @@ export const PLACE_FIELDS = {
 		"osm:check_date:currency:XBT",
 		"osm:note",
 	] as const satisfies (keyof Place)[],
+	// The three tags the embed payment filter (?onchain&lightning&nfc) and
+	// the list's payment icons match on.
+	PAYMENT_METHOD: [
+		"osm:payment:onchain",
+		"osm:payment:lightning",
+		"osm:payment:lightning_contactless",
+	] as const satisfies (keyof Place)[],
 } as const;
 
 export const PLACE_FIELD_SETS = {
 	// verified_at rides along on incremental updates so a changed place keeps
 	// its date through a sync (no flicker) and the recency filter never needs a
 	// full re-fetch to stay fresh — the baseline is loaded once, lazily, by
-	// ensureVerifiedDates() when the filter is first engaged.
-	MAP_SYNC: [...PLACE_FIELDS.CORE, ...PLACE_FIELDS.SYNC, "verified_at"],
+	// ensureVerifiedDates() when the filter is first engaged. The payment tags
+	// ride along for the same reason: incremental rows replace enriched rows
+	// wholesale, and without them a mid-session update would silently drop a
+	// place out of a payment-filtered embed (ensurePaymentMethods() loads the
+	// baseline lazily, like the dates).
+	MAP_SYNC: [
+		...PLACE_FIELDS.CORE,
+		...PLACE_FIELDS.SYNC,
+		"verified_at",
+		...PLACE_FIELDS.PAYMENT_METHOD,
+	],
 	COMPLETE_PLACE: [
 		...PLACE_FIELDS.CORE,
 		...PLACE_FIELDS.SYNC,
@@ -68,9 +84,7 @@ export const PLACE_FIELD_SETS = {
 		"localized_name",
 		"address",
 		"verified_at",
-		"osm:payment:onchain",
-		"osm:payment:lightning",
-		"osm:payment:lightning_contactless",
+		...PLACE_FIELDS.PAYMENT_METHOD,
 	] as const satisfies (keyof Place)[],
 } as const;
 

--- a/src/lib/map/paymentFilter.test.ts
+++ b/src/lib/map/paymentFilter.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import type { Place } from "$lib/types";
+
+import {
+	parsePaymentFilter,
+	placeMatchesPaymentFilter,
+	serializePaymentFilter,
+} from "./paymentFilter";
+
+let nextId = 1;
+function place(overrides: Partial<Place> = {}): Place {
+	return { id: nextId++, lat: 0, lon: 0, ...overrides } as Place;
+}
+
+describe("parsePaymentFilter", () => {
+	it("returns null when no payment param is present", () => {
+		expect(parsePaymentFilter(new URLSearchParams(""))).toBeNull();
+		expect(parsePaymentFilter(new URLSearchParams("?basemap=7"))).toBeNull();
+		expect(
+			parsePaymentFilter(new URLSearchParams("?lat=52.5&long=13.4")),
+		).toBeNull();
+	});
+
+	it("flags each documented param", () => {
+		expect(parsePaymentFilter(new URLSearchParams("?onchain"))).toEqual({
+			onchain: true,
+			lightning: false,
+			nfc: false,
+		});
+		expect(parsePaymentFilter(new URLSearchParams("?lightning"))).toEqual({
+			onchain: false,
+			lightning: true,
+			nfc: false,
+		});
+		expect(parsePaymentFilter(new URLSearchParams("?nfc"))).toEqual({
+			onchain: false,
+			lightning: false,
+			nfc: true,
+		});
+	});
+
+	it("combines params (?onchain&lightning — the documented embed form)", () => {
+		expect(
+			parsePaymentFilter(new URLSearchParams("?onchain&lightning")),
+		).toEqual({ onchain: true, lightning: true, nfc: false });
+	});
+
+	// Presence alone counts, matching the legacy Leaflet params — a
+	// well-meaning ?lightning=false still engages the filter.
+	it("uses presence semantics, ignoring any param value", () => {
+		expect(parsePaymentFilter(new URLSearchParams("?lightning=false"))).toEqual(
+			{ onchain: false, lightning: true, nfc: false },
+		);
+	});
+});
+
+describe("placeMatchesPaymentFilter", () => {
+	const filter = (
+		overrides: Partial<{ onchain: boolean; lightning: boolean; nfc: boolean }>,
+	) => ({ onchain: false, lightning: false, nfc: false, ...overrides });
+
+	it("requires the flagged tag to be exactly 'yes'", () => {
+		const f = filter({ onchain: true });
+		expect(
+			placeMatchesPaymentFilter(place({ "osm:payment:onchain": "yes" }), f),
+		).toBe(true);
+		expect(placeMatchesPaymentFilter(place({}), f)).toBe(false);
+		// Live OSM data carries "no" and free-text noise ("Yes", "yed",
+		// addresses) in these tags — only a literal "yes" may match, exactly
+		// like the legacy Leaflet filter.
+		for (const noise of ["no", "Yes", "YES", "yed", "y"]) {
+			expect(
+				placeMatchesPaymentFilter(
+					place({ "osm:payment:onchain": noise as "yes" }),
+					f,
+				),
+			).toBe(false);
+		}
+	});
+
+	it("ANDs multiple flagged methods, like the legacy filter", () => {
+		const f = filter({ onchain: true, lightning: true });
+		expect(
+			placeMatchesPaymentFilter(
+				place({
+					"osm:payment:onchain": "yes",
+					"osm:payment:lightning": "yes",
+				}),
+				f,
+			),
+		).toBe(true);
+		expect(
+			placeMatchesPaymentFilter(place({ "osm:payment:onchain": "yes" }), f),
+		).toBe(false);
+		expect(
+			placeMatchesPaymentFilter(place({ "osm:payment:lightning": "yes" }), f),
+		).toBe(false);
+	});
+
+	it("maps nfc to the lightning_contactless tag", () => {
+		const f = filter({ nfc: true });
+		expect(
+			placeMatchesPaymentFilter(
+				place({ "osm:payment:lightning_contactless": "yes" }),
+				f,
+			),
+		).toBe(true);
+		// The plain lightning tag must not satisfy nfc.
+		expect(
+			placeMatchesPaymentFilter(place({ "osm:payment:lightning": "yes" }), f),
+		).toBe(false);
+	});
+
+	it("ignores unflagged methods entirely", () => {
+		const f = filter({ lightning: true });
+		expect(
+			placeMatchesPaymentFilter(
+				place({
+					"osm:payment:lightning": "yes",
+					"osm:payment:onchain": "no" as "yes",
+				}),
+				f,
+			),
+		).toBe(true);
+	});
+});
+
+describe("serializePaymentFilter", () => {
+	it("is 'off' for null and never empty for an active filter", () => {
+		expect(serializePaymentFilter(null)).toBe("off");
+		expect(
+			serializePaymentFilter({ onchain: true, lightning: false, nfc: false }),
+		).not.toBe("");
+	});
+
+	it("distinguishes every combination", () => {
+		const combos = [
+			{ onchain: true, lightning: false, nfc: false },
+			{ onchain: false, lightning: true, nfc: false },
+			{ onchain: false, lightning: false, nfc: true },
+			{ onchain: true, lightning: true, nfc: false },
+			{ onchain: true, lightning: true, nfc: true },
+		];
+		const serialized = combos.map(serializePaymentFilter);
+		expect(new Set(serialized).size).toBe(combos.length);
+		expect(serialized).not.toContain("off");
+	});
+});

--- a/src/lib/map/paymentFilter.ts
+++ b/src/lib/map/paymentFilter.ts
@@ -1,0 +1,49 @@
+import type { Place } from "$lib/types";
+
+// The embed payment-method deep link (?onchain&lightning&nfc — see the
+// Embedding wiki page). Presence alone counts and multiple params AND
+// together, matching the legacy Leaflet map (2b45107c) these params were
+// lost from in the #398 rewrite (#1269). `nfc` maps to the
+// payment:lightning_contactless tag.
+export type PaymentMethodFilter = {
+	onchain: boolean;
+	lightning: boolean;
+	nfc: boolean;
+};
+
+export const parsePaymentFilter = (
+	searchParams: URLSearchParams,
+): PaymentMethodFilter | null => {
+	const filter = {
+		onchain: searchParams.has("onchain"),
+		lightning: searchParams.has("lightning"),
+		nfc: searchParams.has("nfc"),
+	};
+	return filter.onchain || filter.lightning || filter.nfc ? filter : null;
+};
+
+// Strictly === "yes": live OSM data carries "no" and free-text noise in
+// these tags, so truthiness would show places that explicitly refuse the
+// method.
+export const placeMatchesPaymentFilter = (
+	place: Place,
+	filter: PaymentMethodFilter,
+): boolean =>
+	(!filter.onchain || place["osm:payment:onchain"] === "yes") &&
+	(!filter.lightning || place["osm:payment:lightning"] === "yes") &&
+	(!filter.nfc || place["osm:payment:lightning_contactless"] === "yes");
+
+// For computeVisibleSignature: "off" when inactive, otherwise a non-empty
+// combination key ("onchain+lightning").
+export const serializePaymentFilter = (
+	filter: PaymentMethodFilter | null,
+): string => {
+	if (!filter) return "off";
+	return [
+		filter.onchain && "onchain",
+		filter.lightning && "lightning",
+		filter.nfc && "nfc",
+	]
+		.filter(Boolean)
+		.join("+");
+};

--- a/src/lib/map/visiblePlaces.test.ts
+++ b/src/lib/map/visiblePlaces.test.ts
@@ -41,6 +41,8 @@ const base = {
 	boostsOnly: false,
 	issueCodes: null,
 	issuesReady: true,
+	paymentFilter: null,
+	paymentReady: true,
 };
 
 const allIssueCodes = new Set(DERIVED_ISSUE_CODES);
@@ -186,6 +188,65 @@ describe("selectVisiblePlaces", () => {
 		expect(r.selection.length).toBe(7);
 	});
 
+	// The embed payment filter (?onchain&lightning&nfc, #1269): a dedicated
+	// corpus so the tag combinations are explicit — the shared corpus stays
+	// payment-agnostic.
+	const paymentCorpus = () => [
+		place({ "osm:payment:onchain": "yes", "osm:payment:lightning": "yes" }),
+		place({ "osm:payment:lightning": "yes" }),
+		place({ "osm:payment:lightning_contactless": "yes" }),
+		place({ "osm:payment:onchain": "no" as "yes" }),
+		place({}),
+		place({ "osm:payment:lightning": "yes", deleted_at: old() }),
+	];
+
+	it("narrows to places tagged yes for every flagged method when ready", () => {
+		const lightningOnly = selectVisiblePlaces({
+			...base,
+			places: paymentCorpus(),
+			paymentFilter: { onchain: false, lightning: true, nfc: false },
+		});
+		expect(lightningOnly.selection.length).toBe(2);
+
+		const both = selectVisiblePlaces({
+			...base,
+			places: paymentCorpus(),
+			paymentFilter: { onchain: true, lightning: true, nfc: false },
+		});
+		expect(both.selection.length).toBe(1);
+
+		const nfc = selectVisiblePlaces({
+			...base,
+			places: paymentCorpus(),
+			paymentFilter: { onchain: false, lightning: false, nfc: true },
+		});
+		expect(nfc.selection.length).toBe(1);
+		expect(nfc.selection[0]["osm:payment:lightning_contactless"]).toBe("yes");
+	});
+
+	it("keeps the payment filter inert until the tags are ready", () => {
+		// Bulk rows before the payment enrichment carry no tags at all; the
+		// gate keeps the world visible instead of hiding every pin.
+		const r = selectVisiblePlaces({
+			...base,
+			places: paymentCorpus(),
+			paymentFilter: { onchain: false, lightning: true, nfc: false },
+			paymentReady: false,
+		});
+		expect(r.selection.length).toBe(5);
+	});
+
+	it("counts chips on the payment-filtered set", () => {
+		// Payment applies pre-category (unlike boosts): inside an embed the
+		// chips must describe the narrowed world, not promise hidden pins.
+		const r = selectVisiblePlaces({
+			...base,
+			places: paymentCorpus(),
+			paymentFilter: { onchain: false, lightning: true, nfc: false },
+		});
+		expect(r.counts.all).toBe(2);
+	});
+
 	it("composes boosts after category (empty intersections are honest)", () => {
 		const r = selectVisiblePlaces({
 			...base,
@@ -237,6 +298,39 @@ describe("computeVisibleSignature", () => {
 		);
 		expect(
 			computeVisibleSignature({ ...inputs, issuesReady: false }, 7, ""),
+		).not.toBe(sig);
+		expect(
+			computeVisibleSignature(
+				{
+					...inputs,
+					paymentFilter: { onchain: true, lightning: false, nfc: false },
+				},
+				7,
+				"",
+			),
+		).not.toBe(sig);
+		// Distinct method combinations must not collide with each other.
+		expect(
+			computeVisibleSignature(
+				{
+					...inputs,
+					paymentFilter: { onchain: true, lightning: false, nfc: false },
+				},
+				7,
+				"",
+			),
+		).not.toBe(
+			computeVisibleSignature(
+				{
+					...inputs,
+					paymentFilter: { onchain: false, lightning: true, nfc: false },
+				},
+				7,
+				"",
+			),
+		);
+		expect(
+			computeVisibleSignature({ ...inputs, paymentReady: false }, 7, ""),
 		).not.toBe(sig);
 		expect(
 			computeVisibleSignature({ ...inputs, mode: "search" }, 7, "1,2"),

--- a/src/lib/map/visiblePlaces.ts
+++ b/src/lib/map/visiblePlaces.ts
@@ -5,6 +5,11 @@ import {
 	countMerchantsByCategory,
 	placeMatchesCategory,
 } from "$lib/categoryMapping";
+import type { PaymentMethodFilter } from "$lib/map/paymentFilter";
+import {
+	placeMatchesPaymentFilter,
+	serializePaymentFilter,
+} from "$lib/map/paymentFilter";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
 import type { DerivedIssueCode } from "$lib/placeIssues";
 import { placeMatchesIssueCodes, serializeIssuesParam } from "$lib/placeIssues";
@@ -45,10 +50,22 @@ export type VisibleSelectionInputs = {
 	// the filter stays inert (rather than flagging every row as
 	// not_verified) until enrichment lands.
 	issuesReady: boolean;
+	// The embed payment-method deep link (?onchain&lightning&nfc, #1269):
+	// null when off; otherwise every flagged method must be tagged "yes"
+	// (AND, legacy Leaflet parity — see $lib/map/paymentFilter). Applied
+	// pre-category: inside an embed the chips must describe the narrowed
+	// world. Callers resolve search exemption like boosts.
+	paymentFilter: PaymentMethodFilter | null;
+	// Same readiness contract as recencyReady: the bulk feed carries no
+	// payment tags until ensurePaymentMethods() enriches it, so bulk-feed
+	// consumers gate on $paymentDataLoaded and the filter stays inert
+	// (rather than hiding every pin) until the tags land.
+	paymentReady: boolean;
 };
 
 export type VisibleSelection = {
-	// The final visible set: recency → category → boosts, deleted rows dropped.
+	// The final visible set: recency → payment → issues → category → boosts,
+	// deleted rows dropped.
 	selection: Place[];
 	// The recency-filtered, PRE-category set — what chip counts and density
 	// ceilings are computed on (a selected chip must not hide the other
@@ -69,6 +86,12 @@ export function selectVisiblePlaces(
 	let preCategory = inputs.recencyReady
 		? filterPlacesByRecency(live, inputs.recency)
 		: live;
+	const paymentFilter = inputs.paymentFilter;
+	if (paymentFilter && inputs.paymentReady) {
+		preCategory = preCategory.filter((p) =>
+			placeMatchesPaymentFilter(p, paymentFilter),
+		);
+	}
 	const issueCodes = inputs.issueCodes;
 	if (issueCodes && inputs.issuesReady) {
 		preCategory = preCategory.filter((p) =>
@@ -115,6 +138,8 @@ export function computeVisibleSignature(
 			? serializeIssuesParam(inputs.issueCodes) || "all"
 			: "off",
 		inputs.issuesReady,
+		serializePaymentFilter(inputs.paymentFilter),
+		inputs.paymentReady,
 		revision,
 		searchResultIds,
 	].join("|");

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -220,6 +220,10 @@ function createMerchantListStore() {
 			boostsOnly: false,
 			issueCodes: null,
 			issuesReady: true,
+			// Search is exempt from the embed payment narrowing (same policy
+			// as boosts): an explicit query should surface all matches.
+			paymentFilter: null,
+			paymentReady: true,
 		});
 		update((state) => ({
 			...resetCategoryState(state),
@@ -404,6 +408,11 @@ function createMerchantListStore() {
 				boostsOnly: false,
 				issueCodes: null,
 				issuesReady: true,
+				// The map page pre-applies the payment deep link to its
+				// local-markers list before calling setMerchants, same division
+				// of labor as boosts and issues.
+				paymentFilter: null,
+				paymentReady: true,
 			});
 
 			const sorted = sortMerchants(
@@ -468,6 +477,11 @@ function createMerchantListStore() {
 						boostsOnly: false,
 						issueCodes: null,
 						issuesReady: true,
+						// A payment deep link forces the local-markers list path
+						// (listBehavior on the map page), so these API radius rows
+						// never meet the filter.
+						paymentFilter: null,
+						paymentReady: true,
 					});
 
 				// Check if we should hide results (too many at low zoom)
@@ -749,6 +763,10 @@ function createMerchantListStore() {
 						boostsOnly: false,
 						issueCodes: null,
 						issuesReady: true,
+						// Search is exempt from the embed payment narrowing (same
+						// policy as boosts): an explicit query surfaces all matches.
+						paymentFilter: null,
+						paymentReady: true,
 					});
 					return {
 						...state,

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -40,6 +40,12 @@ export const placesLoadingProgress = writable<number>(0); // 0-100 percentage
 // src/lib/sync/places.ts (ensureVerifiedDates).
 export const verifiedDatesLoaded = writable(false);
 
+// True once the lazy payment-tag enrichment has loaded. The tags are only
+// fetched when a payment deep link (?onchain&lightning&nfc) is present, so
+// the embed filter gates on this to stay inert until the tags are present.
+// See src/lib/sync/places.ts (ensurePaymentMethods).
+export const paymentDataLoaded = writable(false);
+
 export const users: Writable<User[]> = writable([]);
 export const userError = writable("");
 

--- a/src/lib/sync/places.enrichment.test.ts
+++ b/src/lib/sync/places.enrichment.test.ts
@@ -1,0 +1,124 @@
+import { get } from "svelte/store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { paymentDataLoaded, places, verifiedDatesLoaded } from "$lib/store";
+import type { Place } from "$lib/types";
+
+vi.mock("$lib/axios", () => ({
+	default: { get: vi.fn(), head: vi.fn() },
+}));
+
+import api from "$lib/axios";
+
+import { ensurePaymentMethods, ensureVerifiedDates } from "./places";
+
+const mockGet = vi.mocked(api.get);
+
+const row = (id: number, extra: Partial<Place> = {}): Place =>
+	({ id, lat: 0, lon: 0, ...extra }) as Place;
+
+// The inert-until-ready contract's producer half: the latch guards below are
+// load-bearing — flipping a gate true with no tags merged would hide every
+// pin in a payment-filtered embed (the consumer side is pinned in
+// visiblePlaces.test.ts). The live-data e2e can never reach these branches.
+describe("ensurePaymentMethods", () => {
+	beforeEach(() => {
+		mockGet.mockReset();
+		places.set([]);
+		paymentDataLoaded.set(false);
+		verifiedDatesLoaded.set(false);
+	});
+
+	it("does not latch on a non-array response", async () => {
+		places.set([row(1)]);
+		mockGet.mockResolvedValue({ data: "<html>error page</html>" });
+		await ensurePaymentMethods();
+		expect(get(paymentDataLoaded)).toBe(false);
+	});
+
+	it("does not latch on an empty response", async () => {
+		places.set([row(1)]);
+		mockGet.mockResolvedValue({ data: [] });
+		await ensurePaymentMethods();
+		expect(get(paymentDataLoaded)).toBe(false);
+	});
+
+	it("does not latch on rows carrying no payment tags", async () => {
+		places.set([row(1)]);
+		mockGet.mockResolvedValue({ data: [{ id: 1 }, { id: 2 }] });
+		await ensurePaymentMethods();
+		expect(get(paymentDataLoaded)).toBe(false);
+	});
+
+	it("bails without latching when $places has not loaded yet", async () => {
+		mockGet.mockResolvedValue({
+			data: [{ id: 1, "osm:payment:lightning": "yes" }],
+		});
+		await ensurePaymentMethods();
+		expect(get(paymentDataLoaded)).toBe(false);
+		expect(get(places)).toEqual([]);
+	});
+
+	it("does not latch on a failed fetch", async () => {
+		places.set([row(1)]);
+		mockGet.mockRejectedValue(new Error("network down"));
+		await ensurePaymentMethods();
+		expect(get(paymentDataLoaded)).toBe(false);
+	});
+
+	it("merges tags by id, keeps untagged rows untouched, and latches", async () => {
+		places.set([row(1), row(2, { name: "kept" })]);
+		mockGet.mockResolvedValue({
+			data: [
+				{
+					id: 1,
+					"osm:payment:onchain": "no",
+					"osm:payment:lightning": "yes",
+				},
+			],
+		});
+		await ensurePaymentMethods();
+		expect(get(paymentDataLoaded)).toBe(true);
+		const [first, second] = get(places);
+		expect(first["osm:payment:lightning"]).toBe("yes");
+		// "no" merges too — a row that explicitly refuses a method is data,
+		// and the strict === "yes" match handles it downstream.
+		expect(first["osm:payment:onchain"]).toBe("no");
+		expect(second["osm:payment:lightning"]).toBeUndefined();
+		expect(second.name).toBe("kept");
+	});
+
+	it("is a no-op once latched", async () => {
+		places.set([row(1)]);
+		mockGet.mockResolvedValue({
+			data: [{ id: 1, "osm:payment:lightning": "yes" }],
+		});
+		await ensurePaymentMethods();
+		await ensurePaymentMethods();
+		expect(mockGet).toHaveBeenCalledTimes(1);
+	});
+
+	// The combo-deep-link race (?issues&lightning dispatches both enrichers
+	// in one flush): each reads the whole $places array and republishes it,
+	// so without the enrichment lock the later places.set would erase the
+	// earlier merge — a blank filtered embed for the rest of the session.
+	it("running concurrently with ensureVerifiedDates keeps both merges", async () => {
+		places.set([row(1), row(2)]);
+		mockGet.mockImplementation((url: string) => {
+			if (url.includes("verified_at")) {
+				return Promise.resolve({
+					data: [{ id: 1, verified_at: "2026-08-01" }],
+				});
+			}
+			return Promise.resolve({
+				data: [{ id: 1, "osm:payment:lightning": "yes" }],
+			});
+		});
+		await Promise.all([ensureVerifiedDates(), ensurePaymentMethods()]);
+		expect(get(verifiedDatesLoaded)).toBe(true);
+		expect(get(paymentDataLoaded)).toBe(true);
+		const [first] = get(places);
+		expect(first.verified_at).toBe("2026-08-01");
+		expect(first["osm:payment:lightning"]).toBe("yes");
+	});
+});

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -2,7 +2,11 @@ import type { AxiosProgressEvent } from "axios";
 import { get } from "svelte/store";
 
 import { API_BASE } from "$lib/api-base";
-import { buildFieldsParam, PLACE_FIELD_SETS } from "$lib/api-fields";
+import {
+	buildFieldsParam,
+	PLACE_FIELD_SETS,
+	PLACE_FIELDS,
+} from "$lib/api-fields";
 import api from "$lib/axios";
 import {
 	completePlaceUrl,
@@ -11,6 +15,7 @@ import {
 } from "$lib/placeDetails";
 import {
 	mapUpdates,
+	paymentDataLoaded,
 	places,
 	placesError,
 	placesLoadingProgress,
@@ -94,6 +99,22 @@ const getStaticFileDate = async (): Promise<string> => {
 	return getTwoWeeksAgoDate();
 };
 
+// Serializes the $places enrichment merges (verified dates, payment tags).
+// Each enricher reads the whole array, rebuilds it, and republishes; two
+// running concurrently — a combo deep link like ?issues&lightning dispatches
+// both in one reactive flush — would build from the same snapshot and the
+// later places.set would silently erase the earlier merge, with its
+// readiness flag already latched (hiding pins for the rest of the session).
+// Fetches stay concurrent; only the read→merge→publish window is exclusive.
+// The chain itself never rejects — each section's errors belong to its
+// caller.
+let enrichmentChain: Promise<unknown> = Promise.resolve();
+const withEnrichmentLock = <T>(section: () => Promise<T>): Promise<T> => {
+	const run = enrichmentChain.then(section);
+	enrichmentChain = run.catch(() => undefined);
+	return run;
+};
+
 // The bulk CDN feed (places.json) carries no verification date, so a place's
 // baseline date is unknown until this runs. Fetch verified_at for every place
 // in one lean call and merge it into $places by id. Fetched LAZILY — only when
@@ -122,25 +143,107 @@ export const ensureVerifiedDates = async (): Promise<void> => {
 		// flag false keeps the filter inert (shows everything) and lets a later
 		// sync retry.
 		if (verifiedById.size === 0) return;
-		const current = get(places);
-		// If the bulk places haven't loaded yet (the dates fetch won the race),
-		// bail without latching or caching — otherwise we'd persist an empty
-		// places_v4 and flip the gate true with no data, hiding everything. The
-		// caller re-runs once $places is populated.
-		if (current.length === 0) return;
-		const enriched = current.map((p) => {
-			const verified_at = verifiedById.get(p.id);
-			return verified_at && verified_at !== p.verified_at
-				? { ...p, verified_at }
-				: p;
+		await withEnrichmentLock(async () => {
+			// Re-check under the lock: a concurrent caller may have latched
+			// while this one waited.
+			if (get(verifiedDatesLoaded)) return;
+			const current = get(places);
+			// If the bulk places haven't loaded yet (the dates fetch won the race),
+			// bail without latching or caching — otherwise we'd persist an empty
+			// places_v4 and flip the gate true with no data, hiding everything. The
+			// caller re-runs once $places is populated.
+			if (current.length === 0) return;
+			const enriched = current.map((p) => {
+				const verified_at = verifiedById.get(p.id);
+				return verified_at && verified_at !== p.verified_at
+					? { ...p, verified_at }
+					: p;
+			});
+			// Always publishes (persistence is best-effort inside placeCache), so
+			// the enrichment survives a failed blob write — matching the old
+			// publish-first ordering this replaced.
+			await publishPlaces(enriched);
+			verifiedDatesLoaded.set(true);
 		});
-		// Always publishes (persistence is best-effort inside placeCache), so
-		// the enrichment survives a failed blob write — matching the old
-		// publish-first ordering this replaced.
-		await publishPlaces(enriched);
-		verifiedDatesLoaded.set(true);
 	} catch (error) {
 		console.warn("Could not load verification dates:", error);
+	}
+};
+
+// The bulk feed (MAP_SYNC) carries no payment-method tags, so the embed
+// payment filter (?onchain&lightning&nfc — see $lib/map/paymentFilter) has
+// nothing to match until this runs. Fetch the three tags for every place in
+// one lean call and merge them into $places by id. Fetched LAZILY — only
+// when a payment deep link is present (normal visitors never call this) and
+// once per session. Sets paymentDataLoaded so the filter flips from inert to
+// active. Best-effort: on failure the flag stays false and the filter keeps
+// showing everything.
+type PaymentTagsRow = Pick<
+	Place,
+	| "id"
+	| "osm:payment:onchain"
+	| "osm:payment:lightning"
+	| "osm:payment:lightning_contactless"
+>;
+
+export const ensurePaymentMethods = async (): Promise<void> => {
+	if (get(paymentDataLoaded)) return;
+	try {
+		const response = await api.get<PaymentTagsRow[]>(
+			`${API_BASE}/v4/places?fields=id,${buildFieldsParam(PLACE_FIELDS.PAYMENT_METHOD)}`,
+		);
+		if (!Array.isArray(response.data)) return;
+		const paymentById = new Map<number, PaymentTagsRow>();
+		for (const item of response.data) {
+			if (
+				typeof item?.id === "number" &&
+				(item["osm:payment:onchain"] !== undefined ||
+					item["osm:payment:lightning"] !== undefined ||
+					item["osm:payment:lightning_contactless"] !== undefined)
+			) {
+				paymentById.set(item.id, item);
+			}
+		}
+		// Same latch guard as ensureVerifiedDates: an empty/degenerate response
+		// must NOT flip the gate true, or the filter would hide every pin with
+		// no tags to match. Leaving the flag false keeps the filter inert
+		// (shows everything) and lets a later call retry.
+		if (paymentById.size === 0) return;
+		await withEnrichmentLock(async () => {
+			// Re-check under the lock: a concurrent caller may have latched
+			// while this one waited.
+			if (get(paymentDataLoaded)) return;
+			const current = get(places);
+			// If the bulk places haven't loaded yet (the tags fetch won the race),
+			// bail without latching or caching — the caller re-runs once $places
+			// is populated.
+			if (current.length === 0) return;
+			const enriched = current.map((p) => {
+				const row = paymentById.get(p.id);
+				if (
+					!row ||
+					(row["osm:payment:onchain"] === p["osm:payment:onchain"] &&
+						row["osm:payment:lightning"] === p["osm:payment:lightning"] &&
+						row["osm:payment:lightning_contactless"] ===
+							p["osm:payment:lightning_contactless"])
+				) {
+					return p;
+				}
+				return {
+					...p,
+					"osm:payment:onchain": row["osm:payment:onchain"],
+					"osm:payment:lightning": row["osm:payment:lightning"],
+					"osm:payment:lightning_contactless":
+						row["osm:payment:lightning_contactless"],
+				};
+			});
+			// Always publishes (persistence is best-effort inside placeCache), so
+			// the enrichment survives a failed blob write.
+			await publishPlaces(enriched);
+			paymentDataLoaded.set(true);
+		});
+	} catch (error) {
+		console.warn("Could not load payment methods:", error);
 	}
 };
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -57,6 +57,10 @@ import {
 	pinIconImageExpression,
 	pinVariantFor,
 } from "$lib/map/maplibreSprites";
+import {
+	parsePaymentFilter,
+	placeMatchesPaymentFilter,
+} from "$lib/map/paymentFilter";
 import { createPlacePinSource } from "$lib/map/placePinSource";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
@@ -86,6 +90,7 @@ import {
 } from "$lib/placeIssues";
 import { savedPlaceIds } from "$lib/session";
 import {
+	paymentDataLoaded,
 	places,
 	placesById,
 	placesError,
@@ -93,7 +98,7 @@ import {
 	placesLoadingStatus,
 	verifiedDatesLoaded,
 } from "$lib/store";
-import { ensureVerifiedDates } from "$lib/sync/places";
+import { ensurePaymentMethods, ensureVerifiedDates } from "$lib/sync/places";
 import { theme } from "$lib/theme";
 import type { Place } from "$lib/types";
 import { userLocation } from "$lib/userLocationStore";
@@ -126,6 +131,16 @@ let merchantListPanel: MerchantListPanel;
 const boostsOnly =
 	browser &&
 	new URLSearchParams(window.location.search).get("boosts") === "true";
+
+// Embed payment-method filter (?onchain&lightning&nfc — presence alone
+// counts, AND semantics, matching the legacy Leaflet params the Embedding
+// wiki documents; restored after the #398 rewrite dropped them, #1269).
+// Session-constant like ?boosts: iframes set it in the src URL, there is no
+// UI toggle. Narrows the pins and the nearby list to places whose flagged
+// methods are tagged "yes", once the lazy tag enrichment lands.
+const paymentFilter = browser
+	? parsePaymentFilter(new URLSearchParams(window.location.search))
+	: null;
 
 // "Outdated only" deep link (?outdated, any value — presence alone counts,
 // matching the legacy Leaflet param): seed the verified-recency filter's
@@ -437,16 +452,19 @@ const getBufferedBoundsLngLat = (
 };
 
 // One reactive source for the list fetch behavior. Boosted-only /
-// issues-only: the bulk $places feed already holds the full filtered set
-// at every zoom, and the radius API (api-with-limit) can filter by
-// neither boost nor issue state, so force the local path — the list,
-// count, and panel status stay in sync with the filtered map.
+// issues-only / payment-filtered: the bulk $places feed already holds the
+// full filtered set at every zoom, and the radius API (api-with-limit) can
+// filter by neither boost, issue, nor payment state, so force the local
+// path — the list, count, and panel status stay in sync with the filtered
+// map.
 // MUST stay in source order above every reactive block that calls
 // updateMerchantList() synchronously (the search-exit watcher and the
 // initial-count block): Svelte 4 can't see this dependency through the
 // function body, so ordering falls back to source position.
 $: listBehavior =
-	boostsOnly || issuesOnly ? "local-markers" : getZoomBehavior(currentZoom);
+	boostsOnly || issuesOnly || paymentFilter != null
+		? "local-markers"
+		: getZoomBehavior(currentZoom);
 
 // Refresh the panel's nearby list based on the current viewport. Mirrors
 // /map's `updateMerchantList` minus the panel-offset bookkeeping (out of
@@ -477,6 +495,16 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 					p.lon <= buffered.east,
 			);
 			let listed = boostsOnly ? visible.filter(isBoosted) : visible;
+			// Same readiness gate as the marker pipeline: before the payment
+			// tag enrichment lands, the list stays unfiltered rather than
+			// hiding every bulk row (none carry payment tags yet). Applied
+			// before the issue tallies so chip counts describe the narrowed
+			// embed world, matching selectVisiblePlaces.
+			if (paymentFilter && get(paymentDataLoaded)) {
+				listed = listed.filter((p) =>
+					placeMatchesPaymentFilter(p, paymentFilter),
+				);
+			}
 			// Same readiness gate as the marker pipeline: before the
 			// verified_at enrichment lands, the list stays unfiltered
 			// rather than flagging every bulk row as not_verified.
@@ -493,6 +521,17 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 				listed = listed.filter((p) => placeMatchesIssueCodes(p, issueCodes));
 			}
 			merchantList.setMerchants(listed, center.lat, center.lng);
+			// E2E test hook, same idea as __mapPlacesCount: the payment/boost/
+			// issue deep links force this local path and pre-narrow the list,
+			// and the specs need a DOM-independent way to pin that the list
+			// surface narrows with the pins. Only set here — the api-with-limit
+			// path never sees the filters, so a wiring regression leaves the
+			// hook unset and the spec fails. No-op outside tests.
+			if (typeof window !== "undefined") {
+				(
+					window as unknown as { __nearbyListCount?: number }
+				).__nearbyListCount = listed.length;
+			}
 			if (listOpen || currentZoom >= LABEL_VISIBLE_ZOOM) {
 				if (allowHeavyFetch || currentZoom >= LABEL_VISIBLE_ZOOM) {
 					const radiusKm =
@@ -761,6 +800,12 @@ $: if (map && styleLoaded && $places) {
 		// Trivially ready when the mode is off or exempted, so the dates
 		// landing can't change the signature outside issues mode.
 		issuesReady: !issuesOnly || inSearch || $verifiedDatesLoaded,
+		// Markers exempt search mode from the payment narrowing, same
+		// policy as boosts: an explicit query should surface all matches.
+		paymentFilter: inSearch ? null : paymentFilter,
+		// Trivially ready when the filter is off or exempted, so the tag
+		// enrichment landing can't change the signature outside payment mode.
+		paymentReady: !paymentFilter || inSearch || $paymentDataLoaded,
 	};
 	const renderSig = [
 		computeVisibleSignature(
@@ -826,6 +871,22 @@ $: if (
 ) {
 	didInitialVerifiedLoad = true;
 	void ensureVerifiedDates().then(() => updateMerchantList({ force: true }));
+}
+
+// A payment deep link (?onchain&lightning&nfc): load the payment tags once
+// the bulk places are in (same race guard as the verified block above), so
+// the embed arrives filtered without any interaction.
+let didInitialPaymentLoad = false;
+$: if (
+	browser &&
+	map &&
+	styleLoaded &&
+	$places.length > 0 &&
+	!didInitialPaymentLoad &&
+	paymentFilter != null
+) {
+	didInitialPaymentLoad = true;
+	void ensurePaymentMethods().then(() => updateMerchantList({ force: true }));
 }
 
 // Globe projection is page state: a basemap swap resets the projection to

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -377,6 +377,9 @@ $: filteredSearchResults = selectVisiblePlaces({
 	boostsOnly: false,
 	issueCodes: null,
 	issuesReady: true,
+	// Search is exempt from the embed payment narrowing, matching the pins.
+	paymentFilter: null,
+	paymentReady: true,
 }).selection;
 
 // Helper function to check if a category has matching merchants

--- a/tests/map-payment-filter.spec.ts
+++ b/tests/map-payment-filter.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test';
+import { MARKER_LOAD_TIMEOUT, waitForMarkersToLoad } from './helpers';
+
+// Regression guard for the /map payment deep links (?onchain&lightning&nfc)
+// the Embedding wiki documents for iframe embeds (e.g. boltcard.org). The
+// original params were silently lost in a map rewrite (#398) because nothing
+// pinned their behavior — these tests exist so that can't happen again.
+// See #1269.
+test.describe('Map payment method filters', () => {
+	const placesCount = (page: import('@playwright/test').Page) =>
+		page.evaluate(
+			() => (window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount ?? 0
+		);
+
+	const nearbyListCount = (page: import('@playwright/test').Page) =>
+		page.evaluate(
+			() => (window as unknown as { __nearbyListCount?: number }).__nearbyListCount ?? 0
+		);
+
+	test('?lightning narrows the rendered places once payment tags load', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		// Baseline: unfiltered world view.
+		await page.goto('/map', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		const baseline = await placesCount(page);
+		expect(baseline).toBeGreaterThan(0);
+
+		// Deep link: the filter engages after the one-time payment-tag
+		// enrichment fetch lands, so poll until the count settles below the
+		// baseline (lightning=yes is ~79% of places at the time of writing,
+		// so 95% leaves ample headroom for data drift).
+		await page.goto('/map?lightning', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => placesCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeLessThan(baseline * 0.95);
+		expect(await placesCount(page)).toBeGreaterThan(0);
+	});
+
+	test('the nearby list narrows with the pins', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		// San Salvador center at zoom 15: dense (~250 places) with a small
+		// nfc=yes minority (~12% at the time of writing), so both directions
+		// of the assertion have wide drift headroom. Zoom 15 uses the
+		// local-markers list path even WITHOUT a deep link, giving an
+		// unfiltered baseline for the same viewport.
+		const CITY_HASH = '#15/13.7000/-89.2240';
+
+		await page.goto(`/map${CITY_HASH}`, { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => nearbyListCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeGreaterThan(0);
+		const unfiltered = await nearbyListCount(page);
+
+		// Same viewport with ?nfc: the deep link must narrow the nearby list
+		// too, not just the pins — the panel would otherwise contradict the
+		// embed's filtered map. A dropped list pre-filter leaves the count at
+		// ~unfiltered; a dropped local-markers forcing never sets the hook.
+		await page.goto(`/map?nfc${CITY_HASH}`, { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(
+				async () => {
+					const count = await nearbyListCount(page);
+					return count > 0 && count < unfiltered * 0.5;
+				},
+				{ timeout: MARKER_LOAD_TIMEOUT }
+			)
+			.toBe(true);
+	});
+
+	test('?nfc maps to lightning_contactless and combined params AND together', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		await page.goto('/map', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		const baseline = await placesCount(page);
+		expect(baseline).toBeGreaterThan(0);
+
+		// ?nfc requires payment:lightning_contactless=yes — a small subset
+		// (~12% at the time of writing; 50% leaves headroom for drift).
+		await page.goto('/map?nfc', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => placesCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeLessThan(baseline * 0.5);
+		const nfcCount = await placesCount(page);
+		expect(nfcCount).toBeGreaterThan(0);
+
+		// AND semantics: adding ?lightning can only narrow the set further
+		// (or keep it equal), never widen it.
+		await page.goto('/map?nfc&lightning', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => placesCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeLessThan(baseline * 0.5);
+		expect(await placesCount(page)).toBeLessThanOrEqual(nfcCount);
+		expect(await placesCount(page)).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
Fixes #1269

## What broke

The `?onchain` / `?lightning` / `?nfc` params documented on the [Embedding wiki page](https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Embedding#if-you-would-like-to-filter-by-payment-method) (and used by embeds like boltcard.org) were silently dropped in the #398 map rewrite (`be8955ad`) — the same regression class as `?boosts` (restored in #1097) and `?outdated` (restored in #1155). Nothing pinned their behavior, so nothing failed.

## What this does

- **`$lib/map/paymentFilter.ts`** — parse/match/serialize for the deep link, with the legacy Leaflet semantics: presence-only params, AND across methods, `nfc` → `payment:lightning_contactless`, and **strict `=== "yes"`** matching. The strictness is load-bearing: live OSM data carries `"no"` (13k places for onchain), `"Yes"`, `"yed"`, even email addresses in these tags.
- **`selectVisiblePlaces`** gains `paymentFilter`/`paymentReady` inputs, applied pre-category so chip counts describe the narrowed embed world. Search mode is exempt, same policy as boosts. The render signature covers both new inputs.
- **Lazy enrichment** — the bulk feed carries no payment tags, so a payment deep link fetches the three tags once via `ensurePaymentMethods()` (mirrors `ensureVerifiedDates`, including the degenerate-response latch guards; the filter stays inert until the tags land rather than hiding every pin). The tags also ride along on incremental `MAP_SYNC` rows so a mid-session update can't strip an enriched place out of the filter.
- **Enrichment lock** — combo deep links (`?issues&lightning`) dispatch both enrichers in one reactive flush; each does read→merge→publish over the whole `$places` array, so the later `places.set` could erase the earlier merge with its readiness flag already latched (blank embed for the session). Their merge windows now run serialized; fetches stay concurrent.
- **Map page wiring** — the deep link forces the local-markers list path (the radius API can't filter by payment) and pre-narrows the nearby list, mirroring boosts/issues.

## Tests (so this can't be silently lost again)

- Unit: parse/match/serialize semantics (incl. the `"no"`/noise rejection), pipeline narrowing + inert-until-ready gating + signature coverage, and the enrichment producer (latch guards, merge-by-id, no-op-once-latched, and a concurrency test that fails if the lock is removed — mutation-verified).
- e2e (`tests/map-payment-filter.spec.ts`, modeled on the `?outdated` guard): `?lightning` narrows the rendered pins; `?nfc` + AND semantics; and the nearby list narrows with the pins (San Salvador z15 anchor — ~250 places, ~12% nfc, wide drift headroom on both sides; new `__nearbyListCount` hook next to the existing `__mapPlacesCount` precedent).
- Thresholds calibrated from prod data: lightning=yes ≈79%, nfc=yes ≈12%, onchain=yes ≈40% of 29,320 places.

Not covered (noted deliberately): the search-mode exemption is comment-documented only, matching the equally-unpinned boosts exemption it copies.

## Notes for review

- `/communities/map` never had these params (verified in git history) — out of scope here; the wiki's "in addition to the location params above" phrasing slightly oversells, but the issue and boltcard.org are about `/map`.
- `routes/map/+page.svelte` and `MerchantListPanel` stay legacy syntax on purpose (#1208 hand-conversion hotspots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment-method filtering for embedded maps using `?onchain`, `?lightning`, and `?nfc` URL parameters.
  * Applied filters consistently to map pins and nearby-place lists, including combined filters.
  * Added lazy loading of payment information to support filtering without affecting search results.
* **Bug Fixes**
  * Improved enrichment reliability when payment and verification data load concurrently.
* **Tests**
  * Added coverage for payment filtering, deep links, combined criteria, readiness, and nearby-list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->