### PR TITLE
fix(map): restore ?onchain&lightning&nfc embed payment filters #1269

### DIFF
--- a/src/lib/api-fields.ts
+++ b/src/lib/api-fields.ts
@@ -56,7 +56,17 @@ export const PLACE_FIELD_SETS = {
 	// its date through a sync (no flicker) and the recency filter never needs a
 	// full re-fetch to stay fresh — the baseline is loaded once, lazily, by
 	// ensureVerifiedDates() when the filter is first engaged.
-	MAP_SYNC: [...PLACE_FIELDS.CORE, ...PLACE_FIELDS.SYNC, "verified_at"],
+	MAP_SYNC: [
+		...PLACE_FIELDS.CORE,
+		...PLACE_FIELDS.SYNC,
+		"verified_at",
+		// Payment tags ride along (#1269): without them a MAP_SYNC update
+		// replaces a place wholesale and would wipe the payment-tag
+		// enrichment ensurePaymentMethods() merged in mid-session.
+		"osm:payment:onchain",
+		"osm:payment:lightning",
+		"osm:payment:lightning_contactless",
+	],
 	COMPLETE_PLACE: [
 		...PLACE_FIELDS.CORE,
 		...PLACE_FIELDS.SYNC,

--- a/src/lib/map/paymentMethodFilter.test.ts
+++ b/src/lib/map/paymentMethodFilter.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import type { Place } from "$lib/types";
+
+import {
+	PAYMENT_METHODS,
+	parsePaymentMethodsParam,
+	placeMatchesPaymentMethods,
+	serializePaymentMethodsParam,
+} from "./paymentMethodFilter";
+
+let nextId = 1;
+const place = (overrides: Partial<Place> = {}): Place =>
+	({ id: nextId++, lat: 0, lon: 0, ...overrides }) as Place;
+
+describe("parsePaymentMethodsParam", () => {
+	it("reads bare presence params (the legacy embed form)", () => {
+		expect(
+			parsePaymentMethodsParam(new URLSearchParams("?onchain&nfc")),
+		).toEqual(new Set(["onchain", "nfc"]));
+	});
+
+	it("counts any value as present", () => {
+		expect(
+			parsePaymentMethodsParam(new URLSearchParams("?lightning=1")),
+		).toEqual(new Set(["lightning"]));
+	});
+
+	it("is null when no recognized param appears", () => {
+		expect(parsePaymentMethodsParam(new URLSearchParams(""))).toBeNull();
+		expect(
+			parsePaymentMethodsParam(new URLSearchParams("?paid=true")),
+		).toBeNull();
+	});
+
+	it("ignores unrecognized payment-ish params", () => {
+		expect(
+			parsePaymentMethodsParam(new URLSearchParams("?cash&bitcoin")),
+		).toBeNull();
+	});
+});
+
+describe("serializePaymentMethodsParam", () => {
+	it("round-trips through parse in canonical PAYMENT_METHODS order", () => {
+		const parsed = parsePaymentMethodsParam(
+			new URLSearchParams("?nfc&onchain"),
+		);
+		expect(parsed && serializePaymentMethodsParam(parsed)).toBe("onchain,nfc");
+	});
+});
+
+describe("placeMatchesPaymentMethods", () => {
+	it("requires every selected method to be tagged yes", () => {
+		const full = place({
+			"osm:payment:onchain": "yes",
+			"osm:payment:lightning": "yes",
+			"osm:payment:lightning_contactless": "yes",
+		});
+		for (const method of PAYMENT_METHODS) {
+			expect(placeMatchesPaymentMethods(full, new Set([method]))).toBe(true);
+		}
+		expect(placeMatchesPaymentMethods(full, new Set(PAYMENT_METHODS))).toBe(
+			true,
+		);
+	});
+
+	it("drops places missing any selected method", () => {
+		const lnOnly = place({ "osm:payment:lightning": "yes" });
+		expect(placeMatchesPaymentMethods(lnOnly, new Set(["lightning"]))).toBe(
+			true,
+		);
+		expect(placeMatchesPaymentMethods(lnOnly, new Set(["onchain"]))).toBe(
+			false,
+		);
+		expect(
+			placeMatchesPaymentMethods(lnOnly, new Set(["lightning", "onchain"])),
+		).toBe(false);
+	});
+
+	it("treats non-yes tag values as not accepted", () => {
+		// The generated types promise "yes", but the wire data is untrusted —
+		// anything else must fail the match.
+		const noTag = {
+			id: nextId++,
+			lat: 0,
+			lon: 0,
+			"osm:payment:onchain": "no",
+		} as unknown as Place;
+		expect(placeMatchesPaymentMethods(noTag, new Set(["onchain"]))).toBe(false);
+	});
+
+	it("maps nfc onto lightning_contactless only", () => {
+		const contactless = place({ "osm:payment:lightning_contactless": "yes" });
+		expect(placeMatchesPaymentMethods(contactless, new Set(["nfc"]))).toBe(
+			true,
+		);
+		expect(
+			placeMatchesPaymentMethods(contactless, new Set(["lightning"])),
+		).toBe(false);
+	});
+});

--- a/src/lib/map/paymentMethodFilter.ts
+++ b/src/lib/map/paymentMethodFilter.ts
@@ -1,0 +1,57 @@
+import type { Place } from "$lib/types";
+
+// Legacy embed contract restored (#1269): bare URL params (?onchain&lightning&nfc)
+// narrow the map to places accepting each method — AND across params, presence
+// alone counts (the old Leaflet map filtered markers on load exactly this way).
+// This module feeds that constraint into selectVisiblePlaces so pins, lists,
+// chip counts, and search can never disagree.
+
+export const PAYMENT_METHODS = ["onchain", "lightning", "nfc"] as const;
+
+export type PaymentMethod = (typeof PAYMENT_METHODS)[number];
+
+// URL param → OSM tag field on Place. `nfc` is the legacy param name for
+// payment:lightning_contactless (kept short in the Embedding wiki contract).
+const PAYMENT_METHOD_TAG: Record<
+	PaymentMethod,
+	| "osm:payment:onchain"
+	| "osm:payment:lightning"
+	| "osm:payment:lightning_contactless"
+> = {
+	onchain: "osm:payment:onchain",
+	lightning: "osm:payment:lightning",
+	nfc: "osm:payment:lightning_contactless",
+};
+
+// The tag fields only (all optional on Place). Accepting this narrow shape —
+// which both a full Place and a lean API row satisfy — lets the closed-panel
+// badge count (fetchCountOnly) reuse the predicate without pretending its
+// id+tags rows are full Places.
+export type PaymentTaggedPlace = Pick<
+	Place,
+	(typeof PAYMENT_METHOD_TAG)[PaymentMethod]
+>;
+
+// Presence-based parse matching the legacy behavior: ?onchain&lightning has no
+// values, ?nfc=1 or even ?nfc= all count. No recognized params → null (off).
+export const parsePaymentMethodsParam = (
+	params: URLSearchParams,
+): ReadonlySet<PaymentMethod> | null => {
+	const selected = PAYMENT_METHODS.filter((method) => params.has(method));
+	return selected.length > 0 ? new Set(selected) : null;
+};
+
+export const serializePaymentMethodsParam = (
+	methods: ReadonlySet<PaymentMethod>,
+): string => PAYMENT_METHODS.filter((method) => methods.has(method)).join(",");
+
+// AND semantics: a place must accept EVERY selected method.
+export const placeMatchesPaymentMethods = (
+	place: PaymentTaggedPlace,
+	methods: ReadonlySet<PaymentMethod>,
+): boolean => {
+	for (const method of methods) {
+		if (place[PAYMENT_METHOD_TAG[method]] !== "yes") return false;
+	}
+	return true;
+};

--- a/src/lib/map/visiblePlaces.test.ts
+++ b/src/lib/map/visiblePlaces.test.ts
@@ -2,6 +2,7 @@ import { get } from "svelte/store";
 import { describe, expect, it } from "vitest";
 
 import { CATEGORIES, placeMatchesCategory } from "$lib/categoryMapping";
+import { PAYMENT_METHODS } from "$lib/map/paymentMethodFilter";
 import { DERIVED_ISSUE_CODES } from "$lib/placeIssues";
 import { places } from "$lib/store";
 import type { Place } from "$lib/types";
@@ -41,6 +42,8 @@ const base = {
 	boostsOnly: false,
 	issueCodes: null,
 	issuesReady: true,
+	paymentMethods: null,
+	paymentsReady: true,
 };
 
 const allIssueCodes = new Set(DERIVED_ISSUE_CODES);
@@ -186,6 +189,56 @@ describe("selectVisiblePlaces", () => {
 		expect(r.selection.length).toBe(7);
 	});
 
+	it("narrows to places accepting every selected payment method", () => {
+		const rows = [
+			place({ "osm:payment:onchain": "yes" }),
+			place({ "osm:payment:lightning": "yes" }),
+			place({ "osm:payment:onchain": "yes", "osm:payment:lightning": "yes" }),
+		];
+		const r = selectVisiblePlaces({
+			...base,
+			places: rows,
+			paymentMethods: new Set(["onchain", "lightning"] as const),
+		});
+		expect(r.selection.length).toBe(1);
+		expect(r.counts.all).toBe(1);
+	});
+
+	it("keeps the payments filter inert until the tags are ready", () => {
+		// Bulk rows carry no osm:payment:* fields; before the lazy
+		// enrichment lands the filter must hide nothing.
+		const rows = [place(), place({ icon: "restaurant" })];
+		const r = selectVisiblePlaces({
+			...base,
+			places: rows,
+			paymentMethods: new Set(PAYMENT_METHODS),
+			paymentsReady: false,
+		});
+		expect(r.selection.length).toBe(2);
+	});
+
+	it("applies the payments filter before category counts", () => {
+		const rows = [
+			place({
+				icon: "restaurant",
+				"osm:payment:lightning": "yes",
+				verified_at: recent(),
+			}),
+			place({ icon: "restaurant", verified_at: recent() }),
+		];
+		const r = selectVisiblePlaces({
+			...base,
+			places: rows,
+			category: "restaurants",
+			paymentMethods: new Set(["lightning"] as const),
+		});
+		expect(r.selection.length).toBe(1);
+		// Counts describe the payment-filtered pre-category set, so chips
+		// never promise places the embed filter excludes.
+		expect(r.counts.all).toBe(1);
+		expect(r.counts.restaurants).toBe(1);
+	});
+
 	it("composes boosts after category (empty intersections are honest)", () => {
 		const r = selectVisiblePlaces({
 			...base,
@@ -237,6 +290,29 @@ describe("computeVisibleSignature", () => {
 		);
 		expect(
 			computeVisibleSignature({ ...inputs, issuesReady: false }, 7, ""),
+		).not.toBe(sig);
+		expect(
+			computeVisibleSignature(
+				{ ...inputs, paymentMethods: new Set(["lightning"] as const) },
+				7,
+				"",
+			),
+		).not.toBe(sig);
+		expect(
+			computeVisibleSignature(
+				{ ...inputs, paymentMethods: new Set(["nfc"] as const) },
+				7,
+				"",
+			),
+		).not.toBe(
+			computeVisibleSignature(
+				{ ...inputs, paymentMethods: new Set(["lightning"] as const) },
+				7,
+				"",
+			),
+		);
+		expect(
+			computeVisibleSignature({ ...inputs, paymentsReady: false }, 7, ""),
 		).not.toBe(sig);
 		expect(
 			computeVisibleSignature({ ...inputs, mode: "search" }, 7, "1,2"),

--- a/src/lib/map/visiblePlaces.ts
+++ b/src/lib/map/visiblePlaces.ts
@@ -5,6 +5,11 @@ import {
 	countMerchantsByCategory,
 	placeMatchesCategory,
 } from "$lib/categoryMapping";
+import {
+	type PaymentMethod,
+	placeMatchesPaymentMethods,
+	serializePaymentMethodsParam,
+} from "$lib/map/paymentMethodFilter";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
 import type { DerivedIssueCode } from "$lib/placeIssues";
 import { placeMatchesIssueCodes, serializeIssuesParam } from "$lib/placeIssues";
@@ -45,10 +50,21 @@ export type VisibleSelectionInputs = {
 	// the filter stays inert (rather than flagging every row as
 	// not_verified) until enrichment lands.
 	issuesReady: boolean;
+	// The ?onchain&lightning&nfc embed filter (#1269): null when off; otherwise
+	// a place stays visible only when it accepts EVERY selected method. Unlike
+	// boosts/issues there is no search exemption — an embedded map must keep
+	// its payment promise everywhere.
+	paymentMethods: ReadonlySet<PaymentMethod> | null;
+	// Same readiness contract as the two gates above: the bulk CDN feed and
+	// MAP_SYNC rows lack payment tags entirely, so consumers gate on
+	// $paymentTagsLoaded and stay inert rather than hiding every row. API
+	// rows (search / radius LIST_ITEM) carry the tags natively and pass true.
+	paymentsReady: boolean;
 };
 
 export type VisibleSelection = {
-	// The final visible set: recency → category → boosts, deleted rows dropped.
+	// The final visible set: recency → issues → payments → category → boosts,
+	// deleted rows dropped.
 	selection: Place[];
 	// The recency-filtered, PRE-category set — what chip counts and density
 	// ceilings are computed on (a selected chip must not hide the other
@@ -73,6 +89,12 @@ export function selectVisiblePlaces(
 	if (issueCodes && inputs.issuesReady) {
 		preCategory = preCategory.filter((p) =>
 			placeMatchesIssueCodes(p, issueCodes),
+		);
+	}
+	if (inputs.paymentMethods && inputs.paymentsReady) {
+		const methods = inputs.paymentMethods;
+		preCategory = preCategory.filter((p) =>
+			placeMatchesPaymentMethods(p, methods),
 		);
 	}
 	const counts = countMerchantsByCategory(preCategory);
@@ -115,6 +137,10 @@ export function computeVisibleSignature(
 			? serializeIssuesParam(inputs.issueCodes) || "all"
 			: "off",
 		inputs.issuesReady,
+		inputs.paymentMethods
+			? serializePaymentMethodsParam(inputs.paymentMethods)
+			: "off",
+		inputs.paymentsReady,
 		revision,
 		searchResultIds,
 	].join("|");

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -9,6 +9,11 @@ import type { CategoryCounts, CategoryKey } from "$lib/categoryMapping";
 import { createEmptyCategoryCounts } from "$lib/categoryMapping";
 import { MERCHANT_LIST_MAX_ITEMS } from "$lib/constants";
 import { _ } from "$lib/i18n";
+import type { PaymentMethod } from "$lib/map/paymentMethodFilter";
+import {
+	type PaymentTaggedPlace,
+	placeMatchesPaymentMethods,
+} from "$lib/map/paymentMethodFilter";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
 import {
 	getStoredVerifiedFilter,
@@ -17,7 +22,7 @@ import {
 import { selectVisiblePlaces } from "$lib/map/visiblePlaces";
 import { isBoosted } from "$lib/merchantDrawerLogic";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
-import { verifiedDatesLoaded } from "$lib/store";
+import { paymentTagsLoaded, verifiedDatesLoaded } from "$lib/store";
 import type { Place } from "$lib/types";
 import type { UserLocation } from "$lib/userLocationStore";
 import { userLocation } from "$lib/userLocationStore";
@@ -62,6 +67,11 @@ export type MerchantListState = {
 	categoryCounts: CategoryCounts;
 	// "Verified within N years" filter (null = Any/off); persisted to localStorage
 	verifiedWithinYears: VerifiedFilterYears;
+	// ?onchain&lightning&nfc embed filter (#1269), seeded by the map page from
+	// the URL and locked for the session — no persistence, no user toggle.
+	// null = off. Consumed by every selectVisiblePlaces call site in this
+	// store so pins, lists, and counts can't disagree.
+	paymentMethods: ReadonlySet<PaymentMethod> | null;
 };
 
 const initialState: MerchantListState = {
@@ -80,6 +90,7 @@ const initialState: MerchantListState = {
 	selectedCategory: "all",
 	categoryCounts: createEmptyCategoryCounts(),
 	verifiedWithinYears: getStoredVerifiedFilter(),
+	paymentMethods: null,
 };
 
 // Helper function to reset category state
@@ -210,7 +221,7 @@ function createMerchantListStore() {
 		// Counts come from the shared pipeline on the recency-filtered set;
 		// the panel renders the same pipeline's selection
 		// (filteredSearchResults), so chips and rows can never disagree.
-		const { verifiedWithinYears } = get(store);
+		const { verifiedWithinYears, paymentMethods } = get(store);
 		const { counts: categoryCounts } = selectVisiblePlaces({
 			places: sortedResults,
 			mode: "search",
@@ -220,6 +231,9 @@ function createMerchantListStore() {
 			boostsOnly: false,
 			issueCodes: null,
 			issuesReady: true,
+			// /v4/search rows carry the payment tags natively (LIST_ITEM).
+			paymentMethods,
+			paymentsReady: true,
 		});
 		update((state) => ({
 			...resetCategoryState(state),
@@ -390,7 +404,8 @@ function createMerchantListStore() {
 			centerLon?: number,
 			limit: number = MERCHANT_LIST_MAX_ITEMS,
 		) {
-			const { selectedCategory, verifiedWithinYears } = get(store);
+			const { selectedCategory, verifiedWithinYears, paymentMethods } =
+				get(store);
 			// The shared pipeline applies the recency window (gated on the lazy
 			// dates being loaded, matching the markers), computes chip counts on
 			// the pre-category set, and applies the auto-reset rule — one
@@ -404,6 +419,10 @@ function createMerchantListStore() {
 				boostsOnly: false,
 				issueCodes: null,
 				issuesReady: true,
+				// Bulk-feed rows lack payment tags until the lazy enrichment
+				// lands; inert until then (same gate the markers use).
+				paymentMethods,
+				paymentsReady: paymentMethods == null || get(paymentTagsLoaded),
 			});
 
 			const sorted = sortMerchants(
@@ -457,7 +476,8 @@ function createMerchantListStore() {
 				// otherwise-too-dense area under the ceiling, so the filter stays
 				// effective at zoom 10-14. The density ceiling compares the
 				// PRE-category set — a selected chip must not defeat it.
-				const { selectedCategory, verifiedWithinYears } = get(store);
+				const { selectedCategory, verifiedWithinYears, paymentMethods } =
+					get(store);
 				const { selection, preCategory, counts, effectiveCategory } =
 					selectVisiblePlaces({
 						places: validPlaces,
@@ -468,6 +488,9 @@ function createMerchantListStore() {
 						boostsOnly: false,
 						issueCodes: null,
 						issuesReady: true,
+						// Radius rows carry the payment tags natively (LIST_ITEM).
+						paymentMethods,
+						paymentsReady: true,
 					});
 
 				// Check if we should hide results (too many at low zoom)
@@ -551,19 +574,34 @@ function createMerchantListStore() {
 			// One snapshot so the fields param and the post-response filter can
 			// never disagree; a mid-flight filter change re-invokes this method,
 			// which aborts the stale request above.
-			const { verifiedWithinYears } = get(store);
-			const fields = verifiedWithinYears == null ? "id" : "id,verified_at";
+			const { verifiedWithinYears, paymentMethods } = get(store);
+			// Widen the lean payload with exactly the fields the active filters
+			// need: verified_at for the recency window, the payment tags for
+			// the ?onchain&lightning&nfc embed filter (#1269).
+			const fields = [
+				"id",
+				...(verifiedWithinYears == null ? [] : ["verified_at"]),
+				...(paymentMethods == null
+					? []
+					: [
+							"osm:payment:onchain",
+							"osm:payment:lightning",
+							"osm:payment:lightning_contactless",
+						]),
+			].join(",");
 
 			try {
 				// Typed to the payload actually requested — these rows are not
 				// full Places and must not be handed to anything expecting one.
 				const validItems = await searchPlacesInRadius<
-					Pick<Place, "id" | "verified_at">
+					Pick<Place, "id"> & Pick<Place, "verified_at"> & PaymentTaggedPlace
 				>(center, radiusKm, fields, listAbortController.signal);
-				const recencyPlaces = filterPlacesByRecency(
-					validItems,
-					verifiedWithinYears,
-				);
+				let counted = filterPlacesByRecency(validItems, verifiedWithinYears);
+				if (paymentMethods) {
+					counted = counted.filter((p) =>
+						placeMatchesPaymentMethods(p, paymentMethods),
+					);
+				}
 
 				// A response that raced a filter change can settle before the
 				// re-invocation aborts it (e.g. during applyVerifiedFilter's
@@ -578,7 +616,7 @@ function createMerchantListStore() {
 				update((state) => ({
 					...state,
 					merchants: [],
-					totalCount: recencyPlaces.length,
+					totalCount: counted.length,
 					isLoadingList: false,
 					listError: false,
 					// Preserve existing categoryCounts since we don't have actual merchant data to recalculate them
@@ -749,6 +787,9 @@ function createMerchantListStore() {
 						boostsOnly: false,
 						issueCodes: null,
 						issuesReady: true,
+						paymentMethods: state.paymentMethods,
+						// Search rows carry the payment tags natively (LIST_ITEM).
+						paymentsReady: true,
 					});
 					return {
 						...state,
@@ -764,6 +805,13 @@ function createMerchantListStore() {
 		// Reset the selected category to 'all'
 		resetCategory() {
 			update((state) => resetCategoryState(state));
+		},
+
+		// Seed the ?onchain&lightning&nfc embed filter (#1269). Session-only:
+		// the page parses the URL once at init and calls this — no persistence,
+		// no user-facing toggle. Pass null to turn the filter off.
+		setPaymentMethods(methods: ReadonlySet<PaymentMethod> | null) {
+			update((state) => ({ ...state, paymentMethods: methods }));
 		},
 
 		// Re-sort merchants using current user location (if available)

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -40,6 +40,12 @@ export const placesLoadingProgress = writable<number>(0); // 0-100 percentage
 // src/lib/sync/places.ts (ensureVerifiedDates).
 export const verifiedDatesLoaded = writable(false);
 
+// True once the lazy payment-tag enrichment has loaded. The ?onchain&lightning&nfc
+// embed filter (#1269) needs osm:payment:* fields, which neither the bulk CDN
+// feed nor (pre-#1269) MAP_SYNC rows carry — same lazy pattern as
+// verifiedDatesLoaded above. See src/lib/sync/places.ts (ensurePaymentMethods).
+export const paymentTagsLoaded = writable(false);
+
 export const users: Writable<User[]> = writable([]);
 export const userError = writable("");
 

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -11,6 +11,7 @@ import {
 } from "$lib/placeDetails";
 import {
 	mapUpdates,
+	paymentTagsLoaded,
 	places,
 	placesError,
 	placesLoadingProgress,
@@ -141,6 +142,62 @@ export const ensureVerifiedDates = async (): Promise<void> => {
 		verifiedDatesLoaded.set(true);
 	} catch (error) {
 		console.warn("Could not load verification dates:", error);
+	}
+};
+
+// The bulk feed (CDN places.json) carries no payment tags, so the
+// ?onchain&lightning&nfc embed filter (#1269) has nothing to match on until
+// this runs. Fetch the three payment fields for every place in one lean call
+// and merge them into $places by id. Fetched LAZILY — only when an embed
+// param is present — and once per session (the flag is in-memory). Sets
+// paymentTagsLoaded so the filter flips from inert to active. Later MAP_SYNC
+// updates carry the tags themselves (see MAP_SYNC in api-fields), so changed
+// places stay fresh within the session too. Best-effort: on failure the flag
+// stays false and the filter keeps showing everything.
+export const ensurePaymentMethods = async (): Promise<void> => {
+	if (get(paymentTagsLoaded)) return;
+	try {
+		const response = await api.get<
+			{
+				id: number;
+				"osm:payment:onchain"?: "yes";
+				"osm:payment:lightning"?: "yes";
+				"osm:payment:lightning_contactless"?: "yes";
+			}[]
+		>(
+			`${API_BASE}/v4/places?fields=id,osm:payment:onchain,osm:payment:lightning,osm:payment:lightning_contactless`,
+		);
+		if (!Array.isArray(response.data)) return;
+		const tagsById = new Map(
+			response.data.map((item) => [item.id, item] as const),
+		);
+		// Same degenerate-response guard as ensureVerifiedDates: don't latch
+		// the flag (or republish) off an empty payload — stay inert and let a
+		// later call retry.
+		if (tagsById.size === 0) return;
+		const current = get(places);
+		if (current.length === 0) return;
+		const enriched = current.map((p) => {
+			const item = tagsById.get(p.id);
+			if (!item) return p;
+			let changed = false;
+			const next = { ...p };
+			for (const field of [
+				"osm:payment:onchain",
+				"osm:payment:lightning",
+				"osm:payment:lightning_contactless",
+			] as const) {
+				if (item[field] && next[field] !== item[field]) {
+					next[field] = item[field];
+					changed = true;
+				}
+			}
+			return changed ? next : p;
+		});
+		await publishPlaces(enriched);
+		paymentTagsLoaded.set(true);
+	} catch (error) {
+		console.warn("Could not load payment methods:", error);
 	}
 };
 

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -57,6 +57,7 @@ import {
 	pinIconImageExpression,
 	pinVariantFor,
 } from "$lib/map/maplibreSprites";
+import { parsePaymentMethodsParam } from "$lib/map/paymentMethodFilter";
 import { createPlacePinSource } from "$lib/map/placePinSource";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
@@ -86,6 +87,7 @@ import {
 } from "$lib/placeIssues";
 import { savedPlaceIds } from "$lib/session";
 import {
+	paymentTagsLoaded,
 	places,
 	placesById,
 	placesError,
@@ -93,7 +95,7 @@ import {
 	placesLoadingStatus,
 	verifiedDatesLoaded,
 } from "$lib/store";
-import { ensureVerifiedDates } from "$lib/sync/places";
+import { ensurePaymentMethods, ensureVerifiedDates } from "$lib/sync/places";
 import { theme } from "$lib/theme";
 import type { Place } from "$lib/types";
 import { userLocation } from "$lib/userLocationStore";
@@ -151,6 +153,17 @@ const issuesOnly =
 let selectedIssueCodes: ReadonlySet<DerivedIssueCode> | null = issuesOnly
 	? parseIssuesParam(new URLSearchParams(window.location.search).get("issues"))
 	: null;
+
+// Payment-method embed filter (#1269): bare ?onchain&lightning&nfc params
+// (presence alone, legacy Leaflet contract) narrow everything to places that
+// accept every selected method. Locked for the session like ?boosts/?issues;
+// seeded into the store so lists and counts filter identically to pins.
+const paymentMethods = browser
+	? parsePaymentMethodsParam(new URLSearchParams(window.location.search))
+	: null;
+if (paymentMethods) {
+	merchantList.setPaymentMethods(paymentMethods);
+}
 
 // Viewport issue tallies for the chips bar, computed in updateMerchantList's
 // local-markers path (issues mode always forces that path). Null until the
@@ -761,6 +774,11 @@ $: if (map && styleLoaded && $places) {
 		// Trivially ready when the mode is off or exempted, so the dates
 		// landing can't change the signature outside issues mode.
 		issuesReady: !issuesOnly || inSearch || $verifiedDatesLoaded,
+		// Payment embed filter applies in search mode TOO (an embedded map
+		// keeps its promise everywhere); only the bulk feed needs the
+		// enrichment gate — search rows carry the tags natively.
+		paymentMethods,
+		paymentsReady: paymentMethods == null || inSearch || $paymentTagsLoaded,
 	};
 	const renderSig = [
 		computeVisibleSignature(
@@ -826,6 +844,22 @@ $: if (
 ) {
 	didInitialVerifiedLoad = true;
 	void ensureVerifiedDates().then(() => updateMerchantList({ force: true }));
+}
+
+// Same lazy-enrichment handshake for the payment embed filter (#1269): the
+// bulk feed has no osm:payment:* tags until this lands, then one forced
+// refresh re-runs pins + list through the (now active) pipeline.
+let didInitialPaymentLoad = false;
+$: if (
+	browser &&
+	map &&
+	styleLoaded &&
+	$places.length > 0 &&
+	!didInitialPaymentLoad &&
+	paymentMethods
+) {
+	didInitialPaymentLoad = true;
+	void ensurePaymentMethods().then(() => updateMerchantList({ force: true }));
 }
 
 // Globe projection is page state: a basemap swap resets the projection to

--- a/src/routes/map/components/MerchantListPanel.svelte
+++ b/src/routes/map/components/MerchantListPanel.svelte
@@ -368,6 +368,7 @@ function handleDismissLocation() {
 // The rendered search rows come from the same pipeline as the pins and the
 // chip counts (selectVisiblePlaces), so the list can never disagree with
 // either again.
+$: paymentMethods = $merchantList.paymentMethods;
 $: filteredSearchResults = selectVisiblePlaces({
 	places: searchResults,
 	mode: "search",
@@ -377,6 +378,9 @@ $: filteredSearchResults = selectVisiblePlaces({
 	boostsOnly: false,
 	issueCodes: null,
 	issuesReady: true,
+	// /v4/search rows carry the payment tags natively (LIST_ITEM).
+	paymentMethods,
+	paymentsReady: true,
 }).selection;
 
 // Helper function to check if a category has matching merchants


### PR DESCRIPTION
Closes #1269

## Problem

Payment-method embed filters (`/map?onchain&lightning&nfc`) stopped working after the map engine switch. The legacy Leaflet implementation filtered markers by bare URL params (presence alone, AND semantics) against `payment:onchain` / `payment:lightning` / `payment:lightning_contactless` OSM tags; the MapLibre rewrite never ported it. Embedders like boltcard.org depend on this contract.

## Approach

Rather than special-casing the marker layer, the filter is restored inside the shared visibility pipeline (`selectVisiblePlaces`) so pins, nearby list, search results, chip counts, and the closed-panel badge all derive from one decision — the #1158-#1162 mismatch class.

- **`src/lib/map/paymentMethodFilter.ts`** (new) — parses `?onchain&lightning&nfc` (presence alone, matching the legacy behavior) into a set; predicate requires every selected method tagged `yes`.
- **Pipeline** — new `paymentMethods` + `paymentsReady` inputs, applied pre-category so chip counts describe exactly what selecting them would show, and included in `computeVisibleSignature`. No search exemption: an embedded map must keep its payment promise everywhere.
- **Data availability** — verified against the live API that neither the bulk CDN feed nor MAP_SYNC rows carry any `osm:payment:*` fields, so a naive filter would blank the map:
  - `ensurePaymentMethods()` (mirrors `ensureVerifiedDates`) does one lazy per-session full-table fetch of `id` + the three tags (~600 KB gzipped), merges into `$places`, and latches `paymentTagsLoaded`; on failure the filter stays inert instead of hiding everything.
  - `MAP_SYNC` now requests the three tags so incremental updates can't wipe merged tags mid-session.
- **Badge** — `fetchCountOnly` widens its lean payload with the tags only while the filter is active, so the zoom 10-14 count matches what opening the panel shows.

No UI changes — this restores the documented [Embedding](https://gitea.btcmap.org/teambtcmap/btcmap-general/wiki/Embedding#if-you-would-like-to-filter-by-payment-method) URL contract only.

## Testing

- New unit tests: param parse/serialize round-trip, AND predicate (incl. non-`yes` values and the `nfc` → `lightning_contactless` mapping)
- Pipeline tests: multi-method narrowing, inert-until-ready gate, pre-category chip counts
- Full suite: 653 tests passing; `pnpm run check`, `typecheck`, `lint` clean

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added payment-method filtering for embedded maps using `onchain`, `lightning`, and legacy `nfc` URL parameters.
  * Filters apply consistently to map markers, search results, merchant lists, and total counts.
  * Payment tags are loaded automatically when needed, with filtering enabled once data is ready.
  * Selected payment methods persist for the current session and require all selected methods to match.

* **Bug Fixes**
  * Prevented payment-tag data from being lost during map synchronization updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->