### PR TITLE
fix(app): normalize duplicate slashes before the app boots #1268

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -14,6 +14,15 @@
 		<link rel="preload" href="/icons/boosted-icon-pin.svg" as="image" type="image/svg+xml" />
 
 		<script>
+			// Netlify's CDN collapses duplicate slashes before the SSR function runs, so only
+			// the browser ever sees a hand-typed //map. SvelteKit derives the client-side
+			// `base` — and therefore every resolve() href, the service worker scope and the
+			// router's path matching — from location, so normalize before anything boots.
+			const canonicalPath = location.pathname.replace(/\/{2,}/g, '/');
+			if (canonicalPath !== location.pathname) {
+				location.replace(canonicalPath + location.search + location.hash);
+			}
+
 			// Theme initialization - runs before Svelte hydrates to prevent flash
 			const theme =
 				localStorage.theme === 'dark' ||


### PR DESCRIPTION
Closes #1268.

## It's a real bug, and the nav bar is the mildest symptom

`https://btcmap.org//map` renders the site header and footer on top of the fullscreen map. Digging in, that turned out to be one of several failures, all from the same cause.

## Root cause: client-side only

Netlify's CDN collapses duplicate slashes **before** invoking the SSR function, so the server never sees `//map` — `/map` and `//map` return byte-identical HTML with zero `<header>`. The doubled slash exists only in the browser's `location`.

`svelte.config.js` leaves `paths.relative` at its default `true`, so SvelteKit computes its client-side `base` from `location` at runtime (`new URL(".", location).pathname.slice(0, -1)`). On `//map` that yields `"/"` instead of `""`, and everything downstream is derived from that poisoned `base`.

The nav bar specifically: `src/routes/+layout.ts` passes `url.pathname` through raw, Kit re-runs that universal load in the browser (there's no `+layout.server.ts`, so `data[0]` is `null` in the bootstrap), and the exact-match list in `src/routes/+layout.svelte` misses `//map`. It's a hydration divergence, not an SSR bug.

## Measured on production

Same page load, real browser, `//map` vs `/map`:

| | `/map` | `//map` |
|---|---|---|
| SvelteKit client `base` | `""` | **`"/"`** |
| `<header>` / `<footer>` tags | 0 / 0 | **2 / 1** |
| protocol-relative `<a href="//…">` | 0 | **2** |
| service worker registrations | 1 | **0** |

- **Internal links leave the site.** `resolve()` is `base + pathname`, so community links render as `href="//community/einundzwanzig-franken"` — protocol-relative, resolving to `https://community/…` (DNS failure). 23 files import `resolve` from `$app/paths`.
- **Service worker never registers.** `./service-worker.js` → `//service-worker.js` violates the configured `scope: '/'`.
- **Mid-path duplicates are fatal.** `/communities//map` 200s but requests `../_app/immutable/assets/Footer…css` → `/communities/_app/…` → 404 (the correct path 200s). Unstyled, unhydrated, dead page.
- SPA routing degrades to full page reloads, re-running the ~30k-place sync. And `mapHash.ts` re-commits the `//map` URL to history on every pan, so it's what a user would copy and share.

## Why the guard goes in `app.html`

**No server-side fix is available.** A `handle` hook in `hooks.server.ts` or a `netlify.toml` redirect would be dead code — the CDN normalizes before redirect rules, before static file resolution, and before the function. It would pass in `vite dev` and never fire in prod.

Normalizing `data.pathname` in `+layout.ts` would fix only the nav bar and turn a loud failure into a silent one: a correct-looking page with dead links and no service worker. Since everything above is computed from `location` before any app code runs, the guard has to run first — hence the existing pre-hydration `<script>`, ahead of the bootstrap.

Deliberately **not** setting `paths.relative: false`: it addresses the same tier, but it's a build-wide flag (it also flips Vite's `base` and Kit's CSS asset rewriting) and it destroys the accident that makes `//map` route-match at all today, so `invalidateAll()` would silently no-op on those URLs. Wrong trade for a typo. Happy to file it separately if wanted.

## Safety

- **No loop:** the collapse is idempotent and the guard is an inequality, so the replacement URL is a fixed point. `location.replace` adds no history entry, so Back behaves normally.
- **Encoded slashes untouched:** `/%2F/map` stays encoded (the regex matches only literal `/`).
- **No route can legitimately contain `//`:** Kit's `parse_route_id` emits `([^/]+?)` for every param.
- **Cost on normal loads:** one string compare.

## Verification

- `pnpm run format:fix`, `check` (0 errors), `typecheck` (0), `lint` (0), `test --run` (641 passed) — all green.
- `pnpm build` succeeds and the guard is present in the SSR template at `.netlify/server/chunks/internal2.js`, confirming it ships rather than being stripped.
- Needs a browser check on the deploy preview: open `<preview>//map` and confirm the URL becomes `/map`, `base` is `""`, no `<header>`, and the service worker registers.

No unit test added — a vitest for this would be testing `String.replace`. An e2e is possible but guards a URL nothing links to; happy to add one if you'd rather have the coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)