### PR TITLE
fix(map): harden payment-filter enrichment and pin the embed contract #1269

### DIFF
--- a/src/lib/map/visiblePlaces.ts
+++ b/src/lib/map/visiblePlaces.ts
@@ -5,8 +5,8 @@ import {
 	countMerchantsByCategory,
 	placeMatchesCategory,
 } from "$lib/categoryMapping";
+import type { PaymentMethod } from "$lib/map/paymentMethodFilter";
 import {
-	type PaymentMethod,
 	placeMatchesPaymentMethods,
 	serializePaymentMethodsParam,
 } from "$lib/map/paymentMethodFilter";

--- a/src/lib/merchantListStore.test.ts
+++ b/src/lib/merchantListStore.test.ts
@@ -9,6 +9,7 @@ import {
 	MERCHANT_LIST_MAX_ITEMS,
 } from "$lib/constants";
 import { VERIFIED_FILTER_STORAGE_KEY } from "$lib/map/verifiedFilter";
+import { paymentTagsLoaded } from "$lib/store";
 import type { Place } from "$lib/types";
 import { filterPlacesByRecency } from "$lib/verification";
 
@@ -329,6 +330,66 @@ describe("merchantListStore", () => {
 
 			const after = get(merchantList).merchants.map((m) => m.id);
 			expect(after).toEqual(before);
+		});
+	});
+
+	// The ?onchain&lightning&nfc embed filter narrows radius lists and the
+	// count badge only while the pins narrow too (paymentTagsLoaded): before
+	// the tag enrichment lands — or after it failed — every surface must
+	// stay unfiltered together, or the list contradicts the map (the
+	// #1158-#1162 disagreement class).
+	describe("payment filter readiness gating", () => {
+		const rows = () => [
+			createMockPlace({ id: 1, "osm:payment:lightning": "yes" }),
+			createMockPlace({ id: 2 }),
+		];
+
+		afterEach(() => {
+			paymentTagsLoaded.set(false);
+		});
+
+		it("fetchAndReplaceList stays unfiltered until the tags are ready", async () => {
+			merchantList.setPaymentMethods(new Set(["lightning"] as const));
+			(api.get as Mock).mockResolvedValueOnce({ data: rows() });
+
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).merchants.length).toBe(2);
+		});
+
+		it("fetchAndReplaceList narrows once the tags are ready", async () => {
+			merchantList.setPaymentMethods(new Set(["lightning"] as const));
+			paymentTagsLoaded.set(true);
+			(api.get as Mock).mockResolvedValueOnce({ data: rows() });
+
+			await merchantList.fetchAndReplaceList({ lat: 0, lon: 0 }, 10);
+
+			const state = get(merchantList);
+			expect(state.merchants.length).toBe(1);
+			expect(state.merchants[0].id).toBe(1);
+		});
+
+		it("fetchCountOnly requests lean fields and counts everything until ready", async () => {
+			merchantList.setPaymentMethods(new Set(["lightning"] as const));
+			(api.get as Mock).mockResolvedValueOnce({ data: rows() });
+
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).totalCount).toBe(2);
+			const url = (api.get as Mock).mock.calls[0][0] as string;
+			expect(url).not.toContain("osm:payment");
+		});
+
+		it("fetchCountOnly widens fields and narrows the count once ready", async () => {
+			merchantList.setPaymentMethods(new Set(["lightning"] as const));
+			paymentTagsLoaded.set(true);
+			(api.get as Mock).mockResolvedValueOnce({ data: rows() });
+
+			await merchantList.fetchCountOnly({ lat: 0, lon: 0 }, 10);
+
+			expect(get(merchantList).totalCount).toBe(1);
+			const url = (api.get as Mock).mock.calls[0][0] as string;
+			expect(url).toContain("osm:payment:lightning");
 		});
 	});
 

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -9,11 +9,11 @@ import type { CategoryCounts, CategoryKey } from "$lib/categoryMapping";
 import { createEmptyCategoryCounts } from "$lib/categoryMapping";
 import { MERCHANT_LIST_MAX_ITEMS } from "$lib/constants";
 import { _ } from "$lib/i18n";
-import type { PaymentMethod } from "$lib/map/paymentMethodFilter";
-import {
-	type PaymentTaggedPlace,
-	placeMatchesPaymentMethods,
+import type {
+	PaymentMethod,
+	PaymentTaggedPlace,
 } from "$lib/map/paymentMethodFilter";
+import { placeMatchesPaymentMethods } from "$lib/map/paymentMethodFilter";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
 import {
 	getStoredVerifiedFilter,
@@ -488,9 +488,14 @@ function createMerchantListStore() {
 						boostsOnly: false,
 						issueCodes: null,
 						issuesReady: true,
-						// Radius rows carry the payment tags natively (LIST_ITEM).
+						// Radius rows carry the payment tags natively (LIST_ITEM),
+						// but the gate mirrors the pins' anyway: while the bulk
+						// markers are still inert (enrichment pending or failed) a
+						// narrowed list would contradict the unfiltered map — the
+						// #1158-#1162 disagreement class this pipeline exists to
+						// prevent.
 						paymentMethods,
-						paymentsReady: true,
+						paymentsReady: paymentMethods == null || get(paymentTagsLoaded),
 					});
 
 				// Check if we should hide results (too many at low zoom)
@@ -575,13 +580,20 @@ function createMerchantListStore() {
 			// never disagree; a mid-flight filter change re-invokes this method,
 			// which aborts the stale request above.
 			const { verifiedWithinYears, paymentMethods } = get(store);
+			// The badge narrows by payment only while the pins do (same
+			// readiness flag): before the tag enrichment lands — or after it
+			// failed — the markers show everything, and a narrowed count over
+			// an unfiltered map would contradict it.
+			const activePaymentMethods = get(paymentTagsLoaded)
+				? paymentMethods
+				: null;
 			// Widen the lean payload with exactly the fields the active filters
 			// need: verified_at for the recency window, the payment tags for
 			// the ?onchain&lightning&nfc embed filter (#1269).
 			const fields = [
 				"id",
 				...(verifiedWithinYears == null ? [] : ["verified_at"]),
-				...(paymentMethods == null
+				...(activePaymentMethods == null
 					? []
 					: [
 							"osm:payment:onchain",
@@ -597,9 +609,9 @@ function createMerchantListStore() {
 					Pick<Place, "id"> & Pick<Place, "verified_at"> & PaymentTaggedPlace
 				>(center, radiusKm, fields, listAbortController.signal);
 				let counted = filterPlacesByRecency(validItems, verifiedWithinYears);
-				if (paymentMethods) {
+				if (activePaymentMethods) {
 					counted = counted.filter((p) =>
-						placeMatchesPaymentMethods(p, paymentMethods),
+						placeMatchesPaymentMethods(p, activePaymentMethods),
 					);
 				}
 

--- a/src/lib/sync/places.enrichment.test.ts
+++ b/src/lib/sync/places.enrichment.test.ts
@@ -1,0 +1,217 @@
+import { get } from "svelte/store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { paymentTagsLoaded, places, verifiedDatesLoaded } from "$lib/store";
+import type { Place } from "$lib/types";
+
+vi.mock("$lib/axios", () => ({
+	default: { get: vi.fn(), head: vi.fn() },
+}));
+
+import api from "$lib/axios";
+
+import {
+	applyEnrichmentCaches,
+	ensurePaymentMethods,
+	ensureVerifiedDates,
+} from "./places";
+
+const mockGet = vi.mocked(api.get);
+
+const row = (id: number, extra: Partial<Place> = {}): Place =>
+	({ id, lat: 0, lon: 0, ...extra }) as Place;
+
+// The inert-until-ready contract's producer half: the latch guards below are
+// load-bearing — flipping a gate true with no tags merged would hide every
+// pin in a payment-filtered embed (the consumer side is pinned in
+// visiblePlaces.test.ts). The live-data e2e can never reach these branches.
+describe("ensurePaymentMethods", () => {
+	beforeEach(() => {
+		mockGet.mockReset();
+		places.set([]);
+		paymentTagsLoaded.set(false);
+		verifiedDatesLoaded.set(false);
+	});
+
+	it("does not latch on a non-array response", async () => {
+		places.set([row(1)]);
+		mockGet.mockResolvedValue({ data: "<html>error page</html>" });
+		await ensurePaymentMethods();
+		expect(get(paymentTagsLoaded)).toBe(false);
+	});
+
+	it("does not latch on an empty response", async () => {
+		places.set([row(1)]);
+		mockGet.mockResolvedValue({ data: [] });
+		await ensurePaymentMethods();
+		expect(get(paymentTagsLoaded)).toBe(false);
+	});
+
+	it("does not latch on id-only rows carrying no tags", async () => {
+		// e.g. the fields param silently ignored upstream: latching here
+		// would activate the filter with nothing to match — and the clearing
+		// merge would strip every cached tag on top.
+		places.set([row(1, { "osm:payment:lightning": "yes" })]);
+		mockGet.mockResolvedValue({ data: [{ id: 1 }, { id: 2 }] });
+		await ensurePaymentMethods();
+		expect(get(paymentTagsLoaded)).toBe(false);
+		expect(get(places)[0]["osm:payment:lightning"]).toBe("yes");
+	});
+
+	it("bails without latching when $places has not loaded yet", async () => {
+		mockGet.mockResolvedValue({
+			data: [{ id: 1, "osm:payment:lightning": "yes" }],
+		});
+		await ensurePaymentMethods();
+		expect(get(paymentTagsLoaded)).toBe(false);
+		expect(get(places)).toEqual([]);
+	});
+
+	it("does not latch on a failed fetch", async () => {
+		places.set([row(1)]);
+		mockGet.mockRejectedValue(new Error("network down"));
+		await ensurePaymentMethods();
+		expect(get(paymentTagsLoaded)).toBe(false);
+	});
+
+	it("merges tags by id, keeps unlisted rows untouched, and latches", async () => {
+		places.set([row(1), row(2, { name: "kept" })]);
+		mockGet.mockResolvedValue({
+			data: [
+				{
+					id: 1,
+					"osm:payment:onchain": "no",
+					"osm:payment:lightning": "yes",
+				},
+			],
+		});
+		await ensurePaymentMethods();
+		expect(get(paymentTagsLoaded)).toBe(true);
+		const [first, second] = get(places);
+		expect(first["osm:payment:lightning"]).toBe("yes");
+		// "no" merges too — a row that explicitly refuses a method is data,
+		// and the strict === "yes" match handles it downstream.
+		expect(first["osm:payment:onchain"]).toBe("no");
+		expect(second["osm:payment:lightning"]).toBeUndefined();
+		expect(second.name).toBe("kept");
+	});
+
+	it("clears a stale tag the response no longer carries", async () => {
+		// A previous session persisted lightning=yes; the tag has since been
+		// removed in OSM. The fresh response's id-row without the field must
+		// clear it, or the place stays inside a filtered embed forever.
+		places.set([
+			row(1, { "osm:payment:lightning": "yes" }),
+			row(2, { "osm:payment:lightning": "yes" }),
+		]);
+		mockGet.mockResolvedValue({
+			data: [{ id: 1 }, { id: 2, "osm:payment:onchain": "yes" }],
+		});
+		await ensurePaymentMethods();
+		expect(get(paymentTagsLoaded)).toBe(true);
+		const [first, second] = get(places);
+		expect(first["osm:payment:lightning"]).toBeUndefined();
+		expect(second["osm:payment:lightning"]).toBeUndefined();
+		expect(second["osm:payment:onchain"]).toBe("yes");
+	});
+
+	it("is a no-op once latched", async () => {
+		places.set([row(1)]);
+		mockGet.mockResolvedValue({
+			data: [{ id: 1, "osm:payment:lightning": "yes" }],
+		});
+		await ensurePaymentMethods();
+		await ensurePaymentMethods();
+		expect(mockGet).toHaveBeenCalledTimes(1);
+	});
+
+	// The combo-deep-link race (?issues&lightning dispatches both enrichers
+	// in one flush): each reads the whole $places array and republishes it,
+	// so without the enrichment lock the later places.set would erase the
+	// earlier merge — a blank filtered embed for the rest of the session.
+	it("running concurrently with ensureVerifiedDates keeps both merges", async () => {
+		places.set([row(1), row(2)]);
+		mockGet.mockImplementation((url: string) => {
+			if (url.includes("verified_at")) {
+				return Promise.resolve({
+					data: [{ id: 1, verified_at: "2026-08-01" }],
+				});
+			}
+			return Promise.resolve({
+				data: [{ id: 1, "osm:payment:lightning": "yes" }],
+			});
+		});
+		await Promise.all([ensureVerifiedDates(), ensurePaymentMethods()]);
+		expect(get(verifiedDatesLoaded)).toBe(true);
+		expect(get(paymentTagsLoaded)).toBe(true);
+		const [first] = get(places);
+		expect(first.verified_at).toBe("2026-08-01");
+		expect(first["osm:payment:lightning"]).toBe("yes");
+	});
+});
+
+// The bulk-republish fill-in: elementsSync rebuilds rows from the disk cache
+// or the CDN baseline (neither carries enrichment when persistence is
+// broken — routine for iframe embeds), so once a flag has latched the sync
+// path re-applies the session's cached enrichment before publishing.
+describe("applyEnrichmentCaches", () => {
+	beforeEach(() => {
+		mockGet.mockReset();
+		places.set([]);
+		paymentTagsLoaded.set(false);
+		verifiedDatesLoaded.set(false);
+	});
+
+	const latchBoth = async () => {
+		places.set([row(1), row(2)]);
+		mockGet.mockImplementation((url: string) => {
+			if (url.includes("verified_at")) {
+				return Promise.resolve({
+					data: [{ id: 1, verified_at: "2026-08-01" }],
+				});
+			}
+			return Promise.resolve({
+				data: [
+					{
+						id: 1,
+						"osm:payment:lightning": "yes",
+						"osm:payment:onchain": "no",
+					},
+				],
+			});
+		});
+		await ensureVerifiedDates();
+		await ensurePaymentMethods();
+	};
+
+	it("returns rows unchanged while nothing is latched", () => {
+		const rows = [row(1)];
+		expect(applyEnrichmentCaches(rows)).toBe(rows);
+	});
+
+	it("fills missing enrichment on bare rows once latched", async () => {
+		await latchBoth();
+		// Simulate a CDN-baseline republish: bare rows, no enrichment.
+		const [first, second] = applyEnrichmentCaches([row(1), row(2)]);
+		expect(first.verified_at).toBe("2026-08-01");
+		expect(first["osm:payment:lightning"]).toBe("yes");
+		expect(first["osm:payment:onchain"]).toBe("no");
+		expect(second.verified_at).toBeUndefined();
+		expect(second["osm:payment:lightning"]).toBeUndefined();
+	});
+
+	it("never overwrites values the row already carries", async () => {
+		await latchBoth();
+		// A MAP_SYNC row is fresher than the session cache: its own values
+		// must win, including a payment set that dropped a cached tag.
+		const [fresh] = applyEnrichmentCaches([
+			row(1, {
+				verified_at: "2026-08-20",
+				"osm:payment:onchain": "yes",
+			}),
+		]);
+		expect(fresh.verified_at).toBe("2026-08-20");
+		expect(fresh["osm:payment:onchain"]).toBe("yes");
+		expect(fresh["osm:payment:lightning"]).toBeUndefined();
+	});
+});

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -95,6 +95,73 @@ const getStaticFileDate = async (): Promise<string> => {
 	return getTwoWeeksAgoDate();
 };
 
+// Serializes the $places enrichment merges (verified dates, payment tags).
+// Each enricher reads the whole array, rebuilds it, and republishes; two
+// running concurrently — a combo deep link like ?issues&lightning dispatches
+// both in one reactive flush — would build from the same snapshot and the
+// later places.set would silently erase the earlier merge, with its
+// readiness flag already latched (hiding pins for the rest of the session).
+// Fetches stay concurrent; only the read→merge→publish window is exclusive.
+// The chain itself never rejects — each section's errors belong to its
+// caller.
+let enrichmentChain: Promise<unknown> = Promise.resolve();
+const withEnrichmentLock = <T>(section: () => Promise<T>): Promise<T> => {
+	const run = enrichmentChain.then(section);
+	enrichmentChain = run.catch(() => undefined);
+	return run;
+};
+
+const PAYMENT_TAG_FIELDS = [
+	"osm:payment:onchain",
+	"osm:payment:lightning",
+	"osm:payment:lightning_contactless",
+] as const;
+
+type PaymentTagsRow = {
+	id: number;
+	"osm:payment:onchain"?: "yes";
+	"osm:payment:lightning"?: "yes";
+	"osm:payment:lightning_contactless"?: "yes";
+};
+
+// Bulk republishes (elementsSync's merge path and its CDN fallback) rebuild
+// rows from the disk cache or the CDN baseline — which carry no enrichment
+// when persistence is unavailable (routine for embeds in iframes with
+// blocked third-party storage). Once an enrichment has latched, its
+// readiness flag stays true, so publishing bare rows would blank every
+// filtered pin with nothing re-fetching. Re-apply the session's cached
+// enrichment to outgoing rows, filling ONLY fields the row doesn't already
+// carry — an incremental MAP_SYNC row's own values are fresher than the
+// session cache and must win.
+let verifiedDatesCache: Map<number, string> | null = null;
+let paymentTagsCache: Map<number, PaymentTagsRow> | null = null;
+
+export const applyEnrichmentCaches = (rows: Place[]): Place[] => {
+	const dates = get(verifiedDatesLoaded) ? verifiedDatesCache : null;
+	const tags = get(paymentTagsLoaded) ? paymentTagsCache : null;
+	if (!dates && !tags) return rows;
+	return rows.map((p) => {
+		let next: Place | null = null;
+		const dateFill = dates?.get(p.id);
+		if (dateFill && p.verified_at === undefined) {
+			next = { ...p, verified_at: dateFill };
+		}
+		if (tags && PAYMENT_TAG_FIELDS.every((field) => p[field] === undefined)) {
+			const item = tags.get(p.id);
+			if (
+				item &&
+				PAYMENT_TAG_FIELDS.some((field) => item[field] !== undefined)
+			) {
+				next = next ?? { ...p };
+				for (const field of PAYMENT_TAG_FIELDS) {
+					next[field] = item[field];
+				}
+			}
+		}
+		return next ?? p;
+	});
+};
+
 // The bulk CDN feed (places.json) carries no verification date, so a place's
 // baseline date is unknown until this runs. Fetch verified_at for every place
 // in one lean call and merge it into $places by id. Fetched LAZILY — only when
@@ -123,23 +190,29 @@ export const ensureVerifiedDates = async (): Promise<void> => {
 		// flag false keeps the filter inert (shows everything) and lets a later
 		// sync retry.
 		if (verifiedById.size === 0) return;
-		const current = get(places);
-		// If the bulk places haven't loaded yet (the dates fetch won the race),
-		// bail without latching or caching — otherwise we'd persist an empty
-		// places_v4 and flip the gate true with no data, hiding everything. The
-		// caller re-runs once $places is populated.
-		if (current.length === 0) return;
-		const enriched = current.map((p) => {
-			const verified_at = verifiedById.get(p.id);
-			return verified_at && verified_at !== p.verified_at
-				? { ...p, verified_at }
-				: p;
+		await withEnrichmentLock(async () => {
+			// Re-check under the lock: a concurrent caller may have latched
+			// while this one waited.
+			if (get(verifiedDatesLoaded)) return;
+			const current = get(places);
+			// If the bulk places haven't loaded yet (the dates fetch won the race),
+			// bail without latching or caching — otherwise we'd persist an empty
+			// places_v4 and flip the gate true with no data, hiding everything. The
+			// caller re-runs once $places is populated.
+			if (current.length === 0) return;
+			const enriched = current.map((p) => {
+				const verified_at = verifiedById.get(p.id);
+				return verified_at && verified_at !== p.verified_at
+					? { ...p, verified_at }
+					: p;
+			});
+			verifiedDatesCache = verifiedById;
+			// Always publishes (persistence is best-effort inside placeCache), so
+			// the enrichment survives a failed blob write — matching the old
+			// publish-first ordering this replaced.
+			await publishPlaces(enriched);
+			verifiedDatesLoaded.set(true);
 		});
-		// Always publishes (persistence is best-effort inside placeCache), so
-		// the enrichment survives a failed blob write — matching the old
-		// publish-first ordering this replaced.
-		await publishPlaces(enriched);
-		verifiedDatesLoaded.set(true);
 	} catch (error) {
 		console.warn("Could not load verification dates:", error);
 	}
@@ -157,45 +230,54 @@ export const ensureVerifiedDates = async (): Promise<void> => {
 export const ensurePaymentMethods = async (): Promise<void> => {
 	if (get(paymentTagsLoaded)) return;
 	try {
-		const response = await api.get<
-			{
-				id: number;
-				"osm:payment:onchain"?: "yes";
-				"osm:payment:lightning"?: "yes";
-				"osm:payment:lightning_contactless"?: "yes";
-			}[]
-		>(
+		const response = await api.get<PaymentTagsRow[]>(
 			`${API_BASE}/v4/places?fields=id,osm:payment:onchain,osm:payment:lightning,osm:payment:lightning_contactless`,
 		);
 		if (!Array.isArray(response.data)) return;
-		const tagsById = new Map(
-			response.data.map((item) => [item.id, item] as const),
-		);
-		// Same degenerate-response guard as ensureVerifiedDates: don't latch
-		// the flag (or republish) off an empty payload — stay inert and let a
-		// later call retry.
-		if (tagsById.size === 0) return;
-		const current = get(places);
-		if (current.length === 0) return;
-		const enriched = current.map((p) => {
-			const item = tagsById.get(p.id);
-			if (!item) return p;
-			let changed = false;
-			const next = { ...p };
-			for (const field of [
-				"osm:payment:onchain",
-				"osm:payment:lightning",
-				"osm:payment:lightning_contactless",
-			] as const) {
-				if (item[field] && next[field] !== item[field]) {
-					next[field] = item[field];
-					changed = true;
-				}
+		const tagsById = new Map<number, PaymentTagsRow>();
+		let taggedRows = 0;
+		for (const item of response.data) {
+			if (typeof item?.id !== "number") continue;
+			tagsById.set(item.id, item);
+			if (PAYMENT_TAG_FIELDS.some((field) => item[field] !== undefined)) {
+				taggedRows++;
 			}
-			return changed ? next : p;
+		}
+		// Degenerate-response guard, stricter than a bare row count: an
+		// id-only payload (e.g. the fields param ignored upstream) must not
+		// latch the flag — the clearing merge below would also strip every
+		// cached tag, then hide every pin. Stay inert and let a later call
+		// retry, same contract as ensureVerifiedDates.
+		if (taggedRows === 0) return;
+		await withEnrichmentLock(async () => {
+			// Re-check under the lock: a concurrent caller may have latched
+			// while this one waited.
+			if (get(paymentTagsLoaded)) return;
+			const current = get(places);
+			// If the bulk places haven't loaded yet (the tags fetch won the
+			// race), bail without latching or caching — the caller re-runs once
+			// $places is populated.
+			if (current.length === 0) return;
+			const enriched = current.map((p) => {
+				const item = tagsById.get(p.id);
+				if (!item) return p;
+				let changed = false;
+				const next = { ...p };
+				for (const field of PAYMENT_TAG_FIELDS) {
+					// Diff-assign INCLUDING undefined: a tag removed upstream
+					// must clear a stale persisted "yes", or the place stays
+					// inside a filtered embed forever.
+					if (next[field] !== item[field]) {
+						next[field] = item[field];
+						changed = true;
+					}
+				}
+				return changed ? next : p;
+			});
+			paymentTagsCache = tagsById;
+			await publishPlaces(enriched);
+			paymentTagsLoaded.set(true);
 		});
-		await publishPlaces(enriched);
-		paymentTagsLoaded.set(true);
 	} catch (error) {
 		console.warn("Could not load payment methods:", error);
 	}
@@ -455,8 +537,12 @@ export const elementsSync = async () => {
 				} else if (placesData.length > 0) {
 					// publishPlaces always updates the store (the session keeps
 					// working on broken storage); persistence failure surfaces via
-					// the sync path's own error toast.
-					const { persisted } = await publishPlaces(placesData);
+					// the sync path's own error toast. Cached-enrichment fill-in
+					// keeps latched filters (recency, payment embed) working when
+					// this publish was rebuilt from an unenriched source.
+					const { persisted } = await publishPlaces(
+						applyEnrichmentCaches(placesData),
+					);
 					if (persisted) {
 						// Only save sync timestamp if API succeeded, to avoid creating
 						// gaps where updates between old and new timestamp are
@@ -522,8 +608,12 @@ export const elementsSync = async () => {
 
 					if (parsedPlaces.length > 0) {
 						// Publish-only: localforage already failed reading, so don't
-						// bank on writing — matching the pre-existing behavior.
-						await publishPlaces(parsedPlaces, { persist: false });
+						// bank on writing — matching the pre-existing behavior. The
+						// CDN baseline carries no enrichment at all, so the cached
+						// fill-in matters most on this exact path.
+						await publishPlaces(applyEnrichmentCaches(parsedPlaces), {
+							persist: false,
+						});
 					}
 				} catch (error) {
 					placesError.set(

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -57,7 +57,10 @@ import {
 	pinIconImageExpression,
 	pinVariantFor,
 } from "$lib/map/maplibreSprites";
-import { parsePaymentMethodsParam } from "$lib/map/paymentMethodFilter";
+import {
+	parsePaymentMethodsParam,
+	placeMatchesPaymentMethods,
+} from "$lib/map/paymentMethodFilter";
 import { createPlacePinSource } from "$lib/map/placePinSource";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
 import type { VerifiedFilterYears } from "$lib/map/verifiedFilter";
@@ -490,6 +493,17 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 					p.lon <= buffered.east,
 			);
 			let listed = boostsOnly ? visible.filter(isBoosted) : visible;
+			// The store's pipeline narrows the list itself (setMerchants
+			// consumes state.paymentMethods), but the ?issues chip tallies
+			// below are computed from THIS page-side snapshot — narrow it
+			// here too so the chips can never count places the embed filter
+			// hides. Same readiness gate as the pipeline: inert until the
+			// payment-tag enrichment lands.
+			if (paymentMethods && get(paymentTagsLoaded)) {
+				listed = listed.filter((p) =>
+					placeMatchesPaymentMethods(p, paymentMethods),
+				);
+			}
 			// Same readiness gate as the marker pipeline: before the
 			// verified_at enrichment lands, the list stays unfiltered
 			// rather than flagging every bulk row as not_verified.
@@ -506,6 +520,17 @@ const updateMerchantList = (opts?: { force?: boolean }) => {
 				listed = listed.filter((p) => placeMatchesIssueCodes(p, issueCodes));
 			}
 			merchantList.setMerchants(listed, center.lat, center.lng);
+			// E2E test hook, same idea as __mapPlacesCount: the payment-filter
+			// spec needs a DOM-independent way to pin that the list surface
+			// narrows with the pins (the wiring the #398 rewrite silently
+			// lost). Only set on this local path, so the spec also fails if a
+			// rewrite stops routing filtered sessions through it. No-op
+			// outside tests.
+			if (typeof window !== "undefined") {
+				(
+					window as unknown as { __nearbyListCount?: number }
+				).__nearbyListCount = listed.length;
+			}
 			if (listOpen || currentZoom >= LABEL_VISIBLE_ZOOM) {
 				if (allowHeavyFetch || currentZoom >= LABEL_VISIBLE_ZOOM) {
 					const radiusKm =
@@ -859,7 +884,15 @@ $: if (
 	paymentMethods
 ) {
 	didInitialPaymentLoad = true;
-	void ensurePaymentMethods().then(() => updateMerchantList({ force: true }));
+	void ensurePaymentMethods().then(() => {
+		// ensurePaymentMethods never rejects — failure means the gate is
+		// still false. Un-latch so the next $places publication retries (at
+		// sync cadence): unlike the verified filter there is no UI control
+		// to re-trigger this, and a transient failure would otherwise leave
+		// the embed silently unfiltered for the whole session.
+		if (!get(paymentTagsLoaded)) didInitialPaymentLoad = false;
+		updateMerchantList({ force: true });
+	});
 }
 
 // Globe projection is page state: a basemap swap resets the projection to

--- a/tests/map-payment-filter.spec.ts
+++ b/tests/map-payment-filter.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test';
+import { MARKER_LOAD_TIMEOUT, waitForMarkersToLoad } from './helpers';
+
+// Regression guard for the /map payment deep links (?onchain&lightning&nfc)
+// the Embedding wiki documents for iframe embeds (e.g. boltcard.org). The
+// original params were silently lost in a map rewrite (#398) because nothing
+// pinned their behavior — these tests exist so that can't happen again.
+// See #1269.
+test.describe('Map payment method filters', () => {
+	const placesCount = (page: import('@playwright/test').Page) =>
+		page.evaluate(
+			() => (window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount ?? 0
+		);
+
+	const nearbyListCount = (page: import('@playwright/test').Page) =>
+		page.evaluate(
+			() => (window as unknown as { __nearbyListCount?: number }).__nearbyListCount ?? 0
+		);
+
+	test('?lightning narrows the rendered places once payment tags load', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		// Baseline: unfiltered world view.
+		await page.goto('/map', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		const baseline = await placesCount(page);
+		expect(baseline).toBeGreaterThan(0);
+
+		// Deep link: the filter engages after the one-time payment-tag
+		// enrichment fetch lands, so poll until the count settles below the
+		// baseline (lightning=yes is ~79% of places at the time of writing,
+		// so 95% leaves ample headroom for data drift).
+		await page.goto('/map?lightning', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => placesCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeLessThan(baseline * 0.95);
+		expect(await placesCount(page)).toBeGreaterThan(0);
+	});
+
+	test('?nfc maps to lightning_contactless and combined params AND together', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		await page.goto('/map', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		const baseline = await placesCount(page);
+		expect(baseline).toBeGreaterThan(0);
+
+		// ?nfc requires payment:lightning_contactless=yes — a small subset
+		// (~12% at the time of writing; 50% leaves headroom for drift).
+		await page.goto('/map?nfc', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => placesCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeLessThan(baseline * 0.5);
+		const nfcCount = await placesCount(page);
+		expect(nfcCount).toBeGreaterThan(0);
+
+		// AND semantics: adding ?lightning can only narrow the set further
+		// (or keep it equal), never widen it.
+		await page.goto('/map?nfc&lightning', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => placesCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeLessThan(baseline * 0.5);
+		expect(await placesCount(page)).toBeLessThanOrEqual(nfcCount);
+		expect(await placesCount(page)).toBeGreaterThan(0);
+	});
+
+	test('the nearby list narrows with the pins', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+
+		// San Salvador center at zoom 15: dense (~250 places) with a small
+		// nfc=yes minority (~12% at the time of writing), so both directions
+		// of the assertion have wide drift headroom. Zoom 15 uses the
+		// local-markers list path even WITHOUT a deep link, giving an
+		// unfiltered baseline for the same viewport.
+		const CITY_HASH = '#15/13.7000/-89.2240';
+
+		await page.goto(`/map${CITY_HASH}`, { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(() => nearbyListCount(page), { timeout: MARKER_LOAD_TIMEOUT })
+			.toBeGreaterThan(0);
+		const unfiltered = await nearbyListCount(page);
+
+		// Same viewport with ?nfc: the deep link must narrow the nearby list
+		// too, not just the pins — the panel would otherwise contradict the
+		// embed's filtered map. A dropped list narrowing leaves the count at
+		// ~unfiltered and fails the ratio check.
+		await page.goto(`/map?nfc${CITY_HASH}`, { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+		await expect
+			.poll(
+				async () => {
+					const count = await nearbyListCount(page);
+					return count > 0 && count < unfiltered * 0.5;
+				},
+				{ timeout: MARKER_LOAD_TIMEOUT }
+			)
+			.toBe(true);
+	});
+});


### PR DESCRIPTION
Stacked on #1272 (targets its branch, so merging this folds the changes into that PR). It keeps #1272's design as-is — Set-based module, store-seeded filter, no search exemption, `fetchCountOnly` widening — and adds the hardening + regression guards from the parallel #1271 work, adapted to this codebase shape. All findings below were verified against live behavior/data, not speculated.

## Bug fixes

**1. Enrichment race on combo deep links.** `ensureVerifiedDates` and `ensurePaymentMethods` each do read→merge→publish over the whole `$places` array, with an await (`publishPlaces` yields to main) between read and `places.set`. A combo link like `?issues&lightning` dispatches both in the same reactive flush; whichever publishes last erases the other's merge while **both** readiness flags latch true — a blank filtered embed (or all-places-misclassified issues view) for the rest of the session, with nothing re-fetching. Fix: a small enrichment lock serializes only the merge windows (fetches stay concurrent). The new concurrency test fails if the lock is removed — mutation-verified.

**2. Bulk republish wipes enrichment when storage is broken.** `elementsSync` re-runs every 10 minutes; with no readable cache it rebuilds from the CDN baseline, which carries **zero** enrichment fields (verified against `cdn.static.btcmap.org` — rows have only `id/lat/lon/icon/comments/boosted_until`). Publishing that while `paymentTagsLoaded` stays latched hides every pin, permanently (the enricher early-returns on the flag). Broken/blocked persistence is routine for third-party iframe embeds — exactly the boltcard.org scenario. Fix: the sync path re-applies the session's cached enrichment before publishing, filling only fields a row doesn't already carry so fresher `MAP_SYNC` values always win. This also fixes the pre-existing `verified_at` variant of the same bug (`?outdated`/`?issues` embeds).

**3. One failed tag fetch = silently unfiltered all session.** `didInitialPaymentLoad` latched before the await and `ensurePaymentMethods` never rejects, so a transient failure left no retry path — and unlike the verified filter there's no UI control to re-trigger. Fix: un-latch on failure so the next `$places` publication retries at sync cadence.

**4. Latch guard tightened.** `tagsById.size === 0` counted id-only rows as data: a response missing the tag fields (e.g. `fields` param ignored upstream) would latch the gate with nothing merged → every pin hidden. Now only a response with at least one actually-tagged row latches.

**5. Stale tags now clear.** The merge only copied truthy values, so a `yes` persisted in a previous session survived the tag's removal in OSM forever, keeping the place inside filtered embeds. The merge now diff-assigns including `undefined`. (Guard #4 makes this safe — a degenerate response can't mass-clear.)

**6. `?issues` + payment consistency.** The page-side issue-chip tallies were computed from the unfiltered viewport snapshot while pins and list narrowed — chips could count places the embed filter hides. The snapshot now narrows first, same readiness gate.

## Regression guards

- **`tests/map-payment-filter.spec.ts`** (modeled on the `?outdated` guard, which exists for exactly this reason): `?lightning` narrows the rendered pins; `?nfc` + AND semantics; and the nearby list narrows with the pins. The #398 loss was *page wiring* — unit tests pass right through that, only an e2e pins it. Thresholds calibrated from prod data (lightning=yes ≈79%, nfc ≈12% of 29,320 places; the list test anchors on San Salvador z15: ~250 places, ~31 nfc, wide drift headroom both ways). New `__nearbyListCount` hook follows the existing `__mapPlacesCount` precedent at the same site.
- **`src/lib/sync/places.enrichment.test.ts`**: every latch guard (non-array / empty / id-only / places-race / failed fetch), merge-by-id incl. `"no"` values, stale-tag clearing, no-op-once-latched, the lock concurrency test, and the fill-in helper's don't-overwrite-fresher-rows contract.

Local gates: `format:fix`, `check`, `typecheck`, `lint` clean; 665 unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)