### PR TITLE
feat(map): placement mode — step 1 of the add-location redesign #1134

### DIFF
--- a/src/components/PlacementPinIcon.svelte
+++ b/src/components/PlacementPinIcon.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+// The bespoke placement-mode pin (bitcoin-orange, white outline + dot):
+// the map's placement crosshair, echoed on /add-location's arrival banner
+// so the handed-over pin reads as the same object. Inline SVG rather than
+// <Icon>: the glyph is custom (not in any Iconify set) and must paint on
+// first render without an Iconify API fetch.
+type Props = {
+	width?: number;
+	class?: string;
+};
+
+let { width = 24, class: className = "" }: Props = $props();
+
+// 24x30 viewBox — derived height keeps the pin's 4:5 aspect.
+const height = $derived((width * 30) / 24);
+</script>
+
+<svg {width} {height} viewBox="0 0 24 30" class={className} aria-hidden="true">
+	<path
+		d="M12 29s9-11.5 9-18A9 9 0 103 11c0 6.5 9 18 9 18z"
+		fill="#F7931A"
+		stroke="#fff"
+		stroke-width="1.6"
+	/>
+	<circle cx="12" cy="11" r="4.6" fill="#fff" />
+</svg>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -44,7 +44,9 @@ export type EventName =
 	| "save_prompt_login_click"
 	| "login_create_account_click"
 	| "backup_modal_shown"
-	| "backup_credentials_copied";
+	| "backup_credentials_copied"
+	| "add_place_enter"
+	| "add_place_confirm";
 
 declare global {
 	interface Window {

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -717,7 +717,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Карта на биткойн търговци",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -715,7 +715,14 @@
 		"viewDetails": "Детайли"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Карта на биткойн търговци"
+		"bitcoinMerchantMapTitle": "Карта на биткойн търговци",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"success": {
 		"linkCopied": "Връзката е копирана в клипборда!",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -276,7 +276,14 @@
 		"viewDetails": "Details"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Bitcoin Händlerkarte"
+		"bitcoinMerchantMapTitle": "Bitcoin Händlerkarte",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Kontakt",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -278,7 +278,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Bitcoin Händlerkarte",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -365,7 +365,14 @@
 		"viewDetails": "Details"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Bitcoin Merchant Map"
+		"bitcoinMerchantMapTitle": "Bitcoin Merchant Map",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Contact",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -367,7 +367,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Bitcoin Merchant Map",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -276,7 +276,14 @@
 		"viewDetails": "Detalles"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Mapa de Comercios Bitcoin"
+		"bitcoinMerchantMapTitle": "Mapa de Comercios Bitcoin",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Contacto",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -278,7 +278,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Mapa de Comercios Bitcoin",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -278,7 +278,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Carte des commerces Bitcoin",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -276,7 +276,14 @@
 		"viewDetails": "Détails"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Carte des commerces Bitcoin"
+		"bitcoinMerchantMapTitle": "Carte des commerces Bitcoin",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Contact",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -367,7 +367,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Mappa dei commercianti Bitcoin",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -365,7 +365,14 @@
 		"viewDetails": "Dettagli"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Mappa dei commercianti Bitcoin"
+		"bitcoinMerchantMapTitle": "Mappa dei commercianti Bitcoin",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Contatto",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -365,7 +365,14 @@
 		"viewDetails": "Details"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Bitcoin acceptatiekaart"
+		"bitcoinMerchantMapTitle": "Bitcoin acceptatiekaart",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Contact",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -367,7 +367,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Bitcoin acceptatiekaart",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -274,7 +274,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Mapa de Comerciantes Bitcoin",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -272,7 +272,14 @@
 		"viewDetails": "Detalhes"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Mapa de Comerciantes Bitcoin"
+		"bitcoinMerchantMapTitle": "Mapa de Comerciantes Bitcoin",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Contato",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -278,7 +278,6 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Биткоин карта",
 		"placement": {
-			"fab": "Add a place",
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -276,7 +276,14 @@
 		"viewDetails": "Детали"
 	},
 	"map": {
-		"bitcoinMerchantMapTitle": "Биткоин карта"
+		"bitcoinMerchantMapTitle": "Биткоин карта",
+		"placement": {
+			"fab": "Add a place",
+			"title": "Place the pin",
+			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
+			"cancel": "Cancel",
+			"confirm": "Add a place here"
+		}
 	},
 	"info": {
 		"contact": "Контакты",

--- a/src/lib/placementMode.test.ts
+++ b/src/lib/placementMode.test.ts
@@ -28,4 +28,10 @@ describe("parseCoordsParams", () => {
 		expect(parseCoordsParams(new URLSearchParams("lat=91&long=0"))).toBeNull();
 		expect(parseCoordsParams(new URLSearchParams("lat=0&long=181"))).toBeNull();
 	});
+
+	it("rejects the legacy bounds form (two lat/long pairs)", () => {
+		expect(
+			parseCoordsParams(new URLSearchParams("lat=1&long=2&lat=3&long=4")),
+		).toBeNull();
+	});
 });

--- a/src/lib/placementMode.test.ts
+++ b/src/lib/placementMode.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAddLocationUrl, parseCoordsParams } from "./placementMode";
+
+describe("buildAddLocationUrl", () => {
+	it("builds the add-location URL with 5-decimal coords", () => {
+		expect(buildAddLocationUrl(32.649012345, -16.910299999)).toBe(
+			"/add-location?lat=32.64901&long=-16.91030",
+		);
+	});
+});
+
+describe("parseCoordsParams", () => {
+	it("parses valid coords", () => {
+		expect(
+			parseCoordsParams(new URLSearchParams("lat=32.64901&long=-16.9103")),
+		).toEqual({ lat: 32.64901, long: -16.9103 });
+	});
+
+	it("returns null when a param is missing", () => {
+		expect(parseCoordsParams(new URLSearchParams("lat=32.64901"))).toBeNull();
+		expect(parseCoordsParams(new URLSearchParams(""))).toBeNull();
+	});
+
+	it("returns null for empty, non-numeric, or out-of-range values", () => {
+		expect(parseCoordsParams(new URLSearchParams("lat=&long=1"))).toBeNull();
+		expect(parseCoordsParams(new URLSearchParams("lat=abc&long=1"))).toBeNull();
+		expect(parseCoordsParams(new URLSearchParams("lat=91&long=0"))).toBeNull();
+		expect(parseCoordsParams(new URLSearchParams("lat=0&long=181"))).toBeNull();
+	});
+});

--- a/src/lib/placementMode.ts
+++ b/src/lib/placementMode.ts
@@ -1,0 +1,19 @@
+import { isValidLatitude, isValidLongitude } from "$lib/utils";
+
+// 5 decimal places (~1 m) matches the precision /add-location displays
+// and snaps to in placeMarker().
+export const buildAddLocationUrl = (lat: number, long: number): string =>
+	`/add-location?lat=${lat.toFixed(5)}&long=${long.toFixed(5)}`;
+
+export const parseCoordsParams = (
+	params: URLSearchParams,
+): { lat: number; long: number } | null => {
+	const rawLat = params.get("lat");
+	const rawLong = params.get("long");
+	// Number("") is 0, so empty strings must be rejected before parsing.
+	if (!rawLat?.trim() || !rawLong?.trim()) return null;
+	const lat = Number(rawLat);
+	const long = Number(rawLong);
+	if (!isValidLatitude(lat) || !isValidLongitude(long)) return null;
+	return { lat, long };
+};

--- a/src/lib/placementMode.ts
+++ b/src/lib/placementMode.ts
@@ -1,19 +1,18 @@
-import { isValidLatitude, isValidLongitude } from "$lib/utils";
+import { parseLatLongQuery } from "$lib/map/queryViewport";
 
 // 5 decimal places (~1 m) matches the precision /add-location displays
 // and snaps to in placeMarker().
 export const buildAddLocationUrl = (lat: number, long: number): string =>
 	`/add-location?lat=${lat.toFixed(5)}&long=${long.toFixed(5)}`;
 
+// Delegates to the map's ?lat&long viewport parser so there is a single
+// implementation of the empty-string and ±90/±180 guards. Only a single
+// point is a valid placement handover — the legacy bounds form (two
+// lat/long pairs) is rejected.
 export const parseCoordsParams = (
 	params: URLSearchParams,
 ): { lat: number; long: number } | null => {
-	const rawLat = params.get("lat");
-	const rawLong = params.get("long");
-	// Number("") is 0, so empty strings must be rejected before parsing.
-	if (!rawLat?.trim() || !rawLong?.trim()) return null;
-	const lat = Number(rawLat);
-	const long = Number(rawLong);
-	if (!isValidLatitude(lat) || !isValidLongitude(long)) return null;
-	return { lat, long };
+	const parsed = parseLatLongQuery(params);
+	if (parsed?.kind !== "point") return null;
+	return { lat: parsed.lat, long: parsed.lng };
 };

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -23,6 +23,7 @@ import TextLink from "$components/TextLink.svelte";
 import { _, locale } from "$lib/i18n";
 import type { BtcmapMapHandle } from "$lib/map/createMap";
 import { createBtcmapMap } from "$lib/map/createMap";
+import { parseCoordsParams } from "$lib/placementMode";
 import { theme } from "$lib/theme";
 import { errToast, isValidLatitude, isValidLongitude } from "$lib/utils";
 
@@ -330,6 +331,16 @@ onMount(async () => {
 	if (browser) {
 		// fetch and add captcha
 		fetchCaptcha();
+
+		// Coordinates handed over from the map's placement mode (?lat&long).
+		// Calling placeMarker before the map exists is safe: it records the
+		// coords and the mapLoaded reactive drops the owed marker later.
+		const coords = parseCoordsParams(
+			new URLSearchParams(window.location.search),
+		);
+		if (coords) {
+			placeMarker(coords.lat, coords.long, { fly: true, syncInputs: true });
+		}
 
 		// Initialize the map
 		await initializeMap();

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -287,10 +287,10 @@ const submitForm = (event: SubmitEvent) => {
 				name: name.value,
 				nameEn: nameEn.value,
 				address: address.value,
-				lat: lat ? lat.toString() : "",
-				long: long ? long.toString() : "",
+				lat: lat !== undefined ? lat.toString() : "",
+				long: long !== undefined ? long.toString() : "",
 				osm:
-					lat && long
+					lat !== undefined && long !== undefined
 						? `https://www.openstreetmap.org/edit#map=21/${lat}/${long}`
 						: "",
 				category: category.value,

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -985,6 +985,18 @@ onMount(async () => {
 	const searchParams = new URLSearchParams(window.location.search);
 	placementActive = !issuesOnly && searchParams.has("add");
 	if (placementActive) trackEvent("add_place_enter", { method: "url" });
+	if (issuesOnly && searchParams.has("add")) {
+		// Placement mode is unavailable in the issues worklist, and
+		// AddPlaceMode (whose effect owns ?add) never mounts there — strip
+		// the dead param so it can't linger in shared/bookmarked URLs.
+		searchParams.delete("add");
+		const query = searchParams.toString() ? `?${searchParams.toString()}` : "";
+		history.replaceState(
+			history.state,
+			"",
+			`${window.location.pathname}${query}${window.location.hash}`,
+		);
+	}
 	const queryView = hashCoords ? null : parseLatLongQuery(searchParams);
 	// Distinguish "no ?lat/long" from "malformed ?lat/long" so an embed
 	// linking with bad coords gets a visible hint instead of silently

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -977,6 +977,7 @@ onMount(async () => {
 	const hashCoords = parseHashCoords();
 	const searchParams = new URLSearchParams(window.location.search);
 	placementActive = !issuesOnly && searchParams.has("add");
+	if (placementActive) trackEvent("add_place_enter", { method: "url" });
 	const queryView = hashCoords ? null : parseLatLongQuery(searchParams);
 	// Distinguish "no ?lat/long" from "malformed ?lat/long" so an embed
 	// linking with bad coords gets a visible hint instead of silently

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -128,6 +128,12 @@ let merchantListPanel: MerchantListPanel;
 
 let placementActive = false;
 
+// Placement mode owns the bottom sheet's z-[1002] slot; a merchant drawer
+// opened before (or during, via a stray pin click below) placement starts
+// would otherwise stack on top of it. close() also cleans up ?merchant/?view
+// the same way the existing empty-map-click close path does.
+$: if (placementActive) merchantDrawer.close();
+
 // "Boosted locations only" map filter (?boosts=true). The tools modal sets it
 // via a full page reload, so it's constant for the session; it narrows both the
 // map markers and the nearby list to currently-boosted places.
@@ -967,7 +973,7 @@ onMount(async () => {
 	// near their own country instead of the global default.
 	const hashCoords = parseHashCoords();
 	const searchParams = new URLSearchParams(window.location.search);
-	placementActive = searchParams.has("add");
+	placementActive = !issuesOnly && searchParams.has("add");
 	const queryView = hashCoords ? null : parseLatLongQuery(searchParams);
 	// Distinguish "no ?lat/long" from "malformed ?lat/long" so an embed
 	// linking with bad coords gets a visible hint instead of silently
@@ -1088,6 +1094,7 @@ onMount(async () => {
 			spiderfier = new Spiderfy(map, {
 				forceSpiderifyMinZoom: CLUSTERING_DISABLED_ZOOM,
 				onLeafClick: (feature) => {
+					if (placementActive) return;
 					const placeId = feature.properties?.id;
 					if (typeof placeId === "number") {
 						merchantDrawer.open(placeId, "details");
@@ -1127,6 +1134,7 @@ onMount(async () => {
 			// into the store. Both layers share the same handler since boosted
 			// pins live in their own source above the clustered one.
 			const onPinClick = (e: MapLayerMouseEvent) => {
+				if (placementActive) return;
 				const feature = e.features?.[0] as MapGeoJSONFeature | undefined;
 				const placeId = feature?.properties?.id;
 				if (typeof placeId !== "number") return;

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -128,6 +128,13 @@ let merchantListPanel: MerchantListPanel;
 
 let placementActive = false;
 
+// Menu-modal entry point; AddPlaceMode's URL-sync effect picks up the
+// bind:active flip, so this only has to set state and report the method.
+const startPlacement = () => {
+	placementActive = true;
+	trackEvent("add_place_enter", { method: "menu" });
+};
+
 // Placement mode owns the bottom sheet's z-[1002] slot; a merchant drawer
 // opened before (or during, via a stray pin click below) placement starts
 // would otherwise stack on top of it. close() also cleans up ?merchant/?view
@@ -1516,10 +1523,11 @@ onDestroy(() => {
 	enableGlobe
 	{globeOn}
 	onToggleGlobe={toggleGlobe}
+	onAddPlace={issuesOnly ? null : startPlacement}
 />
 
 {#if styleLoaded && !issuesOnly}
-	<AddPlaceMode {map} bind:active={placementActive} isMobile={isMobileLayout} />
+	<AddPlaceMode {map} bind:active={placementActive} />
 {/if}
 
 <style>

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -131,8 +131,11 @@ let placementActive = false;
 // Placement mode owns the bottom sheet's z-[1002] slot; a merchant drawer
 // opened before (or during, via a stray pin click below) placement starts
 // would otherwise stack on top of it. close() also cleans up ?merchant/?view
-// the same way the existing empty-map-click close path does.
-$: if (placementActive) merchantDrawer.close();
+// the same way the existing empty-map-click close path does. Guard on isOpen
+// (matching that same close path) so ordinary placement entry doesn't push a
+// duplicate, unchanged-URL history entry via close()'s unconditional
+// updateMerchantHash(null) → pushState.
+$: if (placementActive && $merchantDrawer.isOpen) merchantDrawer.close();
 
 // "Boosted locations only" map filter (?boosts=true). The tools modal sets it
 // via a full page reload, so it's constant for the session; it narrows both the

--- a/src/routes/map/+page.svelte
+++ b/src/routes/map/+page.svelte
@@ -106,6 +106,7 @@ import { debounce, errToast, isBoosted } from "$lib/utils";
 import { filterPlacesByRecency } from "$lib/verification";
 
 import type { PageData } from "./$types";
+import AddPlaceMode from "./components/AddPlaceMode.svelte";
 import IssueFilterChips from "./components/IssueFilterChips.svelte";
 import MapControls from "./components/MapControls.svelte";
 import MapSearchBar from "./components/MapSearchBar.svelte";
@@ -124,6 +125,8 @@ const isMobileLayout = browser && window.innerWidth < BREAKPOINTS.md;
 
 // Lets the floating search bar hand focus to the panel's input as it unmounts
 let merchantListPanel: MerchantListPanel;
+
+let placementActive = false;
 
 // "Boosted locations only" map filter (?boosts=true). The tools modal sets it
 // via a full page reload, so it's constant for the session; it narrows both the
@@ -964,6 +967,7 @@ onMount(async () => {
 	// near their own country instead of the global default.
 	const hashCoords = parseHashCoords();
 	const searchParams = new URLSearchParams(window.location.search);
+	placementActive = searchParams.has("add");
 	const queryView = hashCoords ? null : parseLatLongQuery(searchParams);
 	// Distinguish "no ?lat/long" from "malformed ?lat/long" so an embed
 	// linking with bad coords gets a visible hint instead of silently
@@ -1433,7 +1437,7 @@ onDestroy(() => {
 	</div>
 {/if}
 
-{#if styleLoaded && !isMobileLayout}
+{#if styleLoaded && !isMobileLayout && !placementActive}
 	<div class="pointer-events-none absolute top-3 left-3 z-[1000]">
 		<MapSearchBar
 			onActivate={async () => {
@@ -1452,28 +1456,30 @@ onDestroy(() => {
 	</div>
 {/if}
 
-<MerchantListPanel
-	bind:this={merchantListPanel}
-	onPanToNearbyMerchant={panToNearbyMerchant}
-	onZoomToSearchResult={zoomToSearchResult}
-	onZoomToNearbyLevel={zoomToNearbyLevel}
-	onFitSearchResultBounds={fitSearchResultBounds}
-	onHoverStart={() => {
-		// Hover highlight requires feature-state plumbing that isn't
-		// wired here yet — deferred to a follow-up polish.
-	}}
-	onHoverEnd={() => {
-		// See onHoverStart above.
-	}}
-	onSearch={(query) => merchantList.search(query, { getCenter: readSearchCenter })}
-	onRefresh={() => updateMerchantList({ force: true })}
-	behavior={listBehavior}
-	mapReady={styleLoaded}
-	isMobile={isMobileLayout}
-	issuesMode={issuesOnly}
-/>
+{#if !placementActive}
+	<MerchantListPanel
+		bind:this={merchantListPanel}
+		onPanToNearbyMerchant={panToNearbyMerchant}
+		onZoomToSearchResult={zoomToSearchResult}
+		onZoomToNearbyLevel={zoomToNearbyLevel}
+		onFitSearchResultBounds={fitSearchResultBounds}
+		onHoverStart={() => {
+			// Hover highlight requires feature-state plumbing that isn't
+			// wired here yet — deferred to a follow-up polish.
+		}}
+		onHoverEnd={() => {
+			// See onHoverStart above.
+		}}
+		onSearch={(query) => merchantList.search(query, { getCenter: readSearchCenter })}
+		onRefresh={() => updateMerchantList({ force: true })}
+		behavior={listBehavior}
+		mapReady={styleLoaded}
+		isMobile={isMobileLayout}
+		issuesMode={issuesOnly}
+	/>
+{/if}
 
-{#if styleLoaded}
+{#if styleLoaded && !placementActive}
 	<CommunityRail
 		lat={currentLat}
 		lon={currentLon}
@@ -1499,6 +1505,10 @@ onDestroy(() => {
 	{globeOn}
 	onToggleGlobe={toggleGlobe}
 />
+
+{#if styleLoaded && !issuesOnly}
+	<AddPlaceMode {map} bind:active={placementActive} isMobile={isMobileLayout} />
+{/if}
 
 <style>
 	.map-container {

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -7,9 +7,13 @@ import { buildAddLocationUrl } from "$lib/placementMode";
 
 import { goto } from "$app/navigation";
 
-export let map: MapLibreMap | undefined;
-export let active = false;
-export let isMobile = false;
+type Props = {
+	map: MapLibreMap | undefined;
+	active?: boolean;
+	isMobile?: boolean;
+};
+
+let { map, active = $bindable(false), isMobile = false }: Props = $props();
 
 // Keep ?add in the URL so placement mode is linkable. Same raw
 // history.replaceState idiom as writeHashCoords ($lib/map/mapHash.ts),
@@ -74,14 +78,14 @@ const confirm = () => {
 		<div class="mt-4 flex gap-3">
 			<button
 				type="button"
-				on:click={cancel}
+				onclick={cancel}
 				class="h-12 rounded-xl border border-input px-5 font-semibold text-body dark:text-offwhite"
 			>
 				{$_("map.placement.cancel")}
 			</button>
 			<button
 				type="button"
-				on:click={confirm}
+				onclick={confirm}
 				class="h-12 flex-1 rounded-xl bg-bitcoin font-semibold text-white hover:bg-bitcoinHover"
 			>
 				{$_("map.placement.confirm")}
@@ -94,7 +98,7 @@ const confirm = () => {
 	     search sheet's peek, on desktop it sits near the bottom edge -->
 	<button
 		type="button"
-		on:click={enter}
+		onclick={enter}
 		class="bottom-(--fab-bottom) absolute left-3 z-[1000] flex h-12 items-center gap-2 rounded-full bg-bitcoin px-4 font-semibold text-white shadow-lg hover:bg-bitcoinHover"
 		style="--fab-bottom: calc(env(safe-area-inset-bottom) + {isMobile
 			? SEARCH_SHEET_PEEK_HEIGHT + 12

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+import type { Map as MapLibreMap } from "maplibre-gl";
+
+import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
+import { _ } from "$lib/i18n";
+import { buildAddLocationUrl } from "$lib/placementMode";
+
+import { goto } from "$app/navigation";
+
+export let map: MapLibreMap | undefined;
+export let active = false;
+export let isMobile = false;
+
+// Keep ?add in the URL so placement mode is linkable. Same raw
+// history.replaceState idiom as writeHashCoords ($lib/map/mapHash.ts),
+// which preserves location.search on every viewport write — so ?add
+// survives map moves and the hash survives this toggle. Other query
+// params (e.g. ?issues) must be preserved, so edit, don't rebuild.
+const syncUrl = () => {
+	const params = new URLSearchParams(window.location.search);
+	if (active) params.set("add", "");
+	else params.delete("add");
+	const query = params.toString() ? `?${params.toString()}` : "";
+	history.replaceState(
+		history.state,
+		"",
+		`${window.location.pathname}${query}${window.location.hash}`,
+	);
+};
+
+const enter = () => {
+	active = true;
+	syncUrl();
+};
+
+const cancel = () => {
+	active = false;
+	syncUrl();
+};
+
+const confirm = () => {
+	if (!map) return;
+	const center = map.getCenter();
+	goto(buildAddLocationUrl(center.lat, center.lng));
+};
+</script>
+
+{#if active}
+	<!-- center crosshair pin: tip must sit exactly on the map center,
+	     so shift up by the full pin height -->
+	<div
+		class="pointer-events-none absolute left-1/2 top-1/2 z-[1001] -translate-x-1/2 -translate-y-full drop-shadow-lg"
+	>
+		<svg width="40" height="50" viewBox="0 0 24 30">
+			<path
+				d="M12 29s9-11.5 9-18A9 9 0 103 11c0 6.5 9 18 9 18z"
+				fill="#F7931A"
+				stroke="#fff"
+				stroke-width="1.6"
+			/>
+			<circle cx="12" cy="11" r="4.6" fill="#fff" />
+		</svg>
+	</div>
+
+	<div
+		class="absolute bottom-0 left-0 right-0 z-[1002] rounded-t-2xl bg-white p-4 pb-6 shadow-lg dark:bg-dark"
+	>
+		<p class="text-lg font-semibold text-primary dark:text-white">
+			{$_("map.placement.title")}
+		</p>
+		<p class="mt-1 text-sm text-body dark:text-offwhite">
+			{$_("map.placement.hint")}
+		</p>
+		<div class="mt-4 flex gap-3">
+			<button
+				type="button"
+				on:click={cancel}
+				class="h-12 rounded-xl border border-input px-5 font-semibold text-body dark:text-offwhite"
+			>
+				{$_("map.placement.cancel")}
+			</button>
+			<button
+				type="button"
+				on:click={confirm}
+				class="h-12 flex-1 rounded-xl bg-bitcoin font-semibold text-white hover:bg-bitcoinHover"
+			>
+				{$_("map.placement.confirm")}
+			</button>
+		</div>
+	</div>
+{:else}
+	<!-- bottom-(--fab-bottom) + style var mirrors the IssueFilterChips
+	     positioning idiom on this page; on mobile the FAB clears the
+	     search sheet's peek, on desktop it sits near the bottom edge -->
+	<button
+		type="button"
+		on:click={enter}
+		class="bottom-(--fab-bottom) absolute left-3 z-[1000] flex h-12 items-center gap-2 rounded-full bg-bitcoin px-4 font-semibold text-white shadow-lg hover:bg-bitcoinHover"
+		style="--fab-bottom: calc(env(safe-area-inset-bottom) + {isMobile
+			? SEARCH_SHEET_PEEK_HEIGHT + 12
+			: 24}px)"
+	>
+		<span class="text-xl leading-none">+</span>
+		{$_("map.placement.fab")}
+	</button>
+{/if}

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import type { Map as MapLibreMap } from "maplibre-gl";
 
+import { trackEvent } from "$lib/analytics";
 import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
 import { _ } from "$lib/i18n";
 import { buildAddLocationUrl } from "$lib/placementMode";
@@ -32,9 +33,10 @@ const syncUrl = () => {
 	);
 };
 
-const enter = () => {
+const enter = (method: string) => {
 	active = true;
 	syncUrl();
+	trackEvent("add_place_enter", { method });
 };
 
 const cancel = () => {
@@ -45,6 +47,7 @@ const cancel = () => {
 const confirm = () => {
 	if (!map) return;
 	const center = map.getCenter();
+	trackEvent("add_place_confirm");
 	goto(buildAddLocationUrl(center.lat, center.lng));
 };
 </script>
@@ -98,7 +101,7 @@ const confirm = () => {
 	     search sheet's peek, on desktop it sits near the bottom edge -->
 	<button
 		type="button"
-		onclick={enter}
+		onclick={() => enter("fab")}
 		class="bottom-(--fab-bottom) absolute left-3 z-[1000] flex h-12 items-center gap-2 rounded-full bg-bitcoin px-4 font-semibold text-white shadow-lg hover:bg-bitcoinHover"
 		style="--fab-bottom: calc(env(safe-area-inset-bottom) + {isMobile
 			? SEARCH_SHEET_PEEK_HEIGHT + 12

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-import type { Map as MapLibreMap } from "maplibre-gl";
+import type {
+	LngLatLike,
+	Map as MapLibreMap,
+	MapMouseEvent,
+} from "maplibre-gl";
 
 import { trackEvent } from "$lib/analytics";
 import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
@@ -50,6 +54,96 @@ const confirm = () => {
 	trackEvent("add_place_confirm");
 	goto(buildAddLocationUrl(center.lat, center.lng));
 };
+
+// Long-press (touch) and right-click (desktop) both jump straight into
+// placement mode centered on the pressed/clicked point — they still land on
+// the confirm sheet rather than skipping it, so an accidental trigger is
+// always recoverable via Cancel.
+const enterAt = (lngLat: LngLatLike, method: string) => {
+	if (!map || active) return;
+	map.easeTo({ center: lngLat, duration: 300 });
+	enter(method);
+};
+
+const LONG_PRESS_MS = 500;
+const LONG_PRESS_MOVE_TOLERANCE_PX = 10;
+
+$effect(() => {
+	if (!map) return;
+
+	const currentMap = map;
+	const canvas = currentMap.getCanvas();
+
+	let longPressTimer: ReturnType<typeof setTimeout> | undefined;
+	let touchStart: { x: number; y: number } | null = null;
+
+	const clearLongPress = () => {
+		if (longPressTimer !== undefined) {
+			clearTimeout(longPressTimer);
+			longPressTimer = undefined;
+		}
+		touchStart = null;
+	};
+
+	const onTouchStart = (e: TouchEvent) => {
+		// A second finger means pinch/rotate, not a long press.
+		if (e.touches.length > 1) {
+			clearLongPress();
+			return;
+		}
+		if (e.touches.length !== 1) return;
+		const touch = e.touches[0];
+		touchStart = { x: touch.clientX, y: touch.clientY };
+		longPressTimer = setTimeout(() => {
+			if (!touchStart) return;
+			const rect = canvas.getBoundingClientRect();
+			const point = currentMap.unproject([
+				touchStart.x - rect.left,
+				touchStart.y - rect.top,
+			]);
+			clearLongPress();
+			enterAt(point, "long_press");
+		}, LONG_PRESS_MS);
+	};
+
+	// Panning cancels the hold — only a stationary press counts.
+	const onTouchMove = (e: TouchEvent) => {
+		if (!touchStart) return;
+		const touch = e.touches[0];
+		if (!touch) return;
+		const dx = touch.clientX - touchStart.x;
+		const dy = touch.clientY - touchStart.y;
+		if (Math.hypot(dx, dy) > LONG_PRESS_MOVE_TOLERANCE_PX) clearLongPress();
+	};
+
+	const onTouchEnd = () => clearLongPress();
+
+	// Android fires a native contextmenu around the same long-press
+	// threshold as our manual timer; clearing it here stops the timer from
+	// also firing and double-entering placement mode. iOS Safari fires no
+	// contextmenu on long-press, which is what the manual timer is for.
+	const onContextMenu = (e: MapMouseEvent) => {
+		clearLongPress();
+		if (active) return;
+		e.originalEvent.preventDefault();
+		enterAt(e.lngLat, "right_click");
+	};
+
+	canvas.addEventListener("touchstart", onTouchStart, { passive: true });
+	canvas.addEventListener("touchmove", onTouchMove, { passive: true });
+	canvas.addEventListener("touchend", onTouchEnd);
+	canvas.addEventListener("touchcancel", onTouchEnd);
+	currentMap.on("contextmenu", onContextMenu);
+
+	return () => {
+		clearLongPress();
+		canvas.removeEventListener("touchstart", onTouchStart);
+		canvas.removeEventListener("touchmove", onTouchMove);
+		canvas.removeEventListener("touchend", onTouchEnd);
+		canvas.removeEventListener("touchcancel", onTouchEnd);
+		currentMap.off("contextmenu", onContextMenu);
+	};
+});
 </script>
 
 {#if active}

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -6,7 +6,6 @@ import type {
 } from "maplibre-gl";
 
 import { trackEvent } from "$lib/analytics";
-import { SEARCH_SHEET_PEEK_HEIGHT } from "$lib/drawerConfig";
 import { _ } from "$lib/i18n";
 import { buildAddLocationUrl } from "$lib/placementMode";
 
@@ -15,17 +14,18 @@ import { goto } from "$app/navigation";
 type Props = {
 	map: MapLibreMap | undefined;
 	active?: boolean;
-	isMobile?: boolean;
 };
 
-let { map, active = $bindable(false), isMobile = false }: Props = $props();
+let { map, active = $bindable(false) }: Props = $props();
 
 // Keep ?add in the URL so placement mode is linkable. Same raw
 // history.replaceState idiom as writeHashCoords ($lib/map/mapHash.ts),
 // which preserves location.search on every viewport write — so ?add
 // survives map moves and the hash survives this toggle. Other query
 // params (e.g. ?issues) must be preserved, so edit, don't rebuild.
-const syncUrl = () => {
+// Runs as an effect (reading `active` tracks it) so external activation —
+// the page flipping bind:active from the menu entry — syncs too.
+$effect(() => {
 	const params = new URLSearchParams(window.location.search);
 	if (active) params.set("add", "");
 	else params.delete("add");
@@ -35,17 +35,15 @@ const syncUrl = () => {
 		"",
 		`${window.location.pathname}${query}${window.location.hash}`,
 	);
-};
+});
 
 const enter = (method: string) => {
 	active = true;
-	syncUrl();
 	trackEvent("add_place_enter", { method });
 };
 
 const cancel = () => {
 	active = false;
-	syncUrl();
 };
 
 const confirm = () => {
@@ -189,19 +187,4 @@ $effect(() => {
 			</button>
 		</div>
 	</div>
-{:else}
-	<!-- bottom-(--fab-bottom) + style var mirrors the IssueFilterChips
-	     positioning idiom on this page; on mobile the FAB clears the
-	     search sheet's peek, on desktop it sits near the bottom edge -->
-	<button
-		type="button"
-		onclick={() => enter("fab")}
-		class="bottom-(--fab-bottom) absolute left-3 z-[1000] flex h-12 items-center gap-2 rounded-full bg-bitcoin px-4 font-semibold text-white shadow-lg hover:bg-bitcoinHover"
-		style="--fab-bottom: calc(env(safe-area-inset-bottom) + {isMobile
-			? SEARCH_SHEET_PEEK_HEIGHT + 12
-			: 24}px)"
-	>
-		<span class="text-xl leading-none">+</span>
-		{$_("map.placement.fab")}
-	</button>
 {/if}

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -5,6 +5,7 @@ import type {
 	MapMouseEvent,
 } from "maplibre-gl";
 
+import PlacementPinIcon from "$components/PlacementPinIcon.svelte";
 import { trackEvent } from "$lib/analytics";
 import { _ } from "$lib/i18n";
 import { buildAddLocationUrl } from "$lib/placementMode";
@@ -150,15 +151,7 @@ $effect(() => {
 	<div
 		class="pointer-events-none absolute left-1/2 top-1/2 z-[1001] -translate-x-1/2 -translate-y-full drop-shadow-lg"
 	>
-		<svg width="40" height="50" viewBox="0 0 24 30">
-			<path
-				d="M12 29s9-11.5 9-18A9 9 0 103 11c0 6.5 9 18 9 18z"
-				fill="#F7931A"
-				stroke="#fff"
-				stroke-width="1.6"
-			/>
-			<circle cx="12" cy="11" r="4.6" fill="#fff" />
-		</svg>
+		<PlacementPinIcon width={40} />
 	</div>
 
 	<div

--- a/src/routes/map/components/MapControls.svelte
+++ b/src/routes/map/components/MapControls.svelte
@@ -48,6 +48,9 @@ export let enableGlobe = false;
 // every style.load, queued swaps included) can reliably re-apply it.
 export let globeOn = false;
 export let onToggleGlobe: (() => void) | null = null;
+// Forwarded to the menu modal's add row; null keeps the plain
+// /add-location link (communities variant, ?issues mode).
+export let onAddPlace: (() => void) | null = null;
 
 let toolsModalOpen = false;
 let menuModalOpen = false;
@@ -170,4 +173,4 @@ onDestroy(() => {
 	onToggleGlobe={enableGlobe ? onToggleGlobe : null}
 />
 
-<MapMenuModal bind:open={menuModalOpen} {variant} />
+<MapMenuModal bind:open={menuModalOpen} {variant} {onAddPlace} />

--- a/src/routes/map/components/MapMenuModal.svelte
+++ b/src/routes/map/components/MapMenuModal.svelte
@@ -9,9 +9,16 @@ import { session } from "$lib/session";
 type Props = {
 	open?: boolean;
 	variant?: "main" | "communities";
+	// When set (/map outside issues mode), the add row starts placement mode
+	// on the map instead of linking to the standalone form.
+	onAddPlace?: (() => void) | null;
 };
 
-let { open = $bindable(false), variant = "main" }: Props = $props();
+let {
+	open = $bindable(false),
+	variant = "main",
+	onAddPlace = null,
+}: Props = $props();
 
 const loggedIn = $derived(!!$session);
 
@@ -28,14 +35,28 @@ const iconClass = "h-5 w-5 flex-none dark:invert";
 		</a>
 
 		{#if variant === "main"}
-			<a
-				href="/add-location"
-				class={rowClass}
-				onclick={() => trackEvent("add_location_click")}
-			>
-				<img src="/icons/marker.svg" alt="" class={iconClass} />
-				<span>{$_("mapControls.addLocation")}</span>
-			</a>
+			{#if onAddPlace}
+				<button
+					type="button"
+					class="{rowClass} w-full text-left"
+					onclick={() => {
+						open = false;
+						onAddPlace?.();
+					}}
+				>
+					<img src="/icons/marker.svg" alt="" class={iconClass} />
+					<span>{$_("mapControls.addLocation")}</span>
+				</button>
+			{:else}
+				<a
+					href="/add-location"
+					class={rowClass}
+					onclick={() => trackEvent("add_location_click")}
+				>
+					<img src="/icons/marker.svg" alt="" class={iconClass} />
+					<span>{$_("mapControls.addLocation")}</span>
+				</a>
+			{/if}
 			<!-- Full reload on purpose (data-sveltekit-reload): ?issues mode is
 				locked at page init, and a same-route client-side navigation
 				would not remount /map. -->

--- a/src/routes/map/components/MapMenuModal.svelte
+++ b/src/routes/map/components/MapMenuModal.svelte
@@ -6,10 +6,14 @@ import { session } from "$lib/session";
 
 // Page-navigation menu, modal twin of the tools panel. Two variants mirror
 // the old NavButtonsControl: "main" (/map) and "communities" (/communities/map).
-export let open = false;
-export let variant: "main" | "communities" = "main";
+type Props = {
+	open?: boolean;
+	variant?: "main" | "communities";
+};
 
-$: loggedIn = !!$session;
+let { open = $bindable(false), variant = "main" }: Props = $props();
+
+const loggedIn = $derived(!!$session);
 
 const rowClass =
 	"flex items-center gap-3 rounded-lg px-3 py-3 text-body hover:bg-gray-100 dark:text-white dark:hover:bg-white/5";
@@ -18,7 +22,7 @@ const iconClass = "h-5 w-5 flex-none dark:invert";
 
 <Modal bind:open title={$_("mapControls.menu")} titleId="map-menu-title">
 	<nav class="space-y-1">
-		<a href="/" class={rowClass} on:click={() => trackEvent("home_button_click")}>
+		<a href="/" class={rowClass} onclick={() => trackEvent("home_button_click")}>
 			<img src="/icons/home.svg" alt="" class={iconClass} />
 			<span>{$_("mapControls.goToHome")}</span>
 		</a>
@@ -27,7 +31,7 @@ const iconClass = "h-5 w-5 flex-none dark:invert";
 			<a
 				href="/add-location"
 				class={rowClass}
-				on:click={() => trackEvent("add_location_click")}
+				onclick={() => trackEvent("add_location_click")}
 			>
 				<img src="/icons/marker.svg" alt="" class={iconClass} />
 				<span>{$_("mapControls.addLocation")}</span>
@@ -39,7 +43,7 @@ const iconClass = "h-5 w-5 flex-none dark:invert";
 				href="/map?issues"
 				data-sveltekit-reload
 				class={rowClass}
-				on:click={() => trackEvent("issues_map_click")}
+				onclick={() => trackEvent("issues_map_click")}
 			>
 				<img src="/icons/warning.svg" alt="" class={iconClass} />
 				<span>{$_("mapControls.issuesMap")}</span>
@@ -47,7 +51,7 @@ const iconClass = "h-5 w-5 flex-none dark:invert";
 			<a
 				href="/communities/map"
 				class={rowClass}
-				on:click={() => trackEvent("community_map_click")}
+				onclick={() => trackEvent("community_map_click")}
 			>
 				<img src="/icons/group.svg" alt="" class={iconClass} />
 				<span>{$_("mapControls.communityMap")}</span>
@@ -62,7 +66,7 @@ const iconClass = "h-5 w-5 flex-none dark:invert";
 		<a
 			href={loggedIn ? "/user/activity" : "/login"}
 			class={rowClass}
-			on:click={() => trackEvent("account_button_click", { logged_in: loggedIn })}
+			onclick={() => trackEvent("account_button_click", { logged_in: loggedIn })}
 		>
 			<img src="/icons/account.svg" alt="" class={iconClass} />
 			<span>{loggedIn ? $_("mapControls.account") : $_("mapControls.login")}</span>

--- a/tests/map-menu.spec.ts
+++ b/tests/map-menu.spec.ts
@@ -13,8 +13,8 @@ test.describe('Map menu', () => {
 		await waitForMarkersToLoad(page);
 
 		await expect(menuButton(page)).toBeVisible();
-		// Links are not in the DOM until the menu opens.
-		await expect(page.getByRole('link', { name: 'Add location' })).toBeHidden();
+		// Menu content is not in the DOM until the menu opens.
+		await expect(page.getByRole('button', { name: 'Add location' })).toBeHidden();
 
 		await menuButton(page).click();
 		const dialog = page.getByRole('dialog', { name: /^menu$/i });
@@ -22,14 +22,33 @@ test.describe('Map menu', () => {
 		await expect(
 			dialog.getByRole('link', { name: 'Go to home page' })
 		).toBeVisible();
-		await expect(dialog.getByRole('link', { name: 'Add location' })).toHaveAttribute(
-			'href',
-			'/add-location'
-		);
 		await expect(
 			dialog.getByRole('link', { name: 'Community map' })
 		).toHaveAttribute('href', '/communities/map');
 		// Account row reflects session state (logged out -> Log in / login).
 		await expect(dialog.getByRole('link', { name: /log in|account/i })).toBeVisible();
+
+		// The add row is an action, not a link (#1134): it closes the menu
+		// and starts placement mode on the map — confirm sheet plus ?add.
+		await dialog.getByRole('button', { name: 'Add location' }).click();
+		await expect(dialog).toBeHidden();
+		await expect(page.getByText('Place the pin')).toBeVisible();
+		await expect(page).toHaveURL(/[?&]add=/);
+	});
+
+	test('keeps the add row a plain link in ?issues mode', async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await page.goto('/map?issues#17/42.2762511/42.7024218', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page);
+
+		await menuButton(page).click();
+		const dialog = page.getByRole('dialog', { name: /^menu$/i });
+		await expect(dialog).toBeVisible();
+		// Placement mode is deliberately unavailable in the issues worklist,
+		// so the row falls back to the standalone form.
+		await expect(dialog.getByRole('link', { name: 'Add location' })).toHaveAttribute(
+			'href',
+			'/add-location'
+		);
 	});
 });


### PR DESCRIPTION

<img width="451" height="954" alt="image" src="https://github.com/user-attachments/assets/24fbaf8b-8163-4b14-88a8-a0b99ef96e4e" />


<img width="454" height="952" alt="image" src="https://github.com/user-attachments/assets/b079fd0f-bd3d-470f-90c5-f0cd529732e3" />


<img width="479" height="978" alt="image" src="https://github.com/user-attachments/assets/ffb5b45f-2fd1-4ddb-82f6-b5ee2099e012" />

*(Screenshots are from the first iteration, which had a FAB — the entry point has since moved into the map menu per team feedback; crosshair and confirm sheet are unchanged.)*

Step 1 of the add-location redesign (smallest reviewable slice, direction check).

- Entering placement mode (`?add`): the map menu's **"Add location" row** starts it in place, **long-press** on touch devices and **right-click** on desktop drop the pin where you pressed, and `/map?add` deep-links into it
- Placement mode: center crosshair, drag the map under it, confirm
- Confirm hands the coordinates to the existing /add-location form (`?lat&long`), which pre-places its marker and flies to it
- Placement mode suppresses browsing chrome (search, list panel, community rail), is gated out of `?issues` mode (where the menu row falls back to the plain `/add-location` link and a stale `?add` is stripped), ignores merchant-pin taps while active, and closes an open merchant drawer on entry — URL hash and other query params are preserved throughout
- Analytics: `add_place_enter` with `method: menu | url | long_press | right_click`, and `add_place_confirm`. Note: the menu row previously fired `add_location_click`; that event now only fires from the `?issues` fallback link, so its series changes meaning on merge
- New `AddPlaceMode.svelte` and the shared `PlacementPinIcon.svelte` are runes-mode per current guidelines; `map/+page.svelte` wiring stays legacy (#1208 hotspot)
- The new `map.placement.*` i18n keys carry English placeholder strings in all 9 locales by design — translations are a follow-up
- Playwright coverage: menu-entry → placement → `?add`, and the `?issues` fallback (`tests/map-menu.spec.ts`)
- No form or backend changes; the next steps (arrival state #1277, stepper form, dedupe interrupt, submit_place pipeline) follow separately once the direction is confirmed

Try it on the deploy preview: open /map → menu → "Add location", or long-press / right-click the map. Direct entry via /map?add also works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added an interactive map mode for adding a new location.
- Enter placement from the map menu, by long-pressing on touch devices, or by right-clicking on desktop.
- Position, confirm, or cancel a pin and continue to the add-location page with coordinates preserved.
- Map search, filters, merchant lists, and drawer interactions are temporarily hidden during placement.

## Localization
- Added placement labels and instructions across supported languages.

## Bug Fixes
- Valid coordinates, including zero values, are now correctly recognized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
