### PR TITLE
feat(add-location): submit through btcmap-api submit_place pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 OPENCAGE_API_KEY=
 SERVER_CRYPTO_KEY=
 SERVER_INIT_VECTOR=
-# Server-held token for btcmap-api's submit_place RPC (origin "website").
+# Server-held token for btcmap-api's submit_place RPC (origin "btcmap-website").
 # Required in production (Netlify env var); without it /api/submit-place
 # returns 503. Never expose with a VITE_ prefix.
 BTCMAP_IMPORT_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,6 @@ SERVER_INIT_VECTOR=
 # Required in production (Netlify env var); without it /api/submit-place
 # returns 503. Never expose with a VITE_ prefix.
 BTCMAP_IMPORT_TOKEN=
-# Optional RPC override for local API development:
-# BTCMAP_API_RPC_URL=http://127.0.0.1:8000/rpc
 GITEA_API_KEY=
 GITEA_API_URL=
 PUBLIC_UMAMI_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 OPENCAGE_API_KEY=
 SERVER_CRYPTO_KEY=
 SERVER_INIT_VECTOR=
+# Server-held token for btcmap-api's submit_place RPC (origin "website").
+# Required in production (Netlify env var); without it /api/submit-place
+# returns 503. Never expose with a VITE_ prefix.
+BTCMAP_API_TOKEN=
+# Optional RPC override for local API development:
+# BTCMAP_API_RPC_URL=http://127.0.0.1:8000/rpc
 GITEA_API_KEY=
 GITEA_API_URL=
 PUBLIC_UMAMI_URL=

--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
-OPENCAGE_API_KEY=
-SERVER_CRYPTO_KEY=
-SERVER_INIT_VECTOR=
 # Server-held token for btcmap-api's submit_place RPC (origin "btcmap-website").
 # Required in production (Netlify env var); without it /api/submit-place
 # returns 503. Never expose with a VITE_ prefix.
 BTCMAP_IMPORT_TOKEN=
+OPENCAGE_API_KEY=
+SERVER_CRYPTO_KEY=
+SERVER_INIT_VECTOR=
 GITEA_API_KEY=
 GITEA_API_URL=
 PUBLIC_UMAMI_URL=

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ SERVER_INIT_VECTOR=
 # Server-held token for btcmap-api's submit_place RPC (origin "website").
 # Required in production (Netlify env var); without it /api/submit-place
 # returns 503. Never expose with a VITE_ prefix.
-BTCMAP_API_TOKEN=
+BTCMAP_IMPORT_TOKEN=
 # Optional RPC override for local API development:
 # BTCMAP_API_RPC_URL=http://127.0.0.1:8000/rpc
 GITEA_API_KEY=

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To test the frontend against a local [btcmap-api](https://github.com/teambtcmap/
 
 Remove or comment out the env var to switch back to the production API.
 
-**Note:** The add-location form submits through `/api/submit-place`, which calls btcmap-api's `submit_place` RPC and needs `BTCMAP_IMPORT_TOKEN` (plus `BTCMAP_API_RPC_URL` when testing against a local API).
+**Note:** The add-location form submits through `/api/submit-place`, which calls btcmap-api's `submit_place` RPC and needs `BTCMAP_IMPORT_TOKEN`. The RPC target follows `VITE_API_BASE_URL` (the endpoint uses SvelteKit's event fetch, so the dev-proxy path works server-side too).
 
 ### Build project
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To test the frontend against a local [btcmap-api](https://github.com/teambtcmap/
 
 Remove or comment out the env var to switch back to the production API.
 
-**Note:** The add-location form submits through `/api/submit-place`, which calls btcmap-api's `submit_place` RPC and needs `BTCMAP_API_TOKEN` (plus `BTCMAP_API_RPC_URL` when testing against a local API).
+**Note:** The add-location form submits through `/api/submit-place`, which calls btcmap-api's `submit_place` RPC and needs `BTCMAP_IMPORT_TOKEN` (plus `BTCMAP_API_RPC_URL` when testing against a local API).
 
 ### Build project
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ To test the frontend against a local [btcmap-api](https://github.com/teambtcmap/
    - `VITE_API_BASE_URL=/btcmap-api-proxy` — routes through the Vite dev proxy (avoids CORS; works for client-side calls and SSR load functions that use SvelteKit's `event.fetch`)
    - `VITE_API_BASE_URL=http://127.0.0.1:8000` — direct; works everywhere including SSR axios calls, but requires the API to send CORS headers
 3. Start the frontend: `pnpm dev`
-4. For form submissions: place/location add and verify forms use `/api/submit-place` which calls btcmap-api's `submit_place` RPC, requiring `BTCMAP_API_TOKEN` (and optionally `BTCMAP_API_RPC_URL` for local API testing).
 
 Remove or comment out the env var to switch back to the production API.
+
+**Note:** The add-location form submits through `/api/submit-place`, which calls btcmap-api's `submit_place` RPC and needs `BTCMAP_API_TOKEN` (plus `BTCMAP_API_RPC_URL` when testing against a local API).
 
 ### Build project
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To test the frontend against a local [btcmap-api](https://github.com/teambtcmap/
    - `VITE_API_BASE_URL=/btcmap-api-proxy` — routes through the Vite dev proxy (avoids CORS; works for client-side calls and SSR load functions that use SvelteKit's `event.fetch`)
    - `VITE_API_BASE_URL=http://127.0.0.1:8000` — direct; works everywhere including SSR axios calls, but requires the API to send CORS headers
 3. Start the frontend: `pnpm dev`
+4. For form submissions: place/location add and verify forms use `/api/submit-place` which calls btcmap-api's `submit_place` RPC, requiring `BTCMAP_API_TOKEN` (and optionally `BTCMAP_API_RPC_URL` for local API testing).
 
 Remove or comment out the env var to switch back to the production API.
 

--- a/src/lib/placeSubmission.test.ts
+++ b/src/lib/placeSubmission.test.ts
@@ -22,7 +22,7 @@ const fullForm = {
 describe("buildSubmitPlaceParams", () => {
 	it("maps the core fields and renames long to lon", () => {
 		const params = buildSubmitPlaceParams(fullForm, "uuid-1");
-		expect(params.origin).toBe("website");
+		expect(params.origin).toBe("btcmap-website");
 		expect(params.external_id).toBe("uuid-1");
 		expect(params.lat).toBe(52.48841);
 		expect(params.lon).toBe(13.42986);

--- a/src/lib/placeSubmission.test.ts
+++ b/src/lib/placeSubmission.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSubmitPlaceParams } from "./placeSubmission";
+
+const fullForm = {
+	name: "Satoshi's Comics",
+	nameEn: "Satoshi Comics",
+	address: "Nansenstr. 1, Berlin",
+	lat: 52.48841,
+	long: 13.42986,
+	category: "shop",
+	methods: ["onchain", "lightning"],
+	website: "https://example.com",
+	phone: "+49 30 123456",
+	hours: "Mo-Fr 10:00-18:00",
+	notes: "Ring the bell",
+	source: "Business Owner",
+	sourceOther: "",
+	contact: "owner@example.com",
+};
+
+describe("buildSubmitPlaceParams", () => {
+	it("maps the core fields and renames long to lon", () => {
+		const params = buildSubmitPlaceParams(fullForm, "uuid-1");
+		expect(params.origin).toBe("website");
+		expect(params.external_id).toBe("uuid-1");
+		expect(params.lat).toBe(52.48841);
+		expect(params.lon).toBe(13.42986);
+		expect(params.name).toBe("Satoshi's Comics");
+		expect(params.category).toBe("shop");
+	});
+
+	it("carries the rest in extra_fields and drops empty values", () => {
+		const { extra_fields } = buildSubmitPlaceParams(fullForm, "uuid-1");
+		expect(extra_fields).toEqual({
+			"name:en": "Satoshi Comics",
+			address: "Nansenstr. 1, Berlin",
+			payment_methods: "onchain,lightning",
+			website: "https://example.com",
+			phone: "+49 30 123456",
+			opening_hours: "Mo-Fr 10:00-18:00",
+			notes: "Ring the bell",
+			data_source: "Business Owner",
+			contact: "owner@example.com",
+			osm_edit_url:
+				"https://www.openstreetmap.org/edit#map=21/52.48841/13.42986",
+		});
+		// sourceOther was empty — must not appear
+		expect("data_source_details" in extra_fields).toBe(false);
+	});
+
+	it("keeps zero coordinates", () => {
+		const params = buildSubmitPlaceParams(
+			{ ...fullForm, lat: 0, long: 0 },
+			"uuid-2",
+		);
+		expect(params.lat).toBe(0);
+		expect(params.lon).toBe(0);
+	});
+});

--- a/src/lib/placeSubmission.ts
+++ b/src/lib/placeSubmission.ts
@@ -1,0 +1,61 @@
+export type AddLocationSubmission = {
+	name: string;
+	nameEn: string;
+	address: string;
+	lat: number;
+	long: number;
+	category: string;
+	methods: string[];
+	website: string;
+	phone: string;
+	hours: string;
+	notes: string;
+	source: string;
+	sourceOther: string;
+	contact: string;
+};
+
+export type SubmitPlaceParams = {
+	origin: "website";
+	external_id: string;
+	lat: number;
+	lon: number;
+	category: string;
+	name: string;
+	extra_fields: Record<string, string>;
+};
+
+// Maps the add-location form to btcmap-api's submit_place params: the four
+// first-class fields plus everything else as extra_fields. The API's field
+// is `lon`, the form's is `long`. Empty optionals are dropped so the
+// submission record stays clean.
+export const buildSubmitPlaceParams = (
+	form: AddLocationSubmission,
+	externalId: string,
+): SubmitPlaceParams => {
+	const optional: Record<string, string> = {
+		"name:en": form.nameEn,
+		address: form.address,
+		payment_methods: form.methods.join(","),
+		website: form.website,
+		phone: form.phone,
+		opening_hours: form.hours,
+		notes: form.notes,
+		data_source: form.source,
+		data_source_details: form.sourceOther,
+		contact: form.contact,
+		osm_edit_url: `https://www.openstreetmap.org/edit#map=21/${form.lat}/${form.long}`,
+	};
+	const extra_fields = Object.fromEntries(
+		Object.entries(optional).filter(([, value]) => value.trim() !== ""),
+	);
+	return {
+		origin: "website",
+		external_id: externalId,
+		lat: form.lat,
+		lon: form.long,
+		category: form.category,
+		name: form.name,
+		extra_fields,
+	};
+};

--- a/src/lib/placeSubmission.ts
+++ b/src/lib/placeSubmission.ts
@@ -16,7 +16,7 @@ export type AddLocationSubmission = {
 };
 
 export type SubmitPlaceParams = {
-	origin: "website";
+	origin: "btcmap-website";
 	external_id: string;
 	lat: number;
 	lon: number;
@@ -50,7 +50,7 @@ export const buildSubmitPlaceParams = (
 		Object.entries(optional).filter(([, value]) => value.trim() !== ""),
 	);
 	return {
-		origin: "website",
+		origin: "btcmap-website",
 		external_id: externalId,
 		lat: form.lat,
 		lon: form.long,

--- a/src/lib/server/captcha.test.ts
+++ b/src/lib/server/captcha.test.ts
@@ -41,6 +41,13 @@ describe("validateCaptcha", () => {
 		expect(caughtStatus(() => validateCaptcha(secret, "nope"))).toBe(400);
 	});
 
+	it("rejects garbage ciphertext with 400 instead of throwing", () => {
+		// decrypt.final() throws on bad padding ("00") and non-hex input
+		// ("zz") — both must surface as the captcha 400, not a 500.
+		expect(caughtStatus(() => validateCaptcha("00", "x"))).toBe(400);
+		expect(caughtStatus(() => validateCaptcha("zz", ""))).toBe(400);
+	});
+
 	it("rejects a reused secret with 400", () => {
 		const secret = encryptSecret("ABC14");
 		expect(caughtStatus(() => validateCaptcha(secret, "ABC14"))).toBeNull();

--- a/src/lib/server/captcha.test.ts
+++ b/src/lib/server/captcha.test.ts
@@ -1,11 +1,13 @@
 import { vi } from "vitest";
 
-vi.mock("$env/dynamic/private", () => ({
-	env: {
-		SERVER_CRYPTO_KEY: "aa".repeat(32),
-		SERVER_INIT_VECTOR: "bb".repeat(16),
-	},
+// Mutable so individual tests can simulate misconfiguration; vi.hoisted
+// runs before the hoisted vi.mock factory below.
+const mockEnv = vi.hoisted(() => ({
+	SERVER_CRYPTO_KEY: "aa".repeat(32),
+	SERVER_INIT_VECTOR: "bb".repeat(16),
 }));
+
+vi.mock("$env/dynamic/private", () => ({ env: mockEnv }));
 
 import crypto from "node:crypto";
 import { describe, expect, it } from "vitest";
@@ -52,5 +54,17 @@ describe("validateCaptcha", () => {
 		const secret = encryptSecret("ABC14");
 		expect(caughtStatus(() => validateCaptcha(secret, "ABC14"))).toBeNull();
 		expect(caughtStatus(() => validateCaptcha(secret, "ABC14"))).toBe(400);
+	});
+
+	it("reports a malformed server key as 503, not a captcha 400", () => {
+		// Hex typos silently truncate on decode — wrong length must read as
+		// misconfiguration, never blamed on the user's captcha answer.
+		const secret = encryptSecret("ABC15");
+		mockEnv.SERVER_CRYPTO_KEY = "aa".repeat(31);
+		try {
+			expect(caughtStatus(() => validateCaptcha(secret, "ABC15"))).toBe(503);
+		} finally {
+			mockEnv.SERVER_CRYPTO_KEY = "aa".repeat(32);
+		}
 	});
 });

--- a/src/lib/server/captcha.test.ts
+++ b/src/lib/server/captcha.test.ts
@@ -1,0 +1,49 @@
+import { vi } from "vitest";
+
+vi.mock("$env/dynamic/private", () => ({
+	env: {
+		SERVER_CRYPTO_KEY: "aa".repeat(32),
+		SERVER_INIT_VECTOR: "bb".repeat(16),
+	},
+}));
+
+import crypto from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { validateCaptcha } from "./captcha";
+
+const encryptSecret = (text: string): string => {
+	const key = Buffer.from("aa".repeat(32), "hex");
+	const iv = Buffer.from("bb".repeat(16), "hex");
+	const cipher = crypto.createCipheriv("aes-256-cbc", key, iv);
+	let out = cipher.update(text, "utf8", "hex");
+	out += cipher.final("hex");
+	return out;
+};
+
+const caughtStatus = (fn: () => void): number | null => {
+	try {
+		fn();
+		return null;
+	} catch (e) {
+		return (e as { status: number }).status;
+	}
+};
+
+describe("validateCaptcha", () => {
+	it("accepts the matching answer", () => {
+		const secret = encryptSecret("ABC12");
+		expect(caughtStatus(() => validateCaptcha(secret, "ABC12"))).toBeNull();
+	});
+
+	it("rejects a wrong answer with 400", () => {
+		const secret = encryptSecret("ABC13");
+		expect(caughtStatus(() => validateCaptcha(secret, "nope"))).toBe(400);
+	});
+
+	it("rejects a reused secret with 400", () => {
+		const secret = encryptSecret("ABC14");
+		expect(caughtStatus(() => validateCaptcha(secret, "ABC14"))).toBeNull();
+		expect(caughtStatus(() => validateCaptcha(secret, "ABC14"))).toBe(400);
+	});
+});

--- a/src/lib/server/captcha.ts
+++ b/src/lib/server/captcha.ts
@@ -43,6 +43,17 @@ export function validateCaptcha(
 	const initVector = Buffer.from(env.SERVER_INIT_VECTOR, "hex");
 	const serverKey = Buffer.from(env.SERVER_CRYPTO_KEY, "hex");
 
+	// Buffer.from(..., "hex") silently truncates at the first invalid
+	// character, so a typo'd key/IV surfaces here as a wrong length. That
+	// is server misconfiguration (503) — it must not fall into the decrypt
+	// catch below, which reports user-supplied garbage as a captcha 400.
+	if (serverKey.length !== 32 || initVector.length !== 16) {
+		console.error(
+			"[captcha] SERVER_CRYPTO_KEY/SERVER_INIT_VECTOR malformed (wrong length after hex decode)",
+		);
+		error(503, "Service unavailable");
+	}
+
 	const algorithm = "aes-256-cbc" as string;
 	const key = serverKey as unknown as CipherKey;
 	const iv = initVector as unknown as BinaryLike;

--- a/src/lib/server/captcha.ts
+++ b/src/lib/server/captcha.ts
@@ -46,10 +46,18 @@ export function validateCaptcha(
 	const algorithm = "aes-256-cbc" as string;
 	const key = serverKey as unknown as CipherKey;
 	const iv = initVector as unknown as BinaryLike;
-	const decrypt = crypto.createDecipheriv(algorithm, key, iv);
 
-	let secret = decrypt.update(captchaSecret, "hex", "utf8");
-	secret += decrypt.final("utf8");
+	let secret = "";
+	try {
+		const decrypt = crypto.createDecipheriv(algorithm, key, iv);
+		secret = decrypt.update(captchaSecret, "hex", "utf8");
+		secret += decrypt.final("utf8");
+	} catch {
+		// Garbage ciphertext (bots probing with a hand-crafted secret) must
+		// fail like a wrong answer, not surface as an unhandled 500 —
+		// decrypt.final() throws on invalid hex or bad padding.
+		error(400, "Captcha test failed, please try again or contact BTC Map.");
+	}
 
 	if (captchaTest !== secret) {
 		error(400, "Captcha test failed, please try again or contact BTC Map.");

--- a/src/lib/server/captcha.ts
+++ b/src/lib/server/captcha.ts
@@ -1,0 +1,63 @@
+import type { BinaryLike, CipherKey } from "node:crypto";
+import crypto from "node:crypto";
+import { error } from "@sveltejs/kit";
+
+import { env } from "$env/dynamic/private";
+
+// TTL-based cache for used captcha secrets to prevent memory leaks
+const CAPTCHA_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const usedCaptchas = new Map<string, number>();
+
+function addUsedCaptcha(secret: string): void {
+	usedCaptchas.set(secret, Date.now());
+	// Clean up expired entries periodically
+	if (usedCaptchas.size > 100) {
+		const now = Date.now();
+		for (const [key, timestamp] of usedCaptchas) {
+			if (now - timestamp > CAPTCHA_TTL_MS) {
+				usedCaptchas.delete(key);
+			}
+		}
+	}
+}
+
+function isCaptchaUsed(secret: string): boolean {
+	const timestamp = usedCaptchas.get(secret);
+	if (!timestamp) return false;
+	// Check if expired
+	if (Date.now() - timestamp > CAPTCHA_TTL_MS) {
+		usedCaptchas.delete(secret);
+		return false;
+	}
+	return true;
+}
+
+export function validateCaptcha(
+	captchaSecret: string,
+	captchaTest: string,
+): void {
+	if (!env.SERVER_CRYPTO_KEY || !env.SERVER_INIT_VECTOR) {
+		error(503, "Service unavailable");
+	}
+
+	const initVector = Buffer.from(env.SERVER_INIT_VECTOR, "hex");
+	const serverKey = Buffer.from(env.SERVER_CRYPTO_KEY, "hex");
+
+	const algorithm = "aes-256-cbc" as string;
+	const key = serverKey as unknown as CipherKey;
+	const iv = initVector as unknown as BinaryLike;
+	const decrypt = crypto.createDecipheriv(algorithm, key, iv);
+
+	let secret = decrypt.update(captchaSecret, "hex", "utf8");
+	secret += decrypt.final("utf8");
+
+	if (captchaTest !== secret) {
+		error(400, "Captcha test failed, please try again or contact BTC Map.");
+	}
+
+	if (isCaptchaUsed(captchaSecret)) {
+		error(400, "Captcha has already been used, please try another.");
+	} else {
+		addUsedCaptcha(captchaSecret);
+	}
+}

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -248,7 +248,6 @@ let noLocationSelected = false;
 let noMethodSelected = false;
 let submitted = false;
 let submitting = false;
-let submissionIssueNumber: number;
 
 const handleCheckboxClick = () => {
 	noMethodSelected = false;
@@ -286,6 +285,11 @@ const submitForm = (event: SubmitEvent) => {
 		noMethodSelected = true;
 		errToast(get(_)("errors.noPaymentMethod"));
 	} else {
+		if (lat === undefined || long === undefined) {
+			noLocationSelected = true;
+			errToast(get(_)("errors.noLocationSelected"));
+			return;
+		}
 		submitting = true;
 		if (onchain.checked) {
 			methods.push("onchain");
@@ -298,22 +302,17 @@ const submitForm = (event: SubmitEvent) => {
 		}
 
 		axios
-			.post("/api/gitea/issue", {
-				type: "add-location",
+			.post("/api/submit-place", {
 				captchaSecret,
 				captchaTest: captchaInput.value,
 				honey: honeyInput.value,
 				name: name.value,
 				nameEn: nameEn.value,
 				address: address.value,
-				lat: lat !== undefined ? lat.toString() : "",
-				long: long !== undefined ? long.toString() : "",
-				osm:
-					lat !== undefined && long !== undefined
-						? `https://www.openstreetmap.org/edit#map=21/${lat}/${long}`
-						: "",
+				lat,
+				long,
 				category: category.value,
-				methods: methods.toString(),
+				methods,
 				website: website.value,
 				phone: phone.value,
 				hours: hours.value,
@@ -322,13 +321,12 @@ const submitForm = (event: SubmitEvent) => {
 				sourceOther: sourceOther ? sourceOther : "",
 				contact: contact.value,
 			})
-			.then((response) => {
-				submissionIssueNumber = response.data.number;
+			.then(() => {
 				submitted = true;
 			})
 			.catch((error) => {
 				methods = [];
-				if (error.response.data.message.includes("Captcha")) {
+				if (error.response?.data?.message?.includes("Captcha")) {
 					errToast(error.response.data.message);
 				} else {
 					errToast(get(_)("errors.formSubmission"));
@@ -896,7 +894,7 @@ $: if (map && mapLoaded) {
 	<FormSuccess
 		type={$_('addLocation.formSuccessType')}
 		text={$_('addLocation.formSuccessText')}
-		issue={submissionIssueNumber}
+		showIssueLink={false}
 		on:click={resetForm}
 	/>
 {/if}

--- a/src/routes/api/gitea/issue/+server.ts
+++ b/src/routes/api/gitea/issue/+server.ts
@@ -1,43 +1,13 @@
-import type { BinaryLike, CipherKey } from "node:crypto";
-import crypto from "node:crypto";
 import { error } from "@sveltejs/kit";
 import { get } from "svelte/store";
 
 import { GITEA_LABELS } from "$lib/constants";
 import { createIssueWithLabels, type GiteaRepo } from "$lib/gitea";
+import { validateCaptcha } from "$lib/server/captcha";
 import { areas } from "$lib/store";
 import { getAreaIdsByCoordinates } from "$lib/utils";
 
 import type { RequestHandler } from "./$types";
-import { env } from "$env/dynamic/private";
-
-// TTL-based cache for used captcha secrets to prevent memory leaks
-const CAPTCHA_TTL_MS = 10 * 60 * 1000; // 10 minutes
-const usedCaptchas = new Map<string, number>();
-
-function addUsedCaptcha(secret: string): void {
-	usedCaptchas.set(secret, Date.now());
-	// Clean up expired entries periodically
-	if (usedCaptchas.size > 100) {
-		const now = Date.now();
-		for (const [key, timestamp] of usedCaptchas) {
-			if (now - timestamp > CAPTCHA_TTL_MS) {
-				usedCaptchas.delete(key);
-			}
-		}
-	}
-}
-
-function isCaptchaUsed(secret: string): boolean {
-	const timestamp = usedCaptchas.get(secret);
-	if (!timestamp) return false;
-	// Check if expired
-	if (Date.now() - timestamp > CAPTCHA_TTL_MS) {
-		usedCaptchas.delete(secret);
-		return false;
-	}
-	return true;
-}
 
 type IssueConfig = {
 	repo: GiteaRepo;
@@ -77,33 +47,6 @@ type IssueType = keyof typeof CONFIG;
 
 function isValidIssueType(type: unknown): type is IssueType {
 	return typeof type === "string" && type in CONFIG;
-}
-
-function validateCaptcha(captchaSecret: string, captchaTest: string): void {
-	if (!env.SERVER_CRYPTO_KEY || !env.SERVER_INIT_VECTOR) {
-		error(503, "Service unavailable");
-	}
-
-	const initVector = Buffer.from(env.SERVER_INIT_VECTOR, "hex");
-	const serverKey = Buffer.from(env.SERVER_CRYPTO_KEY, "hex");
-
-	const algorithm = "aes-256-cbc" as string;
-	const key = serverKey as unknown as CipherKey;
-	const iv = initVector as unknown as BinaryLike;
-	const decrypt = crypto.createDecipheriv(algorithm, key, iv);
-
-	let secret = decrypt.update(captchaSecret, "hex", "utf8");
-	secret += decrypt.final("utf8");
-
-	if (captchaTest !== secret) {
-		error(400, "Captcha test failed, please try again or contact BTC Map.");
-	}
-
-	if (isCaptchaUsed(captchaSecret)) {
-		error(400, "Captcha has already been used, please try another.");
-	} else {
-		addUsedCaptcha(captchaSecret);
-	}
 }
 
 async function getAreaLabelsFromCoordinates(

--- a/src/routes/api/gitea/issue/+server.ts
+++ b/src/routes/api/gitea/issue/+server.ts
@@ -16,11 +16,6 @@ type IssueConfig = {
 };
 
 const CONFIG = {
-	"add-location": {
-		repo: "btcmap-data",
-		labelId: GITEA_LABELS.DATA.ADD_LOCATION,
-		hasAreaLabels: true,
-	},
 	"verify-location": {
 		repo: "btcmap-data",
 		labelId: GITEA_LABELS.DATA.VERIFY_LOCATION,
@@ -79,27 +74,6 @@ function generateBody(
 	const taggingInstructions = `If you are a new contributor please read our Tagging Instructions [here](https://wiki.btcmap.org/Tagging-Merchants).`;
 
 	switch (type) {
-		case "add-location":
-			return `Merchant name: ${data.name}
-English name (name:en): ${data.nameEn || ""}
-Address: ${data.address}
-Lat: ${data.lat}
-Long: ${data.long}
-Associated areas: ${areasText}
-OSM: ${data.osm}
-Category: ${data.category}
-Payment methods: ${data.methods}
-Website: ${data.website}
-Phone: ${data.phone}
-Opening hours: ${data.hours}
-Notes: ${data.notes}
-Data Source: ${data.source}
-Details (if applicable): ${data.sourceOther}
-Contact: ${data.contact}
-Created at: ${timestamp}
-
-${taggingInstructions}`;
-
 		case "verify-location":
 			return `Merchant name: ${data.name}
 Merchant location: ${data.location}

--- a/src/routes/api/submit-place/+server.ts
+++ b/src/routes/api/submit-place/+server.ts
@@ -81,11 +81,13 @@ export const POST: RequestHandler = async ({ request }) => {
 				params,
 			}),
 		});
-	} catch {
+	} catch (e) {
+		console.error("[submit-place] RPC fetch failed", e);
 		error(502, "Could not submit the location, please try again later.");
 	}
 
 	let rpcBody;
+	let errorBody = "";
 	if (response.ok) {
 		try {
 			rpcBody = await response.json();
@@ -93,6 +95,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			error(502, "Could not submit the location, please try again later.");
 		}
 	} else {
+		errorBody = await response.text().catch(() => "");
 		rpcBody = null;
 	}
 
@@ -101,6 +104,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			"[submit-place] RPC failure",
 			response.status,
 			rpcBody?.error,
+			errorBody ? errorBody.slice(0, 500) : undefined,
 		);
 		error(502, "Could not submit the location, please try again later.");
 	}

--- a/src/routes/api/submit-place/+server.ts
+++ b/src/routes/api/submit-place/+server.ts
@@ -1,0 +1,85 @@
+import { error, json } from "@sveltejs/kit";
+
+import type { AddLocationSubmission } from "$lib/placeSubmission";
+import { buildSubmitPlaceParams } from "$lib/placeSubmission";
+import { validateCaptcha } from "$lib/server/captcha";
+import { isValidLatitude, isValidLongitude } from "$lib/utils";
+
+import type { RequestHandler } from "./$types";
+import { env } from "$env/dynamic/private";
+
+const str = (value: unknown): string =>
+	typeof value === "string" ? value : "";
+
+export const POST: RequestHandler = async ({ request }) => {
+	const body = await request.json();
+
+	if (body.honey) {
+		error(418);
+	}
+
+	validateCaptcha(str(body.captchaSecret), str(body.captchaTest));
+
+	// The submit token is server-held (Netlify env var); without it the
+	// pipeline cannot work, so fail loudly rather than dropping submissions.
+	if (!env.BTCMAP_API_TOKEN) {
+		console.error("[submit-place] BTCMAP_API_TOKEN is not configured");
+		error(503, "Service unavailable");
+	}
+
+	const name = str(body.name).trim();
+	const category = str(body.category).trim();
+	const lat = Number(body.lat);
+	const long = Number(body.long);
+	if (!name) error(400, "Name is required");
+	if (!category) error(400, "Category is required");
+	if (!isValidLatitude(lat) || !isValidLongitude(long)) {
+		error(400, "Invalid coordinates");
+	}
+
+	const submission: AddLocationSubmission = {
+		name,
+		nameEn: str(body.nameEn),
+		address: str(body.address),
+		lat,
+		long,
+		category,
+		methods: Array.isArray(body.methods) ? body.methods.map(str) : [],
+		website: str(body.website),
+		phone: str(body.phone),
+		hours: str(body.hours),
+		notes: str(body.notes),
+		source: str(body.source),
+		sourceOther: str(body.sourceOther),
+		contact: str(body.contact),
+	};
+
+	const params = buildSubmitPlaceParams(submission, crypto.randomUUID());
+	const rpcUrl = env.BTCMAP_API_RPC_URL || "https://api.btcmap.org/rpc";
+
+	const response = await fetch(rpcUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${env.BTCMAP_API_TOKEN}`,
+		},
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: params.external_id,
+			method: "submit_place",
+			params,
+		}),
+	});
+
+	const rpcBody = response.ok ? await response.json() : null;
+	if (!rpcBody || rpcBody.error || !rpcBody.result) {
+		console.error(
+			"[submit-place] RPC failure",
+			response.status,
+			rpcBody?.error,
+		);
+		error(502, "Could not submit the location, please try again later.");
+	}
+
+	return json({ id: rpcBody.result.id });
+};

--- a/src/routes/api/submit-place/+server.ts
+++ b/src/routes/api/submit-place/+server.ts
@@ -9,10 +9,13 @@ import { isValidLatitude, isValidLongitude } from "$lib/utils";
 import type { RequestHandler } from "./$types";
 import { env } from "$env/dynamic/private";
 
-const str = (value: unknown): string =>
+// Coerces non-strings to "" — for the optional free-text fields only.
+const asString = (value: unknown): string =>
 	typeof value === "string" ? value : "";
 
-export const POST: RequestHandler = async ({ request }) => {
+// Event fetch (not global) so a relative API_BASE like /btcmap-api-proxy
+// resolves server-side — same pattern as the other api/ routes.
+export const POST: RequestHandler = async ({ request, fetch }) => {
 	let body;
 	try {
 		body = await request.json();
@@ -28,7 +31,7 @@ export const POST: RequestHandler = async ({ request }) => {
 		error(418);
 	}
 
-	validateCaptcha(str(body.captchaSecret), str(body.captchaTest));
+	validateCaptcha(asString(body.captchaSecret), asString(body.captchaTest));
 
 	// The submit token is server-held (Netlify env var); without it the
 	// pipeline cannot work, so fail loudly rather than dropping submissions.
@@ -37,41 +40,46 @@ export const POST: RequestHandler = async ({ request }) => {
 		error(503, "Service unavailable");
 	}
 
-	const name = str(body.name).trim();
-	const category = str(body.category).trim();
-	const lat = Number(body.lat);
-	const long = Number(body.long);
+	const name = asString(body.name).trim();
+	const category = asString(body.category).trim();
+	// Strict number check: Number(null) and Number("") are 0, which would
+	// silently turn a null-ish coordinate into a valid-looking Null Island
+	// submission instead of a 400.
+	const lat: unknown = body.lat;
+	const long: unknown = body.long;
 	if (!name) error(400, "Name is required");
 	if (!category) error(400, "Category is required");
-	if (!isValidLatitude(lat) || !isValidLongitude(long)) {
+	if (
+		typeof lat !== "number" ||
+		typeof long !== "number" ||
+		!isValidLatitude(lat) ||
+		!isValidLongitude(long)
+	) {
 		error(400, "Invalid coordinates");
 	}
 
 	const submission: AddLocationSubmission = {
 		name,
-		nameEn: str(body.nameEn),
-		address: str(body.address),
+		nameEn: asString(body.nameEn),
+		address: asString(body.address),
 		lat,
 		long,
 		category,
-		methods: Array.isArray(body.methods) ? body.methods.map(str) : [],
-		website: str(body.website),
-		phone: str(body.phone),
-		hours: str(body.hours),
-		notes: str(body.notes),
-		source: str(body.source),
-		sourceOther: str(body.sourceOther),
-		contact: str(body.contact),
+		methods: Array.isArray(body.methods) ? body.methods.map(asString) : [],
+		website: asString(body.website),
+		phone: asString(body.phone),
+		hours: asString(body.hours),
+		notes: asString(body.notes),
+		source: asString(body.source),
+		sourceOther: asString(body.sourceOther),
+		contact: asString(body.contact),
 	};
 
 	const params = buildSubmitPlaceParams(submission, crypto.randomUUID());
-	// BTCMAP_API_RPC_URL stays the explicit override: API_BASE can be a
-	// relative dev-proxy path, which a server-side fetch cannot resolve.
-	const rpcUrl = env.BTCMAP_API_RPC_URL || `${API_BASE}/rpc`;
 
 	let response;
 	try {
-		response = await fetch(rpcUrl, {
+		response = await fetch(`${API_BASE}/rpc`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",

--- a/src/routes/api/submit-place/+server.ts
+++ b/src/routes/api/submit-place/+server.ts
@@ -1,5 +1,6 @@
 import { error, json } from "@sveltejs/kit";
 
+import { API_BASE } from "$lib/api-base";
 import type { AddLocationSubmission } from "$lib/placeSubmission";
 import { buildSubmitPlaceParams } from "$lib/placeSubmission";
 import { validateCaptcha } from "$lib/server/captcha";
@@ -64,7 +65,9 @@ export const POST: RequestHandler = async ({ request }) => {
 	};
 
 	const params = buildSubmitPlaceParams(submission, crypto.randomUUID());
-	const rpcUrl = env.BTCMAP_API_RPC_URL || "https://api.btcmap.org/rpc";
+	// BTCMAP_API_RPC_URL stays the explicit override: API_BASE can be a
+	// relative dev-proxy path, which a server-side fetch cannot resolve.
+	const rpcUrl = env.BTCMAP_API_RPC_URL || `${API_BASE}/rpc`;
 
 	let response;
 	try {
@@ -80,6 +83,9 @@ export const POST: RequestHandler = async ({ request }) => {
 				method: "submit_place",
 				params,
 			}),
+			// Abort before Netlify's ~10s function kill so a hung upstream
+			// surfaces as our logged 502, not an opaque platform timeout.
+			signal: AbortSignal.timeout(8_000),
 		});
 	} catch (e) {
 		console.error("[submit-place] RPC fetch failed", e);

--- a/src/routes/api/submit-place/+server.ts
+++ b/src/routes/api/submit-place/+server.ts
@@ -12,7 +12,16 @@ const str = (value: unknown): string =>
 	typeof value === "string" ? value : "";
 
 export const POST: RequestHandler = async ({ request }) => {
-	const body = await request.json();
+	let body;
+	try {
+		body = await request.json();
+	} catch {
+		error(400, "Invalid request body");
+	}
+
+	if (!body || typeof body !== "object") {
+		error(400, "Invalid request body");
+	}
 
 	if (body.honey) {
 		error(418);
@@ -57,21 +66,36 @@ export const POST: RequestHandler = async ({ request }) => {
 	const params = buildSubmitPlaceParams(submission, crypto.randomUUID());
 	const rpcUrl = env.BTCMAP_API_RPC_URL || "https://api.btcmap.org/rpc";
 
-	const response = await fetch(rpcUrl, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Authorization: `Bearer ${env.BTCMAP_API_TOKEN}`,
-		},
-		body: JSON.stringify({
-			jsonrpc: "2.0",
-			id: params.external_id,
-			method: "submit_place",
-			params,
-		}),
-	});
+	let response;
+	try {
+		response = await fetch(rpcUrl, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Authorization: `Bearer ${env.BTCMAP_API_TOKEN}`,
+			},
+			body: JSON.stringify({
+				jsonrpc: "2.0",
+				id: params.external_id,
+				method: "submit_place",
+				params,
+			}),
+		});
+	} catch {
+		error(502, "Could not submit the location, please try again later.");
+	}
 
-	const rpcBody = response.ok ? await response.json() : null;
+	let rpcBody;
+	if (response.ok) {
+		try {
+			rpcBody = await response.json();
+		} catch {
+			error(502, "Could not submit the location, please try again later.");
+		}
+	} else {
+		rpcBody = null;
+	}
+
 	if (!rpcBody || rpcBody.error || !rpcBody.result) {
 		console.error(
 			"[submit-place] RPC failure",

--- a/src/routes/api/submit-place/+server.ts
+++ b/src/routes/api/submit-place/+server.ts
@@ -31,8 +31,8 @@ export const POST: RequestHandler = async ({ request }) => {
 
 	// The submit token is server-held (Netlify env var); without it the
 	// pipeline cannot work, so fail loudly rather than dropping submissions.
-	if (!env.BTCMAP_API_TOKEN) {
-		console.error("[submit-place] BTCMAP_API_TOKEN is not configured");
+	if (!env.BTCMAP_IMPORT_TOKEN) {
+		console.error("[submit-place] BTCMAP_IMPORT_TOKEN is not configured");
 		error(503, "Service unavailable");
 	}
 
@@ -72,7 +72,7 @@ export const POST: RequestHandler = async ({ request }) => {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				Authorization: `Bearer ${env.BTCMAP_API_TOKEN}`,
+				Authorization: `Bearer ${env.BTCMAP_IMPORT_TOKEN}`,
 			},
 			body: JSON.stringify({
 				jsonrpc: "2.0",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
 		alias: {
 			$lib: path.resolve('./src/lib'),
 			$components: path.resolve('./src/components'),
-			$app: path.resolve('./node_modules/@sveltejs/kit/src/runtime/app')
+			$app: path.resolve('./node_modules/@sveltejs/kit/src/runtime/app'),
+			$env: path.resolve('./node_modules/@sveltejs/kit/src/runtime/env')
 		}
 	}
 });


### PR DESCRIPTION
Part of #1134. Implements the team-chat decision: the website becomes a properly registered import source instead of writing Gitea issues itself.

## What changed

- **New `/api/submit-place` server endpoint**: validates honeypot + captcha (same gates as before), then forwards the submission to btcmap-api's `submit_place` RPC as origin `"btcmap-website"` with a server-held Bearer token (`BTCMAP_IMPORT_TOKEN`, Netlify env var — never shipped to the browser). Network failures, malformed bodies, and upstream errors map to clean 400/502/503 responses, with diagnostic logging for rollout triage.
- **Pure, unit-tested mapper** (`$lib/placeSubmission`): four first-class fields (`name`, `category`, `lat`, `lon` — renamed from the form's `long`) + everything else in `extra_fields`; empty optionals dropped; zero coordinates preserved. `external_id` is a fresh UUID per submission.
- **Captcha validation extracted** to a shared `$lib/server/captcha.ts` (with round-trip unit tests) used by both the new endpoint and the Gitea endpoint.
- **The add-location form** now posts to the new endpoint; the success screen no longer links a Gitea issue (issues are created API-side by `sync_submitted_places`).
- **Gitea endpoint**: only the `add-location` branch removed — `verify-location`, `community`, `verify-community`, and `tagger-onboarding` keep their existing flow. One shared-module improvement does reach them: garbage captcha ciphertext now returns 400 instead of an unhandled 500 (the hardening lives in the extracted captcha module all five forms share).
- Env var documented in `.env.example` and README (`BTCMAP_IMPORT_TOKEN`). The RPC target follows the shared `API_BASE` via SvelteKit's event fetch, so local API dev uses `VITE_API_BASE_URL` like every other call.

## ✅ Rollout gate — cleared, verified in production

1. ~~Origin + token~~ — DONE: origin `btcmap-website` registered with sync enabled on setup; token scoped.
2. ~~End-to-end test~~ — DONE: test submission id 18122 flowed all the way to Gitea ticket btcmap-data#24296 (labels `import/website` + `type/location-submission`, extra_fields rendered, Matrix message fires on creation per sync code). Ticket closed as cleanup; the close syncs back and marks the submission closed — reverse direction verified too.
3. ~~Token in Netlify~~ — DONE (`BTCMAP_IMPORT_TOKEN`, all deploy contexts).

## Notes for the API side

- **Associated areas**: the old Gitea flow attached area labels computed website-side; this flow intentionally doesn't — the API owns the area polygons and can derive them from lat/lon in `sync_submitted_places`.
- **Matrix notification / privacy policy**: our privacy policy says an issue is created and a Matrix message fires per submission. Please confirm the Matrix hook survives the `sync_submitted_places` path — if not, we'll revisit the policy wording.
- **Abuse surface**: every captcha-passing submission is now an authenticated RPC write creating an API DB row (fresh UUID per attempt, so retries aren't deduped). Roughly equivalent to the old Gitea-issue spam surface, but it lands in the API database — flagging in case rate limiting is wanted there.

## Deliberate deviation

`src/routes/add-location/+page.svelte` received a meaningful edit but was **not** converted to runes (CLAUDE.md boy-scout rule): it's a ~900-line legacy page with map lifecycle code — hotspot-grade conversion work that would bloat this PR. Proposing to add it to the #1208 deliberate-hand-conversion list instead.

## Verification

Full checklist green (svelte-check, typecheck, lint, 680 unit tests — 7 new: captcha round-trip/reuse, mapper field/rename/zero-coord cases). Full Playwright suite green (two unrelated live-API specs flaked under parallel load, pass in isolation). Live submit against the production RPC is pending the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjZ7qPmjDm85vTn9MbS2uS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Add-location submissions now use a dedicated API endpoint and are forwarded to BTCMap.
  * Added server-side CAPTCHA validation with protection against reused challenges.
  * Improved validation for required coordinates and submission fields.

* **Documentation**
  * Updated local API setup instructions and configuration requirements.
  * Renamed the BTCMap import token setting and removed the optional API URL setting.

* **Tests**
  * Added coverage for place submission mapping and CAPTCHA validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




