### PR TITLE
feat(merchant): link comment dates to per-comment permalinks

### DIFF
--- a/src/lib/commentPermalink.test.ts
+++ b/src/lib/commentPermalink.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { commentAnchorFromHash, commentDomId } from "./commentPermalink";
+
+describe("commentDomId", () => {
+	it("builds the DOM id for a comment", () => {
+		expect(commentDomId(123)).toBe("comment-123");
+	});
+});
+
+describe("commentAnchorFromHash", () => {
+	it("parses a comment permalink hash into its DOM id", () => {
+		expect(commentAnchorFromHash("#comment-123")).toBe("comment-123");
+	});
+
+	it("round-trips an id built by commentDomId", () => {
+		expect(commentAnchorFromHash(`#${commentDomId(42)}`)).toBe(
+			commentDomId(42),
+		);
+	});
+
+	it("ignores the existing #comments tab deep-link", () => {
+		expect(commentAnchorFromHash("#comments")).toBeNull();
+	});
+
+	it("ignores an empty hash", () => {
+		expect(commentAnchorFromHash("")).toBeNull();
+	});
+
+	it("ignores a bare #comment- prefix without an id", () => {
+		expect(commentAnchorFromHash("#comment-")).toBeNull();
+	});
+
+	it("ignores non-numeric ids", () => {
+		expect(commentAnchorFromHash("#comment-12abc")).toBeNull();
+		expect(commentAnchorFromHash("#comment-abc")).toBeNull();
+	});
+
+	it("ignores unrelated hashes", () => {
+		expect(commentAnchorFromHash("#panel-activity")).toBeNull();
+	});
+
+	it("requires the pattern to span the whole hash", () => {
+		// pins the regex's left anchor: a valid-looking suffix is not enough
+		expect(commentAnchorFromHash("##comment-1")).toBeNull();
+	});
+
+	it("is case-sensitive", () => {
+		expect(commentAnchorFromHash("#Comment-1")).toBeNull();
+	});
+});

--- a/src/lib/commentPermalink.ts
+++ b/src/lib/commentPermalink.ts
@@ -1,0 +1,12 @@
+// Per-comment permalinks on the merchant page: the date on each comment links
+// to #comment-<id>, and arriving with that hash scrolls the comment into view
+// (the i18n loading gate renders content after load, so the browser's native
+// anchor scroll misses on a fresh page load).
+
+export const commentDomId = (id: number): string => `comment-${id}`;
+
+// Parse a location.hash into the comment DOM id it targets. Anything that is
+// not exactly #comment-<digits> is a miss — notably the existing #comments
+// tab deep-link from the map drawer.
+export const commentAnchorFromHash = (hash: string): string | null =>
+	/^#comment-\d+$/.test(hash) ? hash.slice(1) : null;

--- a/src/routes/merchant/[id]/+page.svelte
+++ b/src/routes/merchant/[id]/+page.svelte
@@ -11,6 +11,7 @@ import OpenStatusPill from "$components/OpenStatusPill.svelte";
 import PaymentMethodPills from "$components/PaymentMethodPills.svelte";
 import ShowTags from "$components/ShowTags.svelte";
 import TaggingIssues from "$components/TaggingIssues.svelte";
+import { commentAnchorFromHash, commentDomId } from "$lib/commentPermalink";
 import { _, getDisplayLang, locale } from "$lib/i18n";
 import { boost, placesById, resetBoost } from "$lib/store";
 import type { MerchantActivityEvent, MerchantPageData } from "$lib/types";
@@ -25,6 +26,7 @@ import MerchantHero from "./components/MerchantHero.svelte";
 import MerchantTabs from "./components/MerchantTabs.svelte";
 import MerchantVerifyRow from "./components/MerchantVerifyRow.svelte";
 import { browser } from "$app/environment";
+import { page } from "$app/stores";
 
 // Server data is consumed directly; only the fields the page itself renders
 // (hero, payment indicator, action chips, activity) are mirrored here.
@@ -103,7 +105,20 @@ const handleBoost = () => {
 let eventCount = 50;
 $: eventsPaginated = merchantEvents.slice(0, eventCount);
 
+// Which comment the current #comment-<id> permalink targets. Read the hash
+// from $page.url, not window.location: Kit updates the store inside its
+// link click handler before the browser applies the fragment navigation,
+// so the window value can be one hash behind at that point.
+$: targetCommentAnchor = commentAnchorFromHash($page.url.hash);
+
 onMount(async () => {
+	// A shared permalink misses the browser's native anchor scroll because
+	// the page body renders after the i18n loading gate; land on the comment
+	// once it is in the DOM.
+	if (targetCommentAnchor) {
+		document.getElementById(targetCommentAnchor)?.scrollIntoView();
+	}
+
 	if (browser) {
 		// Refresh localforage so the main map / saved lists reflect current data.
 		try {
@@ -217,7 +232,13 @@ const ogImage = `https://api.btcmap.org/og/element/${data.id}`;
 					{#if comments && comments.length}
 						<div class="divide-y divide-gray-200 dark:divide-white/10">
 							{#each [...comments].reverse() as comment (comment.id)}
-								<MerchantComment text={comment.text} time={comment['created_at']} compact />
+								<MerchantComment
+									commentId={comment.id}
+									text={comment.text}
+									time={comment['created_at']}
+									highlighted={targetCommentAnchor === commentDomId(comment.id)}
+									compact
+								/>
 							{/each}
 						</div>
 					{:else}

--- a/src/routes/merchant/[id]/components/MerchantComment.svelte
+++ b/src/routes/merchant/[id]/components/MerchantComment.svelte
@@ -1,18 +1,34 @@
 <script lang="ts">
 import Time from "svelte-time";
 
+import { commentDomId } from "$lib/commentPermalink";
 import type { MerchantPageData } from "$lib/types";
 
 type Props = {
+	commentId: MerchantPageData["comments"][number]["id"];
 	text: MerchantPageData["comments"][number]["text"];
 	time: MerchantPageData["comments"][number]["created_at"];
 	compact?: boolean;
+	// Driven by the page from the current #comment-<id> hash. CSS :target
+	// can't do this: on a fresh load the comment renders after the i18n
+	// gate, long after the browser gave up finding the fragment target.
+	highlighted?: boolean;
 };
 
-let { text, time, compact = false }: Props = $props();
+let {
+	commentId,
+	text,
+	time,
+	compact = false,
+	highlighted = false,
+}: Props = $props();
 </script>
 
 <div
+	id={commentDomId(commentId)}
+	class="scroll-mt-24 transition-colors {highlighted
+		? 'bg-link/10 dark:bg-link/15'
+		: ''}"
 	class:items-center={!compact}
 	class:items-start={compact}
 	class:space-y-2={!compact}
@@ -50,7 +66,9 @@ let { text, time, compact = false }: Props = $props();
 				class:text-center={!compact}
 				class:lg:inline={!compact}
 			>
-				<Time timestamp={time} />
+				<a href="#{commentDomId(commentId)}" class="hover:underline">
+					<Time timestamp={time} />
+				</a>
 			</span>
 		</div>
 	</div>

--- a/src/routes/merchant/[id]/components/MerchantComment.svelte
+++ b/src/routes/merchant/[id]/components/MerchantComment.svelte
@@ -3,9 +3,13 @@ import Time from "svelte-time";
 
 import type { MerchantPageData } from "$lib/types";
 
-export let text: MerchantPageData["comments"][number]["text"];
-export let time: MerchantPageData["comments"][number]["created_at"];
-export let compact = false;
+type Props = {
+	text: MerchantPageData["comments"][number]["text"];
+	time: MerchantPageData["comments"][number]["created_at"];
+	compact?: boolean;
+};
+
+let { text, time, compact = false }: Props = $props();
 </script>
 
 <div

--- a/tests/merchant-comment-permalink.spec.ts
+++ b/tests/merchant-comment-permalink.spec.ts
@@ -1,0 +1,86 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+import { checkForConsoleErrors, setupConsoleErrorCollection } from './helpers';
+
+// Known merchant with a long-standing comment history — "Maia" coffee shop,
+// 9 comments, the oldest from 2024.
+// WARNING: These tests depend on merchant ID 1128 keeping at least two
+// comments in the API (asserted loudly below). If it gets purged, swap in
+// another merchant with a stable comment history.
+const COMMENTED_MERCHANT_ID = 1128;
+
+// Wait for the comment list, then require >=2 comments so the
+// non-target/negative assertions below actually prove something.
+async function commentDateLinks(page: Page) {
+	const dateLinks = page.locator('a[href^="#comment-"]');
+	await expect(dateLinks.first()).toBeVisible();
+	expect(await dateLinks.count()).toBeGreaterThan(1);
+	return dateLinks;
+}
+
+test.describe('Merchant comment permalinks', () => {
+	test.beforeEach(async ({ page }) => {
+		setupConsoleErrorCollection(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		checkForConsoleErrors(page);
+	});
+
+	test('comment dates link to matching per-comment anchors', async ({ page }) => {
+		await page.goto(`/merchant/${COMMENTED_MERCHANT_ID}`);
+
+		const dateLink = (await commentDateLinks(page)).first();
+		const href = await dateLink.getAttribute('href');
+		expect(href).toMatch(/^#comment-\d+$/);
+
+		const anchorId = href?.slice(1) ?? '';
+		await expect(page.locator(`[id="${anchorId}"]`)).toHaveCount(1);
+		// ...and the link really sits inside the container carrying that id
+		expect(await dateLink.evaluate((el, id) => el.closest(`#${id}`) !== null, anchorId)).toBe(
+			true
+		);
+	});
+
+	test('clicking a date updates the URL and highlights only that comment', async ({ page }) => {
+		await page.goto(`/merchant/${COMMENTED_MERCHANT_ID}`);
+
+		const dateLinks = await commentDateLinks(page);
+		// Click the last comment's date; the first comment doubles as the
+		// non-target below, so a highlight-everything regression fails loudly
+		const firstHref = await dateLinks.first().getAttribute('href');
+		const dateLink = dateLinks.last();
+		const href = await dateLink.getAttribute('href');
+		await dateLink.click();
+
+		await expect.poll(() => new URL(page.url()).hash).toBe(href);
+		await expect(page.locator(`[id="${href?.slice(1)}"]`)).toHaveClass(/bg-link\/10/);
+		// Kit syncs the page store synchronously in its click handler, so the
+		// highlight state is settled once the URL check above has passed — a
+		// one-shot-free negative assertion is safe here
+		await expect(page.locator(`[id="${firstHref?.slice(1)}"]`)).not.toHaveClass(/bg-link\/10/);
+	});
+
+	test('opening a comment permalink scrolls to and highlights the comment', async ({ page }) => {
+		// Derive a permalink from the live page instead of hardcoding a comment id
+		await page.goto(`/merchant/${COMMENTED_MERCHANT_ID}`);
+		const dateLinks = await commentDateLinks(page);
+		const firstHref = await dateLinks.first().getAttribute('href');
+		const href = await dateLinks.last().getAttribute('href');
+		expect(href).toMatch(/^#comment-\d+$/);
+
+		// Leave the page first so the second goto is a fresh document load,
+		// not a same-page fragment navigation
+		await page.goto('about:blank');
+		await page.goto(`/merchant/${COMMENTED_MERCHANT_ID}${href}`);
+
+		// NOTE: this asserts the user-visible outcome. When hydration beats the
+		// window load event, Chrome's native pending-fragment scroll can land
+		// this even without the app's onMount fallback; the late-render path the
+		// fallback exists for is not deterministically exercised here.
+		const target = page.locator(`[id="${href?.slice(1)}"]`);
+		await expect(target).toBeInViewport();
+		await expect(target).toHaveClass(/bg-link\/10/);
+		await expect(page.locator(`[id="${firstHref?.slice(1)}"]`)).not.toHaveClass(/bg-link\/10/);
+	});
+});


### PR DESCRIPTION
## What

https://deploy-preview-1280--btcmap.netlify.app/merchant/12801#comment-2741

<img width="1688" height="833" alt="image" src="https://github.com/user-attachments/assets/3688fe30-014e-4aef-afa1-a50c2a0d46d9" />


On `/merchant/[id]`, each comment's date is now an anchor link to `#comment-<id>`. Clicking it puts a shareable permalink in the URL bar; opening such a permalink scrolls to the comment and highlights it with a subtle teal tint.

## Why the highlight is state-driven (not CSS `:target`)

- On a fresh page load the comment list renders only after the i18n loading gate opens — long after the browser has given up finding the fragment target — so native anchor scrolling and `:target` both miss. A small `onMount` fallback does the scroll, and the highlight derives from `$page.url.hash`.
- The hash is read from `$page.url`, not `window.location`: SvelteKit updates the page store inside its link click handler *before* the browser applies the fragment navigation, so the window value is one hash behind at that moment (verified against the installed Kit 2.69 client source).

## Changes

- `src/lib/commentPermalink.ts` — `commentDomId` + strict `#comment-<digits>` hash parser (the existing `#comments` tab deep-link stays a miss), written test-first with 10 unit tests
- `src/routes/merchant/[id]/components/MerchantComment.svelte` — date wrapped in the anchor, container carries the id, `scroll-mt-24` clears the sticky mobile header; converted to runes mode as its own commit per the boy-scout rule (#1208)
- `src/routes/merchant/[id]/+page.svelte` — targets the highlighted comment reactively, `onMount` scroll fallback (file stays legacy on purpose — #1208 hand-conversion list)
- `tests/merchant-comment-permalink.spec.ts` — Playwright spec against merchant 1128 ("Maia", 9 long-standing comments); derives permalinks from the page instead of hardcoding comment ids, and asserts only the targeted comment is highlighted

The map drawer's separate comment list is untouched; linking its dates to these permalinks would be an easy follow-up.

## Testing

- `format:fix`, `check`, `typecheck`, `lint`, `test --run` (684 unit tests) all green
- A 10-agent adversarial review pass ran over the branch; all confirmed findings (template indentation, e2e mutation-coverage gaps, regex anchor coverage) are fixed in this diff. Known residual: the fresh-load e2e asserts the user-visible outcome and doesn't deterministically exercise the late-render fallback path
- e2e runs in CI only (local Playwright env is broken on this machine); browser QA on the Netlify deploy preview is still advisable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permalink links to merchant comment timestamps.
  * Clicking a comment timestamp updates the URL and highlights that comment.
  * Opening a comment permalink automatically scrolls to and highlights the referenced comment.

* **Tests**
  * Added coverage for valid, invalid, and unrelated comment URL fragments.
  * Added end-to-end tests for comment linking, navigation, scrolling, and highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->