### PR TITLE
feat(add-location): slim details form — category picker, hidden coords, details expander

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -24,6 +24,14 @@ jobs:
           needs-env: 'true'
           needs-sync: 'true'
 
+      # .env.example ships empty captcha keys, which leaves /captcha broken
+      # and every captcha-gated form control permanently disabled — specs
+      # that interact with those controls need working (throwaway) keys.
+      - name: Generate captcha crypto keys
+        run: |
+          echo "SERVER_CRYPTO_KEY=$(openssl rand -hex 32)" >> .env
+          echo "SERVER_INIT_VECTOR=$(openssl rand -hex 16)" >> .env
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v6

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -9,6 +9,7 @@
 		"categoryPlaceholder": "Ресторант и т.н.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"contactDescription": "Ако имаме въпроси, ще се свържем с вас, за да добавим мястото успешно. Проверете папката „Спам“ ако писмото не е влязло в нея.",
 		"contactPlaceholder": "hello@btcmap.org",
 		"dataSourceCustomer": "Посетих като клиент",

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -10,6 +10,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"contactDescription": "Ако имаме въпроси, ще се свържем с вас, за да добавим мястото успешно. Проверете папката „Спам“ ако писмото не е влязло в нея.",
 		"contactPlaceholder": "hello@btcmap.org",
 		"dataSourceCustomer": "Посетих като клиент",

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -7,6 +7,8 @@
 		"businessOwner": "Ако сте собственик на бизнес, моля прочетете нашия",
 		"captchaPlaceholder": "Моля, въведете текста от captcha.",
 		"categoryPlaceholder": "Ресторант и т.н.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"contactDescription": "Ако имаме въпроси, ще се свържем с вас, за да добавим мястото успешно. Проверете папката „Спам“ ако писмото не е влязло в нея.",
 		"contactPlaceholder": "hello@btcmap.org",
 		"dataSourceCustomer": "Посетих като клиент",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -464,6 +464,8 @@
 		"addressTooltip": "Alle Standorte müssen eine physische Präsenz haben. Gib optional eine Adresse ein, wenn das für den Standort des Händlers sinnvoll ist. Dienste ohne Standorte können nicht auf der Karte angezeigt werden.",
 		"addressPlaceholder": "2100 Freedom Drive...",
 		"categoryPlaceholder": "Restaurant usw.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Akzeptierte Zahlungsmethoden auswählen",
 		"paymentMethodError": "Bitte korrigiere dies...",
 		"onchainLabel": "On-Chain",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -467,6 +467,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Akzeptierte Zahlungsmethoden auswählen",
 		"paymentMethodError": "Bitte korrigiere dies...",
 		"onchainLabel": "On-Chain",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -466,6 +466,7 @@
 		"categoryPlaceholder": "Restaurant usw.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Akzeptierte Zahlungsmethoden auswählen",
 		"paymentMethodError": "Bitte korrigiere dies...",
 		"onchainLabel": "On-Chain",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -562,6 +562,8 @@
 		"addressTooltip": "All locations are required to have a physical presence. Optionally enter an address here if that makes sense where the merchant is located. Services without locations are not map-able.",
 		"addressPlaceholder": "2100 Freedom Drive...",
 		"categoryPlaceholder": "Restaurant etc.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Select accepted payment methods",
 		"paymentMethodError": "Please fix this...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -564,6 +564,7 @@
 		"categoryPlaceholder": "Restaurant etc.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Select accepted payment methods",
 		"paymentMethodError": "Please fix this...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -565,6 +565,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Select accepted payment methods",
 		"paymentMethodError": "Please fix this...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -466,6 +466,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Selecciona los métodos de pago aceptados",
 		"paymentMethodError": "Por favor corrige esto...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -465,6 +465,7 @@
 		"categoryPlaceholder": "Restaurante, etc.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Selecciona los métodos de pago aceptados",
 		"paymentMethodError": "Por favor corrige esto...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -463,6 +463,8 @@
 		"addressTooltip": "Todas las ubicaciones deben tener presencia física. Opcionalmente ingresa una dirección aquí si tiene sentido donde está el comercio. Los servicios sin ubicación no se pueden mapear.",
 		"addressPlaceholder": "Av. Libertad 2100...",
 		"categoryPlaceholder": "Restaurante, etc.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Selecciona los métodos de pago aceptados",
 		"paymentMethodError": "Por favor corrige esto...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -467,6 +467,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Sélectionnez les méthodes de paiement acceptées",
 		"paymentMethodError": "Veuillez corriger ceci...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -466,6 +466,7 @@
 		"categoryPlaceholder": "Restaurant etc.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Sélectionnez les méthodes de paiement acceptées",
 		"paymentMethodError": "Veuillez corriger ceci...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -464,6 +464,8 @@
 		"addressTooltip": "Tous les lieux doivent avoir une présence physique. Vous pouvez éventuellement saisir une adresse ici si cela est pertinent pour le commerce. Les services sans localisation ne peuvent pas être cartographiés.",
 		"addressPlaceholder": "2100 Allée de la Liberté...",
 		"categoryPlaceholder": "Restaurant etc.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Sélectionnez les méthodes de paiement acceptées",
 		"paymentMethodError": "Veuillez corriger ceci...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -565,6 +565,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Seleziona i metodi di pagamento accettati",
 		"paymentMethodError": "Si prega di correggere questo...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -564,6 +564,7 @@
 		"categoryPlaceholder": "Ristorante ecc.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Seleziona i metodi di pagamento accettati",
 		"paymentMethodError": "Si prega di correggere questo...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -562,6 +562,8 @@
 		"addressTooltip": "Tutte le posizioni devono avere una presenza fisica. Inserisci opzionalmente un indirizzo qui se ha senso per il luogo in cui si trova il commerciante. I servizi senza una posizione fisica non possono essere mappati.",
 		"addressPlaceholder": "2100 Freedom Drive...",
 		"categoryPlaceholder": "Ristorante ecc.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Seleziona i metodi di pagamento accettati",
 		"paymentMethodError": "Si prega di correggere questo...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -565,6 +565,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Selecteer geaccepteerde betaalmethoden",
 		"paymentMethodError": "Los dit alstublieft op...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -562,6 +562,8 @@
 		"addressTooltip": "Elke locatie vereist een fysiek bezoekadres. Diensten zonder locatie kunnen niet aan de kaart worden toegevoegd.",
 		"addressPlaceholder": "Vrijheidsdreef 21",
 		"categoryPlaceholder": "Restaurant etc.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Selecteer geaccepteerde betaalmethoden",
 		"paymentMethodError": "Los dit alstublieft op...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -564,6 +564,7 @@
 		"categoryPlaceholder": "Restaurant etc.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Selecteer geaccepteerde betaalmethoden",
 		"paymentMethodError": "Los dit alstublieft op...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -469,6 +469,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Selecione os métodos de pagamento aceitos",
 		"paymentMethodError": "Por favor corrija isso...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -466,6 +466,8 @@
 		"addressTooltip": "Todos os locais devem ter presença física. Opcionalmente, insira um endereço aqui se fizer sentido onde o comerciante está localizado. Serviços sem localização não podem ser mapeados.",
 		"addressPlaceholder": "Avenida Liberdade, 2100...",
 		"categoryPlaceholder": "Restaurante etc.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Selecione os métodos de pagamento aceitos",
 		"paymentMethodError": "Por favor corrija isso...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -468,6 +468,7 @@
 		"categoryPlaceholder": "Restaurante etc.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Selecione os métodos de pagamento aceitos",
 		"paymentMethodError": "Por favor corrija isso...",
 		"onchainLabel": "On-chain",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -466,6 +466,7 @@
 		"categoryPlaceholder": "Ресторан и т.д.",
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
+		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
 		"paymentMethodsLegend": "Выберите принимаемые способы оплаты",
 		"paymentMethodError": "Пожалуйста, исправьте...",
 		"onchainLabel": "Ончейн",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -467,6 +467,7 @@
 		"categorySelectPlaceholder": "Select a category…",
 		"categoryOtherOption": "Other…",
 		"moreDetailsToggle": "Add more details (address, website, opening hours…)",
+		"categoryOtherRequired": "Please enter a category.",
 		"paymentMethodsLegend": "Выберите принимаемые способы оплаты",
 		"paymentMethodError": "Пожалуйста, исправьте...",
 		"onchainLabel": "Ончейн",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -464,6 +464,8 @@
 		"addressTooltip": "Все места должны иметь физическое местоположение. При желании введите адрес. Сервисы без фиксированного местоположения не могут быть отображены на карте.",
 		"addressPlaceholder": "2100 Freedom Drive...",
 		"categoryPlaceholder": "Ресторан и т.д.",
+		"categorySelectPlaceholder": "Select a category…",
+		"categoryOtherOption": "Other…",
 		"paymentMethodsLegend": "Выберите принимаемые способы оплаты",
 		"paymentMethodError": "Пожалуйста, исправьте...",
 		"onchainLabel": "Ончейн",

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -544,7 +544,7 @@ $: if (map && mapLoaded) {
 								</button>
 							</div>
 						{/if}
-						<div class="flex space-x-2">
+						<div class="flex space-x-2" class:hidden={!!arrivalCoords && !showAddressSearch}>
 							<div class="w-full">
 								<input
 									id="lat"
@@ -586,7 +586,7 @@ $: if (map && mapLoaded) {
 								{/if}
 							</div>
 						</div>
-						<div class="mt-2">
+						<div class="mt-2" class:hidden={!!arrivalCoords && !showAddressSearch}>
 							<button
 								type="button"
 								class="text-sm font-semibold text-link hover:text-hover focus:outline-link"

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -222,6 +222,9 @@ function handleAddressSelect(
 	if (address && (address.value.trim() === "" || addressFilledBySearch)) {
 		address.value = displayName;
 		addressFilledBySearch = true;
+		// The address field lives behind the "Add more details" expander —
+		// surface it so the filled-in value isn't silently hidden.
+		showMoreDetails = true;
 	}
 }
 

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -13,6 +13,7 @@ import { get } from "svelte/store";
 import FormHelperText from "$components/FormHelperText.svelte";
 import FormSuccess from "$components/FormSuccess.svelte";
 import AddressSearch from "$components/form/AddressSearch.svelte";
+import type { FormSelectOption } from "$components/form/FormSelect.svelte";
 import FormSelect from "$components/form/FormSelect.svelte";
 import Icon from "$components/Icon.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
@@ -21,6 +22,7 @@ import MapUnsupportedFallback from "$components/MapUnsupportedFallback.svelte";
 import PlacementPinIcon from "$components/PlacementPinIcon.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
 import TextLink from "$components/TextLink.svelte";
+import { CATEGORIES, CATEGORY_GROUPS } from "$lib/categoryMapping";
 import { _, locale } from "$lib/i18n";
 import type { BtcmapMapHandle } from "$lib/map/createMap";
 import { createBtcmapMap } from "$lib/map/createMap";
@@ -87,6 +89,8 @@ function resetForm() {
 	showAdvanced = false;
 	source = undefined;
 	sourceOther = undefined;
+	categorySelect = undefined;
+	categoryOther = undefined;
 
 	// Wait for the DOM to update with the form back in place
 	tick().then(async () => {
@@ -94,7 +98,6 @@ function resetForm() {
 		if (name) name.value = "";
 		if (nameEn) nameEn.value = "";
 		if (address) address.value = "";
-		if (category) category.value = "";
 		if (website) website.value = "";
 		if (phone) phone.value = "";
 		if (hours) hours.value = "";
@@ -231,7 +234,16 @@ function toggleAdvanced() {
 		if (long !== undefined) longInput = long.toFixed(5);
 	}
 }
-let category: HTMLInputElement;
+let categorySelect: string | undefined;
+let categoryOther: string | undefined;
+let categoryOtherElement: HTMLInputElement;
+
+// Map taxonomy minus the "all" pseudo-bucket, plus the Other escape
+// hatch — labels verbatim from the map UI.
+const categoryOptions: FormSelectOption[] = CATEGORIES.filter(
+	(key) => key !== "all",
+).map((key) => ({ value: key, label: CATEGORY_GROUPS[key].label }));
+
 let methods: ("onchain" | "lightning" | "nfc")[] = [];
 let onchain: HTMLInputElement;
 let lightning: HTMLInputElement;
@@ -311,7 +323,10 @@ const submitForm = (event: SubmitEvent) => {
 				address: address.value,
 				lat,
 				long,
-				category: category.value,
+				category:
+					categorySelect === "Other"
+						? (categoryOther ?? "").trim()
+						: (categorySelect ?? ""),
 				methods,
 				website: website.value,
 				phone: phone.value,
@@ -609,15 +624,36 @@ $: if (map && mapLoaded) {
 
 					<div>
 						<label for="category" class="mb-2 block font-semibold">{$_('forms.category')}</label>
-						<input
-							disabled={!captchaSecret || !mapLoaded}
-							type="text"
-							name="category"
+						<FormSelect
 							id="category"
-							placeholder={$_('addLocation.categoryPlaceholder')}
-							class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-							bind:this={category}
+							disabled={!captchaSecret || !mapLoaded}
+							name="category"
+							required
+							options={[
+								{ value: '', label: $_('addLocation.categorySelectPlaceholder') },
+								...categoryOptions,
+								{ value: 'Other', label: $_('addLocation.categoryOtherOption') }
+							]}
+							bind:value={categorySelect}
+							on:change={async () => {
+								if (categorySelect === 'Other') {
+									await tick();
+									categoryOtherElement.focus();
+								}
+							}}
 						/>
+						{#if categorySelect === 'Other'}
+							<input
+								disabled={!captchaSecret || !mapLoaded}
+								required
+								type="text"
+								name="category-other"
+								placeholder={$_('addLocation.categoryPlaceholder')}
+								class="mt-2 w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+								bind:value={categoryOther}
+								bind:this={categoryOtherElement}
+							/>
+						{/if}
 					</div>
 
 					<fieldset>

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -169,6 +169,7 @@ let lat: number | undefined;
 let long: number | undefined;
 let selected = false;
 let showAdvanced = false;
+let showMoreDetails = false;
 let latInput = "";
 let longInput = "";
 let latError = "";
@@ -478,25 +479,6 @@ $: if (map && mapLoaded) {
 					</div>
 
 					<div>
-						<div>
-							<label for="name-en" class="mb-2 block font-semibold">
-								{$_('addLocation.nameEnLabel')}
-								<span class="font-normal">{$_('forms.optional')}</span>
-							</label>
-							<FormHelperText text={$_('addLocation.nameEnTooltip')} />
-						</div>
-						<input
-							disabled={!captchaSecret || !mapLoaded}
-							type="text"
-							name="nameEn"
-							id="name-en"
-							placeholder={$_('addLocation.merchantEnglishNamePlaceholder')}
-							class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-							bind:this={nameEn}
-						/>
-					</div>
-
-					<div>
 						<label for="location-picker" class="mb-2 block font-semibold"
 							>{$_('forms.selectLocation')}</label
 						>
@@ -603,24 +585,6 @@ $: if (map && mapLoaded) {
 							{/if}
 						</div>
 					</div>
-
-				<div>
-					<div class="mb-2">
-						<label for="address" class="block font-semibold">{$_('addLocation.addressLabel')}</label>
-						<FormHelperText text={$_('addLocation.addressTooltip')} />
-					</div>
-					
-					<input
-						disabled={!captchaSecret || !mapLoaded}
-						type="text"
-						name="address"
-						id="address"
-						placeholder={$_('addLocation.addressPlaceholder')}
-						class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-						bind:this={address}
-						on:input={() => (addressFilledBySearch = false)}
-					/>
-				</div>
 
 					<div>
 						<label for="category" class="mb-2 block font-semibold">{$_('forms.category')}</label>
@@ -737,60 +701,111 @@ $: if (map && mapLoaded) {
 					</fieldset>
 
 					<div>
-						<label for="website" class="mb-2 block font-semibold"
-							>{$_('forms.website')} <span class="font-normal">{$_('forms.optional')}</span></label
+						<button
+							type="button"
+							class="text-sm font-semibold text-link hover:text-hover focus:outline-link"
+							aria-expanded={showMoreDetails}
+							on:click={() => (showMoreDetails = !showMoreDetails)}
 						>
-						<input
-							disabled={!captchaSecret || !mapLoaded}
-							type="url"
-							name="website"
-							placeholder={$_('addLocation.websitePlaceholder')}
-							class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-							bind:this={website}
-						/>
+							{showMoreDetails ? '▾' : '▸'}
+							{$_('addLocation.moreDetailsToggle')}
+						</button>
 					</div>
 
-					<div>
-						<label for="phone" class="mb-2 block font-semibold"
-							>{$_('forms.phone')} <span class="font-normal">{$_('forms.optional')}</span></label
-						>
-						<input
-							disabled={!captchaSecret || !mapLoaded}
-							type="tel"
-							name="phone"
-							placeholder={$_('addLocation.phonePlaceholder')}
-							class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-							bind:this={phone}
-						/>
-					</div>
+					<div class="space-y-5" class:hidden={!showMoreDetails}>
+						<div>
+							<div>
+								<label for="name-en" class="mb-2 block font-semibold">
+									{$_('addLocation.nameEnLabel')}
+									<span class="font-normal">{$_('forms.optional')}</span>
+								</label>
+								<FormHelperText text={$_('addLocation.nameEnTooltip')} />
+							</div>
+							<input
+								disabled={!captchaSecret || !mapLoaded}
+								type="text"
+								name="nameEn"
+								id="name-en"
+								placeholder={$_('addLocation.merchantEnglishNamePlaceholder')}
+								class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+								bind:this={nameEn}
+							/>
+						</div>
 
-					<div>
-						<label for="hours" class="mb-2 block font-semibold"
-							>{$_('forms.openingHours')}
-							<span class="font-normal">{$_('forms.optional')}</span></label
-						>
-						<input
-							disabled={!captchaSecret || !mapLoaded}
-							type="text"
-							name="hours"
-							placeholder={$_('addLocation.hoursPlaceholder')}
-							class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-							bind:this={hours}
-						/>
-					</div>
+						<div>
+							<div class="mb-2">
+								<label for="address" class="block font-semibold">{$_('addLocation.addressLabel')}</label>
+								<FormHelperText text={$_('addLocation.addressTooltip')} />
+							</div>
 
-					<div>
-						<label for="notes" class="mb-2 block font-semibold"
-							>{$_('forms.notes')} <span class="font-normal">{$_('forms.optional')}</span></label
-						>
-						<textarea
-							disabled={!captchaSecret || !mapLoaded}
-							name="notes"
-							placeholder={$_('addLocation.notesPlaceholder')}
-							rows="3"
-							class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
-							bind:this={notes}
-						></textarea>
+							<input
+								disabled={!captchaSecret || !mapLoaded}
+								type="text"
+								name="address"
+								id="address"
+								placeholder={$_('addLocation.addressPlaceholder')}
+								class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+								bind:this={address}
+								on:input={() => (addressFilledBySearch = false)}
+							/>
+						</div>
+
+						<div>
+							<label for="website" class="mb-2 block font-semibold"
+								>{$_('forms.website')} <span class="font-normal">{$_('forms.optional')}</span></label
+							>
+							<input
+								disabled={!captchaSecret || !mapLoaded}
+								type="url"
+								name="website"
+								placeholder={$_('addLocation.websitePlaceholder')}
+								class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+								bind:this={website}
+							/>
+						</div>
+
+						<div>
+							<label for="phone" class="mb-2 block font-semibold"
+								>{$_('forms.phone')} <span class="font-normal">{$_('forms.optional')}</span></label
+							>
+							<input
+								disabled={!captchaSecret || !mapLoaded}
+								type="tel"
+								name="phone"
+								placeholder={$_('addLocation.phonePlaceholder')}
+								class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+								bind:this={phone}
+							/>
+						</div>
+
+						<div>
+							<label for="hours" class="mb-2 block font-semibold"
+								>{$_('forms.openingHours')}
+								<span class="font-normal">{$_('forms.optional')}</span></label
+							>
+							<input
+								disabled={!captchaSecret || !mapLoaded}
+								type="text"
+								name="hours"
+								placeholder={$_('addLocation.hoursPlaceholder')}
+								class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+								bind:this={hours}
+							/>
+						</div>
+
+						<div>
+							<label for="notes" class="mb-2 block font-semibold"
+								>{$_('forms.notes')} <span class="font-normal">{$_('forms.optional')}</span></label
+							>
+							<textarea
+								disabled={!captchaSecret || !mapLoaded}
+								name="notes"
+								placeholder={$_('addLocation.notesPlaceholder')}
+								rows="3"
+								class="w-full rounded-2xl border-2 border-input p-3 transition-all focus:outline-link disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 dark:bg-white/[0.15] dark:disabled:bg-gray-700 dark:disabled:text-gray-400"
+								bind:this={notes}
+							></textarea>
+						</div>
 					</div>
 
 					<div>

--- a/src/routes/add-location/+page.svelte
+++ b/src/routes/add-location/+page.svelte
@@ -87,6 +87,7 @@ function resetForm() {
 	latError = "";
 	longError = "";
 	showAdvanced = false;
+	showMoreDetails = false;
 	source = undefined;
 	sourceOther = undefined;
 	categorySelect = undefined;
@@ -291,6 +292,11 @@ $: if (mapLoaded && lat !== undefined && long !== undefined && !marker) {
 
 const submitForm = (event: SubmitEvent) => {
 	event.preventDefault();
+	if (categorySelect === "Other" && !(categoryOther ?? "").trim()) {
+		errToast(get(_)("addLocation.categoryOtherRequired"));
+		categoryOtherElement.focus();
+		return;
+	}
 	if (!selected) {
 		noLocationSelected = true;
 		errToast(get(_)("errors.noLocationSelected"));

--- a/tests/add-location-slim-form.spec.ts
+++ b/tests/add-location-slim-form.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+
+// Step 2 of the add-location redesign: slim details form (#1134) —
+// category picker, coordinate fields hidden for map-placed pins, and
+// optional fields behind the "Add more details" expander.
+test.describe('Add Location — slim form', () => {
+	test('category is a picker and Other reveals a required text input', async ({
+		page
+	}) => {
+		await page.goto('/add-location');
+		await page.waitForLoadState('domcontentloaded');
+
+		const category = page.locator('#category');
+		await expect(category).toBeVisible();
+		// Taxonomy options present, no free-text field by default.
+		await expect(category.locator('option[value="restaurants"]')).toHaveCount(1);
+		await expect(page.locator('input[name="category-other"]')).toHaveCount(0);
+
+		await category.selectOption('Other');
+		const other = page.locator('input[name="category-other"]');
+		await expect(other).toBeVisible();
+		await expect(other).toHaveAttribute('required', '');
+	});
+
+	test('map-placed pins hide the coordinate fields; escape hatch restores them', async ({
+		page
+	}) => {
+		await page.goto('/add-location?lat=52.52000&long=13.40500');
+		await page.waitForLoadState('domcontentloaded');
+
+		await expect(page.locator('#lat')).toBeHidden();
+		await expect(
+			page.getByRole('button', { name: /Advanced — enter coordinates manually/ })
+		).toBeHidden();
+
+		await page
+			.getByRole('button', { name: 'Search for an address instead' })
+			.click();
+		await expect(page.locator('#lat')).toBeVisible();
+	});
+
+	test('optional fields sit behind the expander and stay functional', async ({
+		page
+	}) => {
+		await page.goto('/add-location');
+		await page.waitForLoadState('domcontentloaded');
+
+		const websiteInput = page.locator('input[name="website"]');
+		await expect(websiteInput).toBeHidden();
+
+		const toggle = page.getByRole('button', { name: /Add more details/ });
+		await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+		await expect(websiteInput).toBeVisible();
+		await websiteInput.fill('https://example.com');
+		// Collapse again — the value survives because the group stays mounted.
+		await toggle.click();
+		await expect(websiteInput).toBeHidden();
+		await toggle.click();
+		await expect(websiteInput).toHaveValue('https://example.com');
+	});
+});


### PR DESCRIPTION
Part of #1134. Stacked on #1279 — base is `feat/add-location-submit-place`, please merge after it lands (GitHub will auto-retarget this PR to `main` once #1279 merges).

## What changed

<img width="1304" height="1319" alt="image" src="https://github.com/user-attachments/assets/17e1b30c-866c-44a6-8315-4385b1e41db6" />
<img width="624" height="366" alt="image" src="https://github.com/user-attachments/assets/d0d78b09-1194-4cb8-a8e6-6a23faca28fe" />


Three UX changes to the add-location form, each with its own motivation:

- **Category picker with an "Other" escape hatch** — the free-text category field let a live typo (`restaurtant`) reach production data. `#category` is now a `<select>` over the same taxonomy keys the map already filters by (`restaurants`, `shopping`, `groceries`, `coffee`, `atms`, `hotels`, `beauty`), with an `Other` option that reveals a required free-text input for anything outside that list.
- **Coordinate fields hidden for map-placed pins** — team feedback was explicit: hide the lat/lon fields when a pin arrives from the map's placement mode (`?lat&long`). The manual advanced-entry toggle is hidden along with them; a "Search for an address instead" escape hatch restores the full manual-entry layout for anyone who needs it.
- **Optional fields collapsed behind a details expander** — mobile-first form weight: everything past name/category/coordinates (website, phone, socials, etc.) now sits behind an "Add more details" toggle so the default view is short. The field group stays mounted while collapsed, so entered values survive a collapse/re-expand round trip.
- **Address search auto-expands the details section** — picking a result from the address search fills the `#address` field, which lives inside the "Add more details" expander. Selecting a result now also opens that expander, so the filled-in address is visible instead of silently attached to the submission.

## Heads-up for supertaggers

Submitted `category` values are now either a taxonomy key (`restaurants`, `shopping`, `groceries`, `coffee`, `atms`, `hotels`, `beauty`) or free text typed into the `Other` field — no longer an unconstrained free-text string by default. Tickets synced from these submissions will show one of those keys instead of arbitrary text unless the submitter picked `Other`.

## Deliberate deviation

Same as #1279: `src/routes/add-location/+page.svelte` stays legacy Svelte 4, not converted to runes, per the CLAUDE.md boy-scout rule's hotspot exception — it's a large page with map lifecycle code that would bloat this PR with an unrelated conversion diff.

## Scope

No pipeline or backend changes — this is form UI/UX only (category picker, coordinate visibility, details expander) plus its Playwright coverage.

## Verification

- New spec `tests/add-location-slim-form.spec.ts` (3 tests) plus the existing `add-location-arrival.spec.ts` and `add-location-coords.spec.ts` — all green.
- Full checklist green: `format:fix`, `check`, `typecheck`, `lint`, 682 unit tests.
- Full Playwright suite green (77/77). The shared dev machine was under heavy load during this run; a couple of add-location specs raced the local 5s action timeout under 5 parallel workers and passed cleanly when re-run in isolation / with reduced worker concurrency — consistent with the known load-flakiness already called out for the live-API specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjZ7qPmjDm85vTn9MbS2uS

