### PR TITLE
feat(apps): promote Blink from coming soon to available

### DIFF
--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -371,7 +371,7 @@ export const appConfigs: AppConfig[] = [
 		id: "blink",
 		name: "Blink",
 		logo: "/images/apps/blink.png",
-		tag: "coming-soon",
+		tag: "powered-by-btcmap",
 		sponsor: false,
 		stores: [
 			{
@@ -383,6 +383,11 @@ export const appConfigs: AppConfig[] = [
 				store: "apk",
 				platform: "android",
 				url: "https://github.com/blinkbitcoin/blink-mobile/releases/latest",
+			},
+			{
+				store: "zapstore",
+				platform: "android",
+				url: "https://zapstore.dev/apps/com.galoyapp",
 			},
 			{
 				store: "app-store",


### PR DESCRIPTION
Promotes Blink from the coming-soon section to the available apps section and adds a Zapstore download link.

Changes:
- Changed `tag` from `"coming-soon"` to `"powered-by-btcmap"` in `src/lib/apps.ts`
- Added Zapstore store entry for Blink wallet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an Android download option for the Blink app through Zapstore.
  - Updated the Blink app listing to indicate it is powered by BTC Map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->