### PR TITLE
feat(map): duplicate-place interrupt before add-location handoff

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -46,7 +46,9 @@ export type EventName =
 	| "backup_modal_shown"
 	| "backup_credentials_copied"
 	| "add_place_enter"
-	| "add_place_confirm";
+	| "add_place_confirm"
+	| "add_place_nearby_shown"
+	| "add_place_nearby_continue";
 
 declare global {
 	interface Window {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -48,7 +48,8 @@ export type EventName =
 	| "add_place_enter"
 	| "add_place_confirm"
 	| "add_place_nearby_shown"
-	| "add_place_nearby_continue";
+	| "add_place_nearby_continue"
+	| "add_place_nearby_candidate_click";
 
 declare global {
 	interface Window {

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -725,15 +725,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Карта на биткойн търговци",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Поставете маркера",
+			"hint": "Преместете картата, докато маркерът застане върху входа на обекта, след което потвърдете.",
+			"cancel": "Отказ",
+			"confirm": "Добавете място тук",
+			"nearbyTitle": "Едно от тези ли е?",
+			"nearbyHint": "Тези места вече съществуват близо до вашия маркер — отворете някое, за да проверите, или добавете ново място.",
+			"nearbyUnnamed": "Място без име",
+			"nearbyBack": "Назад",
+			"nearbyContinue": "Нито едно от тези — добавяне на ново място"
 		}
 	},
 	"success": {

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -728,7 +728,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"success": {

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -278,15 +278,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Bitcoin Händlerkarte",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Pin platzieren",
+			"hint": "Verschiebe die Karte, bis der Pin auf dem Eingang des Geschäfts sitzt, und bestätige dann.",
+			"cancel": "Abbrechen",
+			"confirm": "Hier einen Ort hinzufügen",
+			"nearbyTitle": "Ist es einer von diesen?",
+			"nearbyHint": "Diese Orte existieren bereits in der Nähe deines Pins — öffne einen zum Prüfen oder füge einen neuen Ort hinzu.",
+			"nearbyUnnamed": "Unbenannter Ort",
+			"nearbyBack": "Zurück",
+			"nearbyContinue": "Keiner davon — neuen Ort hinzufügen"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -281,7 +281,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -370,7 +370,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -278,15 +278,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Mapa de Comercios Bitcoin",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Coloca el pin",
+			"hint": "Arrastra el mapa hasta que el pin quede sobre la entrada del negocio y luego confirma.",
+			"cancel": "Cancelar",
+			"confirm": "Añadir un lugar aquí",
+			"nearbyTitle": "¿Es uno de estos?",
+			"nearbyHint": "Estos lugares ya existen cerca de tu pin — abre uno para comprobarlo o añade un nuevo lugar.",
+			"nearbyUnnamed": "Lugar sin nombre",
+			"nearbyBack": "Atrás",
+			"nearbyContinue": "Ninguno de estos — añadir un nuevo lugar"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -281,7 +281,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -278,15 +278,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Carte des commerces Bitcoin",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Placez l'épingle",
+			"hint": "Déplacez la carte jusqu'à ce que l'épingle soit sur l'entrée du commerce, puis confirmez.",
+			"cancel": "Annuler",
+			"confirm": "Ajouter un lieu ici",
+			"nearbyTitle": "Est-ce l'un de ceux-ci ?",
+			"nearbyHint": "Ces lieux existent déjà près de votre épingle — ouvrez-en un pour vérifier, ou ajoutez un nouveau lieu.",
+			"nearbyUnnamed": "Lieu sans nom",
+			"nearbyBack": "Retour",
+			"nearbyContinue": "Aucun de ceux-ci — ajouter un nouveau lieu"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -281,7 +281,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -367,15 +367,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Mappa dei commercianti Bitcoin",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Posiziona il segnaposto",
+			"hint": "Trascina la mappa finché il segnaposto non si trova sull'ingresso dell'attività, poi conferma.",
+			"cancel": "Annulla",
+			"confirm": "Aggiungi un luogo qui",
+			"nearbyTitle": "È uno di questi?",
+			"nearbyHint": "Questi luoghi esistono già vicino al tuo segnaposto — aprine uno per controllare, oppure aggiungi un nuovo luogo.",
+			"nearbyUnnamed": "Luogo senza nome",
+			"nearbyBack": "Indietro",
+			"nearbyContinue": "Nessuno di questi — aggiungi un nuovo luogo"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -370,7 +370,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -367,15 +367,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Bitcoin acceptatiekaart",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Plaats de pin",
+			"hint": "Sleep de kaart tot de pin op de ingang van de zaak staat en bevestig daarna.",
+			"cancel": "Annuleren",
+			"confirm": "Voeg hier een locatie toe",
+			"nearbyTitle": "Is het een van deze?",
+			"nearbyHint": "Deze locaties bestaan al in de buurt van je pin — open er een om te controleren, of voeg een nieuwe locatie toe.",
+			"nearbyUnnamed": "Naamloze locatie",
+			"nearbyBack": "Terug",
+			"nearbyContinue": "Geen van deze — nieuwe locatie toevoegen"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -370,7 +370,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -274,15 +274,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Mapa de Comerciantes Bitcoin",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Posicione o pino",
+			"hint": "Arraste o mapa até o pino ficar sobre a entrada do estabelecimento e depois confirme.",
+			"cancel": "Cancelar",
+			"confirm": "Adicionar um local aqui",
+			"nearbyTitle": "É um destes?",
+			"nearbyHint": "Estes locais já existem perto do seu pino — abra um para conferir ou adicione um novo local.",
+			"nearbyUnnamed": "Local sem nome",
+			"nearbyBack": "Voltar",
+			"nearbyContinue": "Nenhum destes — adicionar um novo local"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -277,7 +277,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -278,15 +278,15 @@
 	"map": {
 		"bitcoinMerchantMapTitle": "Биткоин карта",
 		"placement": {
-			"title": "Place the pin",
-			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
-			"cancel": "Cancel",
-			"confirm": "Add a place here",
-			"nearbyTitle": "Is it one of these?",
-			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
-			"nearbyUnnamed": "Unnamed place",
-			"nearbyBack": "Back",
-			"nearbyContinue": "None of these — add a new place"
+			"title": "Разместите метку",
+			"hint": "Перемещайте карту, пока метка не окажется на входе заведения, затем подтвердите.",
+			"cancel": "Отмена",
+			"confirm": "Добавить место здесь",
+			"nearbyTitle": "Это одно из этих мест?",
+			"nearbyHint": "Эти места уже существуют рядом с вашей меткой — откройте одно из них, чтобы проверить, или добавьте новое место.",
+			"nearbyUnnamed": "Место без названия",
+			"nearbyBack": "Назад",
+			"nearbyContinue": "Ни одно из них — добавить новое место"
 		}
 	},
 	"info": {

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -281,7 +281,12 @@
 			"title": "Place the pin",
 			"hint": "Drag the map until the pin sits on the business entrance, then confirm.",
 			"cancel": "Cancel",
-			"confirm": "Add a place here"
+			"confirm": "Add a place here",
+			"nearbyTitle": "Is it one of these?",
+			"nearbyHint": "These places already exist near your pin — open one to check, or add a new place.",
+			"nearbyUnnamed": "Unnamed place",
+			"nearbyBack": "Back",
+			"nearbyContinue": "None of these — add a new place"
 		}
 	},
 	"info": {

--- a/src/lib/merchantListStore.ts
+++ b/src/lib/merchantListStore.ts
@@ -2,7 +2,6 @@ import axios from "axios";
 import { get, writable } from "svelte/store";
 
 import { trackEvent } from "$lib/analytics";
-import { API_BASE } from "$lib/api-base";
 import { buildFieldsParam, PLACE_FIELD_SETS } from "$lib/api-fields";
 import api from "$lib/axios";
 import type { CategoryCounts, CategoryKey } from "$lib/categoryMapping";
@@ -22,6 +21,7 @@ import {
 import { selectVisiblePlaces } from "$lib/map/visiblePlaces";
 import { isBoosted } from "$lib/merchantDrawerLogic";
 import { merchantDrawer } from "$lib/merchantDrawerStore";
+import { buildRadiusSearchUrl, filterValidPlaces } from "$lib/radiusSearch";
 import { paymentTagsLoaded, verifiedDatesLoaded } from "$lib/store";
 import type { Place } from "$lib/types";
 import type { UserLocation } from "$lib/userLocationStore";
@@ -145,17 +145,14 @@ function isCancellation(error: Error): boolean {
 	return axios.isCancel(error) || error.name === "AbortError";
 }
 
-// Filter out invalid API response items missing required id field
-function filterValidPlaces<T extends { id?: unknown }>(items: T[]): T[] {
-	return items.filter((item): item is T => typeof item?.id === "number");
-}
-
 // The one radius-search fetcher behind the three list reducers
-// (fetchAndReplaceList, fetchCountOnly, fetchEnrichedDetails). Owns the URL
-// shape, the 10s transport policy, the array-shape validation (the API can
-// return an HTML error page), and the dropping of rows without a numeric id.
-// What each reducer does with the rows — and how loudly it fails — stays
-// that reducer's own policy.
+// (fetchAndReplaceList, fetchCountOnly, fetchEnrichedDetails). Owns the
+// transport policy (axios, 10s timeout, caller-managed AbortSignal) and the
+// error-shape policy (the array-shape check below — the API can return an
+// HTML error page). The URL shape and the dropping of rows without a
+// numeric id live in $lib/radiusSearch, shared with the placement dedupe
+// name lookup. What each reducer does with the rows — and how loudly it
+// fails — stays that reducer's own policy.
 async function searchPlacesInRadius<T extends { id?: unknown }>(
 	center: { lat: number; lon: number },
 	radiusKm: number,
@@ -163,7 +160,7 @@ async function searchPlacesInRadius<T extends { id?: unknown }>(
 	signal: AbortSignal,
 ): Promise<T[]> {
 	const response = await api.get<T[]>(
-		`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`,
+		buildRadiusSearchUrl(center, radiusKm, fields),
 		{ timeout: 10000, signal },
 	);
 	if (!Array.isArray(response.data)) {

--- a/src/lib/placementMode.test.ts
+++ b/src/lib/placementMode.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { Place } from "$lib/types";
 
 import {
 	buildAddLocationUrl,
+	fetchNearbyPlaceNames,
 	findNearbyPlaces,
 	parseCoordsParams,
 } from "./placementMode";
@@ -90,5 +91,47 @@ describe("findNearbyPlaces", () => {
 
 	it("returns empty for an empty store", () => {
 		expect(findNearbyPlaces(LAT, LONG, [])).toEqual([]);
+	});
+});
+
+describe("fetchNearbyPlaceNames", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("maps valid rows by id, skipping empty names and non-numeric ids", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({
+				ok: true,
+				json: async () => [
+					{ id: 1, name: "Kiosk 87" },
+					{ id: 2, name: "" },
+					{ id: "x", name: "bad" },
+				],
+			})),
+		);
+		const names = await fetchNearbyPlaceNames(42.2762511, 42.7024218);
+		expect(names).toEqual(new Map([[1, "Kiosk 87"]]));
+	});
+
+	it("returns an empty Map when the response is not ok", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => ({ ok: false, json: async () => [] })),
+		);
+		const names = await fetchNearbyPlaceNames(42.2762511, 42.7024218);
+		expect(names).toEqual(new Map());
+	});
+
+	it("returns an empty Map when fetch rejects", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () => {
+				throw new Error("network error");
+			}),
+		);
+		const names = await fetchNearbyPlaceNames(42.2762511, 42.7024218);
+		expect(names).toEqual(new Map());
 	});
 });

--- a/src/lib/placementMode.test.ts
+++ b/src/lib/placementMode.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { buildAddLocationUrl, parseCoordsParams } from "./placementMode";
+import type { Place } from "$lib/types";
+
+import {
+	buildAddLocationUrl,
+	findNearbyPlaces,
+	parseCoordsParams,
+} from "./placementMode";
 
 describe("buildAddLocationUrl", () => {
 	it("builds the add-location URL with 5-decimal coords", () => {
@@ -33,5 +39,56 @@ describe("parseCoordsParams", () => {
 		expect(
 			parseCoordsParams(new URLSearchParams("lat=1&long=2&lat=3&long=4")),
 		).toBeNull();
+	});
+});
+
+const makePlace = (
+	id: number,
+	lat: number,
+	lon: number,
+	extra: Partial<Place> = {},
+): Place => ({
+	id,
+	lat,
+	lon,
+	icon: "restaurant",
+	name: `Place ${id}`,
+	...extra,
+});
+
+describe("findNearbyPlaces", () => {
+	// At lat 42, 0.0005° of latitude ≈ 55.6 m (inside 75 m) and 0.001° ≈ 111 m
+	// (outside) — offsets chosen so the radius cut is unambiguous.
+	const LAT = 42.2762511;
+	const LONG = 42.7024218;
+
+	it("returns places inside the radius, closest first, with distances in meters", () => {
+		const near = makePlace(1, LAT + 0.0005, LONG);
+		const nearer = makePlace(2, LAT + 0.0002, LONG);
+		const far = makePlace(3, LAT + 0.001, LONG);
+		const result = findNearbyPlaces(LAT, LONG, [near, far, nearer]);
+		expect(result.map(({ place }) => place.id)).toEqual([2, 1]);
+		expect(result[0].distanceM).toBeGreaterThan(20);
+		expect(result[0].distanceM).toBeLessThan(25);
+		expect(result[1].distanceM).toBeGreaterThan(50);
+		expect(result[1].distanceM).toBeLessThan(60);
+	});
+
+	it("excludes deleted places even inside the radius", () => {
+		const deleted = makePlace(1, LAT, LONG, {
+			deleted_at: "2026-01-01T00:00:00Z",
+		});
+		expect(findNearbyPlaces(LAT, LONG, [deleted])).toEqual([]);
+	});
+
+	it("caps the list at NEARBY_LIMIT", () => {
+		const cluster = Array.from({ length: 7 }, (_, i) =>
+			makePlace(i + 1, LAT + i * 0.00005, LONG),
+		);
+		expect(findNearbyPlaces(LAT, LONG, cluster)).toHaveLength(5);
+	});
+
+	it("returns empty for an empty store", () => {
+		expect(findNearbyPlaces(LAT, LONG, [])).toEqual([]);
 	});
 });

--- a/src/lib/placementMode.ts
+++ b/src/lib/placementMode.ts
@@ -1,3 +1,4 @@
+import { API_BASE } from "$lib/api-base";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
 import type { Place } from "$lib/types";
 import { calculateDistance } from "$lib/utils";
@@ -41,3 +42,32 @@ export const findNearbyPlaces = (
 		.filter(({ distanceM }) => distanceM <= NEARBY_RADIUS_M)
 		.sort((a, b) => a.distanceM - b.distanceM)
 		.slice(0, NEARBY_LIMIT);
+
+// The static CDN feed deliberately ships no name field (map-perf
+// constraint), so candidate names come from a tiny radius search at
+// interrupt time; any failure degrades to the unnamed fallback.
+export const fetchNearbyPlaceNames = async (
+	lat: number,
+	long: number,
+): Promise<Map<number, string>> => {
+	const names = new Map<number, string>();
+	try {
+		const response = await fetch(
+			`${API_BASE}/v4/places/search/?lat=${lat}&lon=${long}&radius_km=${NEARBY_RADIUS_M / 1000}&fields=id,name`,
+			{ signal: AbortSignal.timeout(5000) },
+		);
+		if (!response.ok) return names;
+		const rows: unknown = await response.json();
+		if (!Array.isArray(rows)) return names;
+		for (const row of rows) {
+			const id = (row as { id?: unknown }).id;
+			const name = (row as { name?: unknown }).name;
+			if (typeof id === "number" && typeof name === "string" && name) {
+				names.set(id, name);
+			}
+		}
+	} catch {
+		// Timeout/network failure — candidates just keep the fallback label.
+	}
+	return names;
+};

--- a/src/lib/placementMode.ts
+++ b/src/lib/placementMode.ts
@@ -1,7 +1,9 @@
-import { API_BASE } from "$lib/api-base";
 import { parseLatLongQuery } from "$lib/map/queryViewport";
+import { buildRadiusSearchUrl, filterValidPlaces } from "$lib/radiusSearch";
 import type { Place } from "$lib/types";
 import { calculateDistance } from "$lib/utils";
+
+import type { Place as ApiPlace } from "$types/btcmap-api/Place";
 
 // 5 decimal places (~1 m) matches the precision /add-location displays
 // and snaps to in placeMarker().
@@ -53,17 +55,22 @@ export const fetchNearbyPlaceNames = async (
 	const names = new Map<number, string>();
 	try {
 		const response = await fetch(
-			`${API_BASE}/v4/places/search/?lat=${lat}&lon=${long}&radius_km=${NEARBY_RADIUS_M / 1000}&fields=id,name`,
+			buildRadiusSearchUrl(
+				{ lat, lon: long },
+				NEARBY_RADIUS_M / 1000,
+				"id,name",
+			),
 			{ signal: AbortSignal.timeout(5000) },
 		);
 		if (!response.ok) return names;
 		const rows: unknown = await response.json();
 		if (!Array.isArray(rows)) return names;
-		for (const row of rows) {
-			const id = (row as { id?: unknown }).id;
-			const name = (row as { name?: unknown }).name;
-			if (typeof id === "number" && typeof name === "string" && name) {
-				names.set(id, name);
+		const validRows = filterValidPlaces(
+			rows as Pick<ApiPlace, "id" | "name">[],
+		);
+		for (const row of validRows) {
+			if (typeof row.name === "string" && row.name) {
+				names.set(row.id, row.name);
 			}
 		}
 	} catch {

--- a/src/lib/placementMode.ts
+++ b/src/lib/placementMode.ts
@@ -1,4 +1,6 @@
 import { parseLatLongQuery } from "$lib/map/queryViewport";
+import type { Place } from "$lib/types";
+import { calculateDistance } from "$lib/utils";
 
 // 5 decimal places (~1 m) matches the precision /add-location displays
 // and snaps to in placeMarker().
@@ -16,3 +18,26 @@ export const parseCoordsParams = (
 	if (parsed?.kind !== "point") return null;
 	return { lat: parsed.lat, long: parsed.lng };
 };
+
+export const NEARBY_RADIUS_M = 75;
+export const NEARBY_LIMIT = 5;
+
+export type NearbyPlace = { place: Place; distanceM: number };
+
+// Duplicate check for the placement confirm step: existing (non-deleted)
+// places within NEARBY_RADIUS_M of the pin, closest first, capped at
+// NEARBY_LIMIT. calculateDistance returns km.
+export const findNearbyPlaces = (
+	lat: number,
+	long: number,
+	places: Place[],
+): NearbyPlace[] =>
+	places
+		.filter((place) => !place.deleted_at)
+		.map((place) => ({
+			place,
+			distanceM: calculateDistance(lat, long, place.lat, place.lon) * 1000,
+		}))
+		.filter(({ distanceM }) => distanceM <= NEARBY_RADIUS_M)
+		.sort((a, b) => a.distanceM - b.distanceM)
+		.slice(0, NEARBY_LIMIT);

--- a/src/lib/radiusSearch.test.ts
+++ b/src/lib/radiusSearch.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildRadiusSearchUrl, filterValidPlaces } from "./radiusSearch";
+
+describe("buildRadiusSearchUrl", () => {
+	it("produces the exact expected URL for a sample center/radius/fields", () => {
+		expect(
+			buildRadiusSearchUrl(
+				{ lat: 42.2762511, lon: 42.7024218 },
+				0.075,
+				"id,name",
+			),
+		).toBe(
+			"https://api.btcmap.org/v4/places/search/?lat=42.2762511&lon=42.7024218&radius_km=0.075&fields=id,name",
+		);
+	});
+});
+
+describe("filterValidPlaces", () => {
+	it("drops rows with missing or string ids while keeping numeric-id rows", () => {
+		const rows = [
+			{ id: 1, name: "Kiosk 87" },
+			{ id: "x", name: "bad id" },
+			{ name: "missing id" },
+			{ id: 2, name: "Cafe" },
+		];
+		expect(filterValidPlaces(rows)).toEqual([
+			{ id: 1, name: "Kiosk 87" },
+			{ id: 2, name: "Cafe" },
+		]);
+	});
+});

--- a/src/lib/radiusSearch.ts
+++ b/src/lib/radiusSearch.ts
@@ -1,0 +1,16 @@
+import { API_BASE } from "$lib/api-base";
+
+// URL shape and row validation for /v4/places/search/ — shared by the
+// merchant-list fetcher (axios transport) and the placement dedupe name
+// lookup (native fetch). Transport policy stays at each call site.
+export const buildRadiusSearchUrl = (
+	center: { lat: number; lon: number },
+	radiusKm: number,
+	fields: string,
+): string =>
+	`${API_BASE}/v4/places/search/?lat=${center.lat}&lon=${center.lon}&radius_km=${radiusKm}&fields=${fields}`;
+
+// Drop rows missing a numeric id — the API can return partial garbage.
+export function filterValidPlaces<T extends { id?: unknown }>(items: T[]): T[] {
+	return items.filter((item): item is T => typeof item?.id === "number");
+}

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -31,6 +31,10 @@ let { map, active = $bindable(false) }: Props = $props();
 // `nearby === hits` holding after a plain assignment — $state would wrap the
 // array in a new proxy on assignment, breaking that reference check.
 let nearby: NearbyPlace[] | null = $state.raw(null);
+// True once the async name lookup for the current `nearby` list has
+// settled (success, empty, or failure) — gates the "Unnamed place"
+// fallback so it doesn't flash before names have had a chance to arrive.
+let namesLoaded = $state(false);
 
 // Symmetric focus management for the confirm<->interrupt swap: whichever
 // button unmounts, the surviving sheet's equivalent button takes focus
@@ -84,6 +88,7 @@ const confirm = async () => {
 		return;
 	}
 	nearby = hits;
+	namesLoaded = false;
 	trackEvent("add_place_nearby_shown", { count: hits.length });
 	await tick();
 	backButtonEl?.focus();
@@ -91,12 +96,15 @@ const confirm = async () => {
 	const names = await fetchNearbyPlaceNames(center.lat, center.lng);
 	// Identity guard: Back, Cancel, a map move, or a newer confirm all
 	// replace/clear `nearby` — never patch a list the user left.
-	if (nearby !== hits || names.size === 0) return;
-	nearby = hits.map((hit) =>
-		names.has(hit.place.id)
-			? { ...hit, place: { ...hit.place, name: names.get(hit.place.id) } }
-			: hit,
-	);
+	if (nearby !== hits) return;
+	namesLoaded = true;
+	if (names.size > 0) {
+		nearby = hits.map((hit) =>
+			names.has(hit.place.id)
+				? { ...hit, place: { ...hit.place, name: names.get(hit.place.id) } }
+				: hit,
+		);
+	}
 };
 
 const addAnyway = () => {
@@ -272,7 +280,8 @@ $effect(() => {
 							class="flex items-baseline justify-between gap-3 rounded-lg px-2 py-1.5 hover:underline"
 						>
 							<span class="font-semibold text-link"
-								>{place.name || $_("map.placement.nearbyUnnamed")}</span
+								>{place.name ||
+									(namesLoaded ? $_("map.placement.nearbyUnnamed") : "…")}</span
 							>
 							<span class="shrink-0 text-sm text-body dark:text-offwhite"
 								>{Math.round(distanceM)} m</span

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -8,7 +8,9 @@ import type {
 import PlacementPinIcon from "$components/PlacementPinIcon.svelte";
 import { trackEvent } from "$lib/analytics";
 import { _ } from "$lib/i18n";
-import { buildAddLocationUrl } from "$lib/placementMode";
+import type { NearbyPlace } from "$lib/placementMode";
+import { buildAddLocationUrl, findNearbyPlaces } from "$lib/placementMode";
+import { places } from "$lib/store";
 
 import { goto } from "$app/navigation";
 
@@ -18,6 +20,8 @@ type Props = {
 };
 
 let { map, active = $bindable(false) }: Props = $props();
+
+let nearby: NearbyPlace[] | null = $state(null);
 
 // Keep ?add in the URL so placement mode is linkable. Same raw
 // history.replaceState idiom as writeHashCoords ($lib/map/mapHash.ts),
@@ -44,14 +48,39 @@ const enter = (method: string) => {
 };
 
 const cancel = () => {
+	nearby = null;
 	active = false;
+};
+
+// add_place_confirm keeps meaning "handed off to the form" — it fires on
+// both the direct path and the add-anyway path, so the funnel metric is
+// unchanged by the interrupt.
+const navigateToForm = (lat: number, long: number) => {
+	trackEvent("add_place_confirm");
+	goto(buildAddLocationUrl(lat, long));
 };
 
 const confirm = () => {
 	if (!map) return;
 	const center = map.getCenter();
-	trackEvent("add_place_confirm");
-	goto(buildAddLocationUrl(center.lat, center.lng));
+	const hits = findNearbyPlaces(center.lat, center.lng, $places);
+	if (hits.length === 0) {
+		navigateToForm(center.lat, center.lng);
+		return;
+	}
+	nearby = hits;
+	trackEvent("add_place_nearby_shown", { count: hits.length });
+};
+
+const addAnyway = () => {
+	if (!map) return;
+	const center = map.getCenter();
+	trackEvent("add_place_nearby_continue");
+	navigateToForm(center.lat, center.lng);
+};
+
+const backToConfirm = () => {
+	nearby = null;
 };
 
 // Long-press (touch) and right-click (desktop) both jump straight into
@@ -143,6 +172,20 @@ $effect(() => {
 		currentMap.off("contextmenu", onContextMenu);
 	};
 });
+
+// Moving the map moves the pin, so a shown candidate list is stale —
+// drop back to the confirm sheet.
+$effect(() => {
+	if (!map || nearby === null) return;
+	const currentMap = map;
+	const onMoveStart = () => {
+		nearby = null;
+	};
+	currentMap.on("movestart", onMoveStart);
+	return () => {
+		currentMap.off("movestart", onMoveStart);
+	};
+});
 </script>
 
 {#if active}
@@ -157,27 +200,69 @@ $effect(() => {
 	<div
 		class="absolute bottom-0 left-0 right-0 z-[1002] rounded-t-2xl bg-white p-4 pb-6 shadow-lg dark:bg-dark"
 	>
-		<p class="text-lg font-semibold text-primary dark:text-white">
-			{$_("map.placement.title")}
-		</p>
-		<p class="mt-1 text-sm text-body dark:text-offwhite">
-			{$_("map.placement.hint")}
-		</p>
-		<div class="mt-4 flex gap-3">
-			<button
-				type="button"
-				onclick={cancel}
-				class="h-12 rounded-xl border border-input px-5 font-semibold text-body dark:text-offwhite"
-			>
-				{$_("map.placement.cancel")}
-			</button>
-			<button
-				type="button"
-				onclick={confirm}
-				class="h-12 flex-1 rounded-xl bg-bitcoin font-semibold text-white hover:bg-bitcoinHover"
-			>
-				{$_("map.placement.confirm")}
-			</button>
-		</div>
+		{#if nearby === null}
+			<p class="text-lg font-semibold text-primary dark:text-white">
+				{$_("map.placement.title")}
+			</p>
+			<p class="mt-1 text-sm text-body dark:text-offwhite">
+				{$_("map.placement.hint")}
+			</p>
+			<div class="mt-4 flex gap-3">
+				<button
+					type="button"
+					onclick={cancel}
+					class="h-12 rounded-xl border border-input px-5 font-semibold text-body dark:text-offwhite"
+				>
+					{$_("map.placement.cancel")}
+				</button>
+				<button
+					type="button"
+					onclick={confirm}
+					class="h-12 flex-1 rounded-xl bg-bitcoin font-semibold text-white hover:bg-bitcoinHover"
+				>
+					{$_("map.placement.confirm")}
+				</button>
+			</div>
+		{:else}
+			<p class="text-lg font-semibold text-primary dark:text-white">
+				{$_("map.placement.nearbyTitle")}
+			</p>
+			<p class="mt-1 text-sm text-body dark:text-offwhite">
+				{$_("map.placement.nearbyHint")}
+			</p>
+			<ul class="mt-3 max-h-40 space-y-1 overflow-y-auto">
+				{#each nearby as { place, distanceM } (place.id)}
+					<li>
+						<a
+							href="/merchant/{place.id}"
+							class="flex items-baseline justify-between gap-3 rounded-lg px-2 py-1.5 hover:underline"
+						>
+							<span class="font-semibold text-link"
+								>{place.name ?? $_("map.placement.nearbyUnnamed")}</span
+							>
+							<span class="shrink-0 text-sm text-body dark:text-offwhite"
+								>{Math.round(distanceM)} m</span
+							>
+						</a>
+					</li>
+				{/each}
+			</ul>
+			<div class="mt-4 flex gap-3">
+				<button
+					type="button"
+					onclick={backToConfirm}
+					class="h-12 rounded-xl border border-input px-5 font-semibold text-body dark:text-offwhite"
+				>
+					{$_("map.placement.nearbyBack")}
+				</button>
+				<button
+					type="button"
+					onclick={addAnyway}
+					class="h-12 flex-1 rounded-xl bg-bitcoin font-semibold text-white hover:bg-bitcoinHover"
+				>
+					{$_("map.placement.nearbyContinue")}
+				</button>
+			</div>
+		{/if}
 	</div>
 {/if}

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -10,7 +10,11 @@ import PlacementPinIcon from "$components/PlacementPinIcon.svelte";
 import { trackEvent } from "$lib/analytics";
 import { _ } from "$lib/i18n";
 import type { NearbyPlace } from "$lib/placementMode";
-import { buildAddLocationUrl, findNearbyPlaces } from "$lib/placementMode";
+import {
+	buildAddLocationUrl,
+	fetchNearbyPlaceNames,
+	findNearbyPlaces,
+} from "$lib/placementMode";
 import { places } from "$lib/store";
 
 import { goto } from "$app/navigation";
@@ -22,7 +26,11 @@ type Props = {
 
 let { map, active = $bindable(false) }: Props = $props();
 
-let nearby: NearbyPlace[] | null = $state(null);
+// Raw (non-deep-proxying) state: `nearby` is always reassigned wholesale
+// (never mutated in place), and the confirm() identity guard below relies on
+// `nearby === hits` holding after a plain assignment — $state would wrap the
+// array in a new proxy on assignment, breaking that reference check.
+let nearby: NearbyPlace[] | null = $state.raw(null);
 
 // Symmetric focus management for the confirm<->interrupt swap: whichever
 // button unmounts, the surviving sheet's equivalent button takes focus
@@ -79,6 +87,16 @@ const confirm = async () => {
 	trackEvent("add_place_nearby_shown", { count: hits.length });
 	await tick();
 	backButtonEl?.focus();
+
+	const names = await fetchNearbyPlaceNames(center.lat, center.lng);
+	// Identity guard: Back, Cancel, a map move, or a newer confirm all
+	// replace/clear `nearby` — never patch a list the user left.
+	if (nearby !== hits || names.size === 0) return;
+	nearby = hits.map((hit) =>
+		names.has(hit.place.id)
+			? { ...hit, place: { ...hit.place, name: names.get(hit.place.id) } }
+			: hit,
+	);
 };
 
 const addAnyway = () => {

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -4,6 +4,7 @@ import type {
 	Map as MapLibreMap,
 	MapMouseEvent,
 } from "maplibre-gl";
+import { tick } from "svelte";
 
 import PlacementPinIcon from "$components/PlacementPinIcon.svelte";
 import { trackEvent } from "$lib/analytics";
@@ -22,6 +23,12 @@ type Props = {
 let { map, active = $bindable(false) }: Props = $props();
 
 let nearby: NearbyPlace[] | null = $state(null);
+
+// Symmetric focus management for the confirm<->interrupt swap: whichever
+// button unmounts, the surviving sheet's equivalent button takes focus
+// instead of it falling back to <body>.
+let backButtonEl: HTMLButtonElement | undefined = $state();
+let confirmButtonEl: HTMLButtonElement | undefined = $state();
 
 // Keep ?add in the URL so placement mode is linkable. Same raw
 // history.replaceState idiom as writeHashCoords ($lib/map/mapHash.ts),
@@ -60,7 +67,7 @@ const navigateToForm = (lat: number, long: number) => {
 	goto(buildAddLocationUrl(lat, long));
 };
 
-const confirm = () => {
+const confirm = async () => {
 	if (!map) return;
 	const center = map.getCenter();
 	const hits = findNearbyPlaces(center.lat, center.lng, $places);
@@ -70,6 +77,8 @@ const confirm = () => {
 	}
 	nearby = hits;
 	trackEvent("add_place_nearby_shown", { count: hits.length });
+	await tick();
+	backButtonEl?.focus();
 };
 
 const addAnyway = () => {
@@ -79,8 +88,10 @@ const addAnyway = () => {
 	navigateToForm(center.lat, center.lng);
 };
 
-const backToConfirm = () => {
+const backToConfirm = async () => {
 	nearby = null;
+	await tick();
+	confirmButtonEl?.focus();
 };
 
 // Long-press (touch) and right-click (desktop) both jump straight into
@@ -216,6 +227,7 @@ $effect(() => {
 					{$_("map.placement.cancel")}
 				</button>
 				<button
+					bind:this={confirmButtonEl}
 					type="button"
 					onclick={confirm}
 					class="h-12 flex-1 rounded-xl bg-bitcoin font-semibold text-white hover:bg-bitcoinHover"
@@ -235,10 +247,14 @@ $effect(() => {
 					<li>
 						<a
 							href="/merchant/{place.id}"
+							onclick={() =>
+								trackEvent("add_place_nearby_candidate_click", {
+									placeId: place.id,
+								})}
 							class="flex items-baseline justify-between gap-3 rounded-lg px-2 py-1.5 hover:underline"
 						>
 							<span class="font-semibold text-link"
-								>{place.name ?? $_("map.placement.nearbyUnnamed")}</span
+								>{place.name || $_("map.placement.nearbyUnnamed")}</span
 							>
 							<span class="shrink-0 text-sm text-body dark:text-offwhite"
 								>{Math.round(distanceM)} m</span
@@ -249,6 +265,7 @@ $effect(() => {
 			</ul>
 			<div class="mt-4 flex gap-3">
 				<button
+					bind:this={backButtonEl}
 					type="button"
 					onclick={backToConfirm}
 					class="h-12 rounded-xl border border-input px-5 font-semibold text-body dark:text-offwhite"

--- a/tests/map-placement-dedupe.spec.ts
+++ b/tests/map-placement-dedupe.spec.ts
@@ -6,7 +6,11 @@ import { stubMapData, waitForMarkersToLoad } from './helpers';
 // Step 3 of the add-location redesign (#1134): confirming a placement pin
 // near existing places interrupts with a duplicate check before the form.
 // Hermetic via stubMapData — Stub Cafe (~6 m from the shared viewport
-// center) is the only STUB_PLACES entry inside the 75 m radius.
+// center) is the only STUB_PLACES entry inside the 75 m radius. The static
+// feed carries no `name` field in production, so the first test stubs
+// name-less places and layers a /v4/places/search/ route on top (registered
+// after stubMapData so it wins) to supply the candidate's name, mirroring
+// how the interrupt actually resolves names at show time.
 test.describe('Placement dedupe interrupt', () => {
 	test.use({ serviceWorkers: 'block' });
 
@@ -22,12 +26,28 @@ test.describe('Placement dedupe interrupt', () => {
 	test('confirm near an existing place shows the interrupt; Back returns', async ({
 		page
 	}) => {
-		await stubMapData(page);
+		// Name-less places, matching the real static feed (no `name` key).
+		await stubMapData(page, [
+			{ id: 1, lat: 42.2762, lon: 42.7024, icon: 'restaurant' },
+			{ id: 2, lat: 42.277, lon: 42.703, icon: 'question_mark' },
+			{ id: 3, lat: 42.2755, lon: 42.7018, icon: 'cafe' }
+		]);
+		// Registered after stubMapData so this route wins (Playwright matches
+		// routes in reverse registration order) and supplies the candidate name
+		// the interrupt fetches at show time.
+		await page.route('**/v4/places/search/**', (route) =>
+			route.fulfill({
+				status: 200,
+				contentType: 'application/json',
+				body: JSON.stringify([{ id: 1, name: 'Stub Cafe' }])
+			})
+		);
 		await startPlacement(page);
 
 		await page.getByRole('button', { name: 'Add a place here' }).click();
 		await expect(page.getByText('Is it one of these?')).toBeVisible();
 		// Only the in-radius candidate is listed, linked to its merchant page.
+		// The name arrives via the radius search stub, not the (name-less) feed.
 		const candidate = page.getByRole('link', { name: /Stub Cafe/ });
 		await expect(candidate).toHaveAttribute('href', '/merchant/1');
 		await expect(page.getByRole('link', { name: /Stub Shop/ })).toHaveCount(0);
@@ -61,5 +81,24 @@ test.describe('Placement dedupe interrupt', () => {
 
 		await page.getByRole('button', { name: 'Add a place here' }).click();
 		await expect(page).toHaveURL(/\/add-location\?lat=42\.27\d+&long=42\.70\d+/);
+	});
+
+	test('falls back to Unnamed place when the name lookup returns nothing', async ({
+		page
+	}) => {
+		// Name-less places, matching the real static feed (no `name` key). No
+		// extra search route — stubMapData's catch-all already answers [].
+		await stubMapData(page, [
+			{ id: 1, lat: 42.2762, lon: 42.7024, icon: 'restaurant' },
+			{ id: 2, lat: 42.277, lon: 42.703, icon: 'question_mark' },
+			{ id: 3, lat: 42.2755, lon: 42.7018, icon: 'cafe' }
+		]);
+		await startPlacement(page);
+
+		await page.getByRole('button', { name: 'Add a place here' }).click();
+		await expect(page.getByText('Is it one of these?')).toBeVisible();
+		const candidate = page.getByRole('link', { name: /Unnamed place/ });
+		await expect(candidate).toBeVisible();
+		await expect(candidate).toHaveAttribute('href', '/merchant/1');
 	});
 });

--- a/tests/map-placement-dedupe.spec.ts
+++ b/tests/map-placement-dedupe.spec.ts
@@ -1,0 +1,65 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+import { stubMapData, waitForMarkersToLoad } from './helpers';
+
+// Step 3 of the add-location redesign (#1134): confirming a placement pin
+// near existing places interrupts with a duplicate check before the form.
+// Hermetic via stubMapData — Stub Cafe (~6 m from the shared viewport
+// center) is the only STUB_PLACES entry inside the 75 m radius.
+test.describe('Placement dedupe interrupt', () => {
+	test.use({ serviceWorkers: 'block' });
+
+	const startPlacement = async (page: Page) => {
+		await page.setViewportSize({ width: 1280, height: 720 });
+		await page.goto('/map#17/42.2762511/42.7024218', { waitUntil: 'load' });
+		await waitForMarkersToLoad(page, { skipApiWait: true });
+		await page.getByRole('button', { name: /^menu$/i }).click();
+		await page.getByRole('button', { name: 'Add location' }).click();
+		await expect(page.getByText('Place the pin')).toBeVisible();
+	};
+
+	test('confirm near an existing place shows the interrupt; Back returns', async ({
+		page
+	}) => {
+		await stubMapData(page);
+		await startPlacement(page);
+
+		await page.getByRole('button', { name: 'Add a place here' }).click();
+		await expect(page.getByText('Is it one of these?')).toBeVisible();
+		// Only the in-radius candidate is listed, linked to its merchant page.
+		const candidate = page.getByRole('link', { name: /Stub Cafe/ });
+		await expect(candidate).toHaveAttribute('href', '/merchant/1');
+		await expect(page.getByRole('link', { name: /Stub Shop/ })).toHaveCount(0);
+		// No navigation happened yet.
+		await expect(page).toHaveURL(/\/map/);
+
+		await page.getByRole('button', { name: 'Back' }).click();
+		await expect(page.getByText('Place the pin')).toBeVisible();
+		await expect(page.getByText('Is it one of these?')).toBeHidden();
+	});
+
+	test('add-anyway continues to the form with the pin coords', async ({
+		page
+	}) => {
+		await stubMapData(page);
+		await startPlacement(page);
+
+		await page.getByRole('button', { name: 'Add a place here' }).click();
+		await page
+			.getByRole('button', { name: 'None of these — add a new place' })
+			.click();
+		await expect(page).toHaveURL(/\/add-location\?lat=42\.27\d+&long=42\.70\d+/);
+	});
+
+	test('no nearby places goes straight to the form', async ({ page }) => {
+		// One stub place far outside the radius — markers load, no candidates.
+		await stubMapData(page, [
+			{ id: 9, lat: 42.3, lon: 42.75, icon: 'cafe', name: 'Far Place' }
+		]);
+		await startPlacement(page);
+
+		await page.getByRole('button', { name: 'Add a place here' }).click();
+		await expect(page).toHaveURL(/\/add-location\?lat=42\.27\d+&long=42\.70\d+/);
+	});
+});

--- a/tests/map-placement-dedupe.spec.ts
+++ b/tests/map-placement-dedupe.spec.ts
@@ -50,7 +50,9 @@ test.describe('Placement dedupe interrupt', () => {
 		// The name arrives via the radius search stub, not the (name-less) feed.
 		const candidate = page.getByRole('link', { name: /Stub Cafe/ });
 		await expect(candidate).toHaveAttribute('href', '/merchant/1');
-		await expect(page.getByRole('link', { name: /Stub Shop/ })).toHaveCount(0);
+		// Radius filter: of the three stub places only id 1 (~6 m) is inside
+		// 75 m — exactly one candidate row renders.
+		await expect(page.locator('a[href^="/merchant/"]')).toHaveCount(1);
 		// No navigation happened yet.
 		await expect(page).toHaveURL(/\/map/);
 


### PR DESCRIPTION
## Motivation

<img width="1132" height="676" alt="image" src="https://github.com/user-attachments/assets/dace3c88-6b72-4531-b3af-c9b4ec796ebe" />


With the `submit_place` pipeline live (#1279), every duplicate submission now costs a supertagger a Gitea ticket round-trip to catch and close. This is step 3 of the add-location redesign ladder, following #1276, #1277, #1279, and #1289: before a placed pin hands off to the add-location form, check whether it's likely a duplicate and give the user a chance to link to an existing place instead of filing a new one.

## Behavior

- On placement confirm, existing (non-deleted) places within a 75 m radius of the pin are surfaced, closest first, capped at 5 candidates.
- If none are found, confirm goes straight to the form as before.
- If candidates exist, an interrupt sheet ("Is it one of these?") lists them; each candidate links to its merchant page so the user can check it in a new context without losing placement state.
- **Back** returns to the placement pin sheet.
- **None of these — add a new place** ("add-anyway") continues to the form with the pin's coordinates.
- Moving the map while the interrupt is open resets the candidate list (it's re-derived from the pin's current position).
- Duplicate detection needs no new API calls: candidates are computed client-side from the map's existing places store, which deliberately carries no `name` field (map-perf constraint). Candidate names are the one exception — they're fetched at interrupt-show time via the existing `/v4/places/search/` radius endpoint, falling back to "Unnamed place" if the lookup fails or returns nothing.
- If the places store is empty or still syncing, no candidates are found and confirm goes straight to the form — the same behavior as before this feature.

## Analytics

- `add_place_nearby_shown` — fires when the interrupt is shown, with a `count` of candidates.
- `add_place_nearby_continue` — fires when the user picks add-anyway.
- `add_place_nearby_candidate_click` — fires when the user opens a listed candidate's merchant page; this is the feature's success outcome, a duplicate averted.
- `add_place_confirm` keeps its existing meaning: "handed off to the form." It now fires on both the direct path (no candidates) and the add-anyway path, so the funnel metric is unchanged by the interrupt.

## i18n

The whole `map.placement` namespace (step-1 confirm sheet + this interrupt) is now translated in all 8 non-English locales, matching each file's tone and diacritic conventions — translations are machine-assisted, native-speaker review welcome.

## Testing

New spec `tests/map-placement-dedupe.spec.ts` covers all three paths (interrupt shown + Back, add-anyway, no-nearby-places) against the hermetic `stubMapData` fixture. Full checklist (format, check, typecheck, lint, unit tests) and the full Playwright suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjZ7qPmjDm85vTn9MbS2uS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added nearby-place checks when placing a pin to help prevent duplicate locations.
  * Nearby matches now show distance information, with options to open an existing place, go back, or continue adding a new one.
  * Added merchant address copying with confirmation feedback.
  * Added placement-flow support across English, Bulgarian, German, Spanish, French, Italian, Dutch, Brazilian Portuguese, and Russian.

* **Tests**
  * Added coverage for proximity filtering, result limits, deleted places, empty results, name lookup failures, and placement-flow navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


