### PR TITLE
refactor(map): drop dead data-refresh state left by #1091

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -28,7 +28,6 @@ export const placesById = derived(
 	($places) => new Map($places.map((p) => [p.id, p])),
 );
 export const placesError = writable("");
-export const placesSyncCount = writable(0);
 
 // Progress tracking for places sync
 export const placesLoadingStatus = writable<string>(""); // e.g. "Downloading places...", "Processing data..."
@@ -59,8 +58,6 @@ export const reports: Writable<Report[]> = writable([]);
 export const reportError = writable("");
 
 export const syncStatus: Writable<boolean> = writable();
-
-export const mapUpdates = writable(false);
 
 export const selectedMerchant: Writable<Place | null> = writable(null);
 

--- a/src/lib/sync/places.ts
+++ b/src/lib/sync/places.ts
@@ -10,13 +10,11 @@ import {
 	primePlaceDetails,
 } from "$lib/placeDetails";
 import {
-	mapUpdates,
 	paymentTagsLoaded,
 	places,
 	placesError,
 	placesLoadingProgress,
 	placesLoadingStatus,
-	placesSyncCount,
 	verifiedDatesLoaded,
 } from "$lib/store";
 import { clearTables } from "$lib/sync/clearTables";
@@ -308,10 +306,6 @@ export const elementsSync = async () => {
 
 		await Promise.resolve(cachedPlaces)
 			.then(async (cachedPlaces) => {
-				// add to sync count to only show data refresh after initial load
-				const count = get(placesSyncCount);
-				placesSyncCount.set(count + 1);
-
 				let placesData: Place[] = [];
 
 				// Step 1: Get base data from static CDN if no cache exists
@@ -486,11 +480,6 @@ export const elementsSync = async () => {
 							updatedPlaceIds,
 							recentUpdates,
 						);
-
-						// Show refresh indicator if we got updates and had cached data
-						if (cachedPlaces) {
-							mapUpdates.set(true);
-						}
 					}
 
 					apiSucceeded = true;
@@ -583,9 +572,6 @@ export const elementsSync = async () => {
 				console.error(err);
 
 				// Fallback: try to load from static CDN
-				const count = get(placesSyncCount);
-				placesSyncCount.set(count + 1);
-
 				try {
 					// Fetch as text to parse in worker
 					const staticResponse = await api.get(


### PR DESCRIPTION
## What

`#1091` removed `DataRefreshControl`, its registration, the `data_refresh_click` analytics event, and the `dataRefreshAvailable` / `dataRefreshAlt` i18n keys — but left the two stores that fed the control behind.

This deletes them.

| Symbol | Was written | Was read |
|---|---|---|
| `mapUpdates` (`src/lib/store.ts`) | `sync/places.ts` — `mapUpdates.set(true)` after a cached-data update | nowhere |
| `placesSyncCount` (`src/lib/store.ts`) | `sync/places.ts`, two sites | only to increment itself |

`placesSyncCount`'s own comment gave it away — *"add to sync count to only show data refresh after initial load"* — the "data refresh" being the control that no longer exists.

## Why

No subscribers, so no behavior change. It's write-only state that reads as live wiring when you're tracing the places sync.

## Notes

- `get` stays imported in `sync/places.ts` — still used by the `verifiedDatesLoaded` / `paymentTagsLoaded` enrichment paths.
- The `data_refresh_click` event is already absent from `EventName` in `src/lib/analytics.ts`; nothing here touches analytics. Historical rows for it remain in Umami, as expected.

## Gate

`format:fix` (no changes) · `check` 0 errors / 0 warnings · `typecheck` clean · `lint` clean · `vitest` 684 passed (39 files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed obsolete map refresh indicators from place synchronization.
  * Place updates no longer trigger unnecessary refresh counters or cached-data refresh states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
