### PR TITLE
feat(merchant-drawer): add copy button to the merchant address

### DIFF
--- a/src/components/CopyButton.svelte
+++ b/src/components/CopyButton.svelte
@@ -13,7 +13,6 @@ type Props = {
 	label?: string;
 	// Announced/shown in place of `label` while the copy confirmation is up.
 	copiedLabel?: string;
-	iconType?: "fa" | "material";
 	class?: string;
 };
 
@@ -22,11 +21,11 @@ let {
 	size = "24",
 	label = undefined,
 	copiedLabel = undefined,
-	iconType = "fa",
 	class: className = "text-link transition-colors hover:text-hover",
 }: Props = $props();
 
 let copied = $state(false);
+const currentLabel = $derived(copied ? (copiedLabel ?? label) : label);
 let resetTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const copy = async (field: string) => {
@@ -59,13 +58,13 @@ onDestroy(() => clearTimeout(resetTimeout));
 <button
 	type="button"
 	class={className}
-	aria-label={copied ? (copiedLabel ?? label) : label}
-	title={copied ? (copiedLabel ?? label) : label}
+	aria-label={currentLabel}
+	title={currentLabel}
 	onclick={() => copy(value)}
 >
 	{#if copied}
-		<Icon type={iconType} icon="check" w={size} h={size} />
+		<Icon icon="check" w={size} h={size} />
 	{:else}
-		<Icon type={iconType} icon={iconType === 'material' ? 'content_copy' : 'clipboard'} w={size} h={size} />
+		<Icon icon="content_copy" w={size} h={size} />
 	{/if}
 </button>

--- a/src/components/CopyButton.svelte
+++ b/src/components/CopyButton.svelte
@@ -1,9 +1,33 @@
 <script lang="ts">
+import { onDestroy } from "svelte";
+
 import Icon from "$components/Icon.svelte";
 
-export let value: string;
+type Props = {
+	value: string;
+	// Icon edge length in px. The drawer needs a much smaller mark than the
+	// invoice/donation call-outs this component was originally built for.
+	size?: string;
+	// Accessible name, also used as the hover tooltip. Icon-only buttons have
+	// no text content, so without this the button is unnamed for screen readers.
+	label?: string;
+	// Announced/shown in place of `label` while the copy confirmation is up.
+	copiedLabel?: string;
+	iconType?: "fa" | "material";
+	class?: string;
+};
 
-let copied = false;
+let {
+	value,
+	size = "24",
+	label = undefined,
+	copiedLabel = undefined,
+	iconType = "fa",
+	class: className = "text-link transition-colors hover:text-hover",
+}: Props = $props();
+
+let copied = $state(false);
+let resetTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const copy = async (field: string) => {
 	let success = false;
@@ -24,15 +48,24 @@ const copy = async (field: string) => {
 	}
 	if (success) {
 		copied = true;
-		setTimeout(() => (copied = false), 2100);
+		clearTimeout(resetTimeout);
+		resetTimeout = setTimeout(() => (copied = false), 2100);
 	}
 };
+
+onDestroy(() => clearTimeout(resetTimeout));
 </script>
 
-<button class="text-link transition-colors hover:text-hover" on:click={() => copy(value)}>
+<button
+	type="button"
+	class={className}
+	aria-label={copied ? (copiedLabel ?? label) : label}
+	title={copied ? (copiedLabel ?? label) : label}
+	onclick={() => copy(value)}
+>
 	{#if copied}
-		<Icon type="fa" icon="check" w="24" h="24" />
+		<Icon type={iconType} icon="check" w={size} h={size} />
 	{:else}
-		<Icon type="fa" icon="clipboard" w="24" h="24" />
+		<Icon type={iconType} icon={iconType === 'material' ? 'content_copy' : 'clipboard'} w={size} h={size} />
 	{/if}
 </button>

--- a/src/components/MerchantDetailsContent.svelte
+++ b/src/components/MerchantDetailsContent.svelte
@@ -4,6 +4,7 @@ import { onDestroy } from "svelte";
 
 import BoostCard from "$components/BoostCard.svelte";
 import CompanionAppPill from "$components/CompanionAppPill.svelte";
+import CopyButton from "$components/CopyButton.svelte";
 import Icon from "$components/Icon.svelte";
 import MerchantComment from "$components/MerchantComment.svelte";
 import MerchantIssuesRow from "$components/MerchantIssuesRow.svelte";
@@ -159,8 +160,19 @@ async function fetchComments(placeId: number) {
 			{/if}
 
 			{#if merchant.address}
-				<p class="mt-0.5 text-sm text-body dark:text-white" title={$_('merchant.address')}>
-					{merchant.address}
+				<p
+					class="mt-0.5 flex items-start gap-1 text-sm text-body dark:text-white"
+					title={$_('merchant.address')}
+				>
+					<span class="min-w-0">{merchant.address}</span>
+					<CopyButton
+						value={merchant.address}
+						size="14"
+						iconType="material"
+						label={$_('merchant.copyAddress')}
+						copiedLabel={$_('merchant.addressCopied')}
+						class="-mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-body/60 transition-colors hover:bg-gray-100 hover:text-link dark:text-white/60 dark:hover:bg-white/10 dark:hover:text-white"
+					/>
 				</p>
 			{:else if isLoading}
 				<div class="mt-1 h-5 w-1/2 animate-pulse rounded bg-link/50"></div>

--- a/src/components/MerchantDetailsContent.svelte
+++ b/src/components/MerchantDetailsContent.svelte
@@ -168,7 +168,6 @@ async function fetchComments(placeId: number) {
 					<CopyButton
 						value={merchant.address}
 						size="14"
-						iconType="material"
 						label={$_('merchant.copyAddress')}
 						copiedLabel={$_('merchant.addressCopied')}
 						class="-mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-body/60 transition-colors hover:bg-gray-100 hover:text-link dark:text-white/60 dark:hover:bg-white/10 dark:hover:text-white"

--- a/src/lib/i18n/locales/bg.json
+++ b/src/lib/i18n/locales/bg.json
@@ -600,6 +600,8 @@
 		"links": "Връзки",
 		"activity": "Активност на {name}",
 		"address": "Адрес",
+		"copyAddress": "Копиране на адреса",
+		"addressCopied": "Адресът е копиран",
 		"call": "Обади се",
 		"comments": "Коментари",
 		"commentsCount": "Коментари ({count})",

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -152,6 +152,8 @@
 		"deletedDetail": "Die unten angezeigten Daten sind veraltet und dienen nur als Referenz.",
 		"merchantName": "Händlername",
 		"address": "Adresse",
+		"copyAddress": "Adresse kopieren",
+		"addressCopied": "Adresse kopiert",
 		"openingHours": "Öffnungszeiten",
 		"openNow": "Jetzt geöffnet",
 		"closed": "Geschlossen",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -241,6 +241,8 @@
 		"deletedDetail": "The data shown below is outdated and for reference only.",
 		"merchantName": "Merchant name",
 		"address": "Address",
+		"copyAddress": "Copy address",
+		"addressCopied": "Address copied",
 		"openingHours": "Opening hours",
 		"openNow": "Open now",
 		"closed": "Closed",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -152,6 +152,8 @@
 		"deletedDetail": "Los datos mostrados a continuación están desactualizados y son solo de referencia.",
 		"merchantName": "Nombre del comercio",
 		"address": "Dirección",
+		"copyAddress": "Copiar dirección",
+		"addressCopied": "Dirección copiada",
 		"openingHours": "Horario de apertura",
 		"openNow": "Abierto ahora",
 		"closed": "Cerrado",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -152,6 +152,8 @@
 		"deletedDetail": "Les données affichées ci-dessous sont obsolètes et fournies à titre indicatif uniquement.",
 		"merchantName": "Nom du commerce",
 		"address": "Adresse",
+		"copyAddress": "Copier l'adresse",
+		"addressCopied": "Adresse copiée",
 		"openingHours": "Horaires d'ouverture",
 		"openNow": "Ouvert",
 		"closed": "Fermé",

--- a/src/lib/i18n/locales/it.json
+++ b/src/lib/i18n/locales/it.json
@@ -241,6 +241,8 @@
 		"deletedDetail": "I dati mostrati di seguito sono obsoleti e solo a scopo di riferimento.",
 		"merchantName": "Nome del commerciante",
 		"address": "Indirizzo",
+		"copyAddress": "Copia indirizzo",
+		"addressCopied": "Indirizzo copiato",
 		"openingHours": "Orari di apertura",
 		"openNow": "Aperto ora",
 		"closed": "Chiuso",

--- a/src/lib/i18n/locales/nl.json
+++ b/src/lib/i18n/locales/nl.json
@@ -241,6 +241,8 @@
 		"deletedDetail": "De onderstaande gegevens zijn niet meer actueel en staan er puur ter informatie.",
 		"merchantName": "Naam ondernemer",
 		"address": "Adres",
+		"copyAddress": "Adres kopiëren",
+		"addressCopied": "Adres gekopieerd",
 		"openingHours": "Openingstijden",
 		"openNow": "Nu open",
 		"closed": "Gesloten",

--- a/src/lib/i18n/locales/pt-BR.json
+++ b/src/lib/i18n/locales/pt-BR.json
@@ -152,6 +152,8 @@
 		"deletedDetail": "Os dados mostrados abaixo estão desatualizados e são apenas para referência.",
 		"merchantName": "Nome do comerciante",
 		"address": "Endereço",
+		"copyAddress": "Copiar endereço",
+		"addressCopied": "Endereço copiado",
 		"openingHours": "Horário de funcionamento",
 		"openNow": "Aberto agora",
 		"closed": "Fechado",

--- a/src/lib/i18n/locales/ru.json
+++ b/src/lib/i18n/locales/ru.json
@@ -152,6 +152,8 @@
 		"deletedDetail": "Данные ниже устарели и приведены только для справки.",
 		"merchantName": "Название торговца",
 		"address": "Адрес",
+		"copyAddress": "Копировать адрес",
+		"addressCopied": "Адрес скопирован",
 		"openingHours": "Часы работы",
 		"openNow": "Открыто",
 		"closed": "Закрыто",


### PR DESCRIPTION
## Why

People want the merchant address as text so they can paste it into their own maps or directions app.

Today the address is a plain `<p>`. On mobile that text is effectively un-selectable: it sits inside a bottom sheet whose `pointerdown` / `touchmove` handlers fight long-press-to-select, so there is no reliable way to get the address out of the drawer.

## What

A small clipboard button after the address, swapping to a check for ~2s on success.

Because it lands in `MerchantDetailsContent.svelte`, it shows up in all three places that component backs:

- the desktop map drawer
- the mobile map drawer
- the area merchant drawer

```
 ┌────┐  Bitcoin Cafe
 │ ☕ │  Hauptstr. 12, 20095 Hamburg  ⧉
 └────┘  ● Open now
```

## Commits

1. **`refactor(copy-button)`** — `CopyButton` was hardcoded to a 24px FontAwesome clipboard in link colour with **no accessible name**. Parameterised `size`, `class` and the `aria-label`/`title`, converted to runes mode, and cleared the reset timeout on destroy. Defaults keep the existing invoice and donation call sites rendering identically.
2. **`feat(merchant-drawer)`** — the address affordance itself, plus `merchant.copyAddress` / `merchant.addressCopied` added to all 9 locales.
3. **`refactor(copy-button)`** — settle on one copy icon app-wide (see below).

## Details

- **One copy icon everywhere: material `content_copy`.** `BackupCredentials` already uses it twice, and material is the dominant set in the repo (91 uses vs 55, most of the FA ones being brand glyphs). `CopyButton`'s FA `clipboard` was the only one of its kind, so the two existing call sites move to `content_copy` too. One visible side effect: in `DonationOption.svelte:52` the copy button now sits next to an FA `qrcode`, so an outlined icon beside a filled one — minor, and worth it for a single copy affordance app-wide.
- 24px tap target (`h-6 w-6`) around the 14px mark, negatively offset so it stays optically aligned with the first line of a wrapping address.
- Muted `text-body/60`, so it reads as a secondary affordance rather than competing with the merchant name link.
- The address text stays plain selectable text — the button is additive.

## Testing

`format:fix` · `check` (0 errors) · `typecheck` · `lint` · `test --run` (692 passing) all green. No component test harness exists in this repo yet (vitest only covers `src/lib`), so the interaction wants a look on the deploy preview.

## Notes / follow-ups

- **`shareMerchant` can show a false success.** `src/lib/utils.ts:235` fires `navigator.clipboard.writeText` with no `await`, no `.catch()` and no fallback, while both callers (`MerchantDetailsContent.svelte:267`, `MerchantActionChips.svelte:20`) show their ✓ confirmation unconditionally. If the write rejects, the user sees "copied" with an empty clipboard, plus an unhandled rejection. Not touched here — separate PR.
- **Three clipboard implementations at three reliability tiers** — `CopyButton` (API + `execCommand` fallback + success gate), `BackupCredentials:17` (API + toast, no fallback), `utils.ts:235` (fire-and-forget). Worth extracting to `$lib/clipboard.ts`; as a bonus that puts the logic under vitest's `src/lib` coverage.
- **`MerchantDetailsContent.svelte` left in legacy mode.** The boy-scout rule in `CLAUDE.md` points at converting it, but this is a ~12-line addition to a 388-line file backing three drawers — an unverified whole-file conversion felt like the wrong thing to bundle with it. Happy to do it separately.
- **The `Navigate` action is `geo:{lat},{lon}`** (`MerchantDetailsContent.svelte:229`). Works on Android, does nothing on iOS Safari or desktop — plausibly *why* people are reaching for copy/paste. A universal `https://` maps URL with name + address would cover every platform.
- The two pre-existing `CopyButton` call sites (invoice, donation) still pass no `label`, so those buttons remain unnamed for screen readers. Each would need its own i18n key.