### PR TITLE
fix(icons): resolve destruction, dresser and adult_content to material-symbols

### DIFF
--- a/src/lib/map/maplibreSprites.test.ts
+++ b/src/lib/map/maplibreSprites.test.ts
@@ -8,6 +8,7 @@ import {
 	PIN_FILL_REGULAR,
 	PIN_FILLS,
 	pinVariantFor,
+	resolveIconifyName,
 	spriteName,
 } from "./maplibreSprites";
 
@@ -79,4 +80,28 @@ describe("sprite naming and fills", () => {
 		const svg = buildCompositeSvg("<svg></svg>", "nv");
 		expect(svg).toContain(`fill="${PIN_FILLS.nv}"`);
 	});
+});
+
+describe("resolveIconifyName", () => {
+	it("substitutes the Bitcoin glyph for the untagged placeholder", () => {
+		expect(resolveIconifyName("question_mark")).toBe(
+			"material-symbols:currency-bitcoin",
+		);
+	});
+
+	it("uses the default ic:outline form for ids that exist there", () => {
+		expect(resolveIconifyName("local_cafe")).toBe("ic:outline-local-cafe");
+		expect(resolveIconifyName("18_up_rating")).toBe("ic:outline-18-up-rating");
+	});
+
+	// These ids have no ic:outline counterpart, so without a table entry they
+	// resolve to a 404 name. The sprite pipeline papers over that with its
+	// material-symbols retry, but Icon.svelte has no fallback and renders
+	// nothing at all — a blank icon in the list, drawer and area cards.
+	it.each(["destruction", "dresser", "adult_content"])(
+		"keeps %s off the broken ic:outline path",
+		(icon) => {
+			expect(resolveIconifyName(icon)).toMatch(/^material-symbols:/);
+		},
+	);
 });

--- a/src/lib/materialIcons.ts
+++ b/src/lib/materialIcons.ts
@@ -23,9 +23,15 @@ export const materialExceptions: Record<string, string> = {
 	potted_plant: "material-symbols:potted-plant-outline",
 	footprint: "material-symbols:footprint-outline",
 	water_pump: "material-symbols:water-pump-outline",
-	adult_content: "material-symbols:explicit-outline",
 	raven: "material-symbols:raven-outline",
 	surgical: "material-symbols:surgical-outline",
+	destruction: "material-symbols:destruction-outline",
+	dresser: "material-symbols:dresser-outline",
+	// Renamed upstream to 18_up_rating (which needs no entry — ic:outline has
+	// it). Kept because the static CDN bulk feed still serves the old id, and
+	// cold-cache clients derive updated_since from that file's Last-Modified —
+	// which is NEWER than the rename, so the delta never corrects them.
+	adult_content: "material-symbols:18-up-rating-outline",
 };
 
 // Resolves a Material icon name to its Iconify name: an explicit override


### PR DESCRIPTION
An upstream icon-id migration on 2026-08-31 renamed the `icon` field on 41 places. Two of the new ids don't resolve.

## The break

`resolveMaterialIcon` falls through to `ic:outline-<id>` for anything not in the exception table. Two new ids have no `ic:outline` counterpart:

| id | places | `ic:outline-*` | `material-symbols:*` |
|---|---|---|---|
| `destruction` | 6 | 404 | 200 |
| `dresser` | 2 | 404 | 200 |

Map pins survive — `fetchIconInnerSvg` retries against `material-symbols:<stem>`, at the cost of a wasted round-trip per sprite. Nothing else does: `Icon.svelte` has no fallback, and `@iconify/svelte` renders *nothing* on a miss (its render is guarded by `{#if data}`, no placeholder). So the merchant list item, merchant drawer and area merchant card showed a blank where the icon should be.

I swept all 158 icon ids currently served by `/v4/places` against the Iconify API — these were the only two failures.

## Why `adult_content` stays

The same migration renamed `adult_content` → `18_up_rating`. The new id needs no entry (`ic:outline-18-up-rating` exists), but the old entry can't be deleted yet:

- `cdn.static.btcmap.org/api/v4/places.json` still serves the **old** ids, despite a `Last-Modified` three hours *after* the rename.
- Cold-cache clients derive `updated_since` from exactly that header (`getStaticFileDate`, `src/lib/sync/places.ts:68`), so the delta query starts after the rename timestamp and never picks it up.

Net effect: fresh visitors keep `adult_content` until the CDN snapshot catches up, while returning visitors with a warm cache already have `18_up_rating`. Repointing the entry from `explicit-outline` to `18-up-rating-outline` means both cohorts see the same glyph for the same merchant — and it matches what the id now says. The entry becomes safe to drop once the static feed catches up.

## Test plan

- [x] `pnpm run format:fix`
- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test --run` — 697 passed
- [x] Every exception-table target verified against the Iconify API (200)

Added `resolveIconifyName` coverage asserting these three ids stay off the `ic:outline` path — the table had no test before, so a future cleanup could silently reintroduce the blank icon.