### PR TITLE
refactor(map): extract MapPanelShell + convert MerchantDrawerDesktop to runes #1208

### DIFF
--- a/src/routes/map/components/AddPlaceFormPanel.svelte
+++ b/src/routes/map/components/AddPlaceFormPanel.svelte
@@ -1,20 +1,16 @@
 <script lang="ts">
-import { fly } from "svelte/transition";
-
 import AddLocationForm from "$components/add-location/AddLocationForm.svelte";
 import CloseButton from "$components/CloseButton.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
-import { MAP_PANEL_MARGIN, MERCHANT_DRAWER_WIDTH } from "$lib/constants";
 import { _ } from "$lib/i18n";
 
-// In-map host for the add-location form (#1134). Desktop wears the
-// merchant drawer's exact dialect — left-docked card, same sizing and
-// chrome — so the map keeps one panel language; the map and its
+import MapPanelShell from "./MapPanelShell.svelte";
+
+// In-map host for the add-location form (#1134), wearing the shared
+// MapPanelShell: left-docked drawer card on desktop — the map and its
 // crosshair pin stay live beside it, and the host refreshes `coords` on
-// every settled move. Mobile is a full-screen sheet: a long form wants
-// full height and native scroll, not the peek-drawer's drag gestures.
-// (The drawers themselves stay merchant-specific — reusing their shell
-// literally would pull the #1208 hand-conversion hotspots in here.)
+// every settled move — and a full-screen sheet on mobile, since a long
+// form wants full height and native scroll, not peek-drawer gestures.
 type Props = {
 	coords: { lat: number; long: number };
 	// Back to the placement sheet (the close button and Escape).
@@ -27,10 +23,6 @@ let { coords, onclose, onaddanother, onexit }: Props = $props();
 
 let submitted = $state(false);
 
-// Mount-time is fine: a mid-session viewport-class change would only
-// soften the entry animation, nothing else.
-const desktop = window.matchMedia("(min-width: 768px)").matches;
-
 const onKeydown = (event: KeyboardEvent) => {
 	if (event.key === "Escape") {
 		event.preventDefault();
@@ -41,22 +33,13 @@ const onKeydown = (event: KeyboardEvent) => {
 
 <svelte:window onkeydown={onKeydown} />
 
-<!-- Card classes and max-height mirror MerchantDrawerDesktop verbatim,
-     attribution corner left uncovered. -->
-<section
-	aria-label={$_('addLocation.title')}
-	in:fly={desktop ? { x: -MERCHANT_DRAWER_WIDTH, duration: 300 } : { y: 200, duration: 300 }}
-	class="absolute inset-0 z-[1002] overflow-y-auto bg-white md:inset-auto md:top-3 md:left-(--drawer-left) md:max-h-[calc(100%-0.75rem-max(3rem,env(safe-area-inset-bottom)))] md:w-full md:max-w-(--drawer-w) md:rounded-lg md:shadow-lg dark:bg-dark"
-	style="--drawer-left: {MAP_PANEL_MARGIN}px; --drawer-w: {MERCHANT_DRAWER_WIDTH}px"
->
-	<div
-		class="sticky top-0 z-10 flex items-center justify-between rounded-t-lg bg-white p-2 dark:bg-dark"
-	>
+<MapPanelShell label={$_('addLocation.title')}>
+	{#snippet header()}
 		<h2 class="pl-2 text-lg font-semibold text-primary dark:text-white">
 			{$_('addLocation.title')}
 		</h2>
 		<CloseButton on:click={onclose} ariaLabel={$_('map.placement.cancel')} />
-	</div>
+	{/snippet}
 
 	{#if !submitted}
 		<div class="px-4 pb-[calc(env(safe-area-inset-bottom)+1.5rem)] md:pb-4">
@@ -95,4 +78,4 @@ const onKeydown = (event: KeyboardEvent) => {
 			</button>
 		</div>
 	{/if}
-</section>
+</MapPanelShell>

--- a/src/routes/map/components/MapPanelShell.svelte
+++ b/src/routes/map/components/MapPanelShell.svelte
@@ -4,6 +4,8 @@ import { fly } from "svelte/transition";
 
 import { MAP_PANEL_MARGIN, MERCHANT_DRAWER_WIDTH } from "$lib/constants";
 
+import { browser } from "$app/environment";
+
 // The map's one panel-card definition: desktop floating card (drawer
 // sizing, max-height leaving the attribution corner uncovered, fly-in,
 // sticky header) — full-screen sheet below md for hosts that render
@@ -33,8 +35,11 @@ let {
 }: Props = $props();
 
 // Mount-time is fine: a mid-session viewport-class change would only
-// soften the entry animation, nothing else.
-const desktop = window.matchMedia("(min-width: 768px)").matches;
+// soften the entry animation, nothing else. Both consumers instantiate
+// the shell client-side only today, but the browser guard keeps a
+// future SSR-rendered consumer from throwing here — transitions don't
+// run on the server anyway.
+const desktop = browser && window.matchMedia("(min-width: 768px)").matches;
 </script>
 
 <section

--- a/src/routes/map/components/MapPanelShell.svelte
+++ b/src/routes/map/components/MapPanelShell.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+import { fly } from "svelte/transition";
+
+import { MAP_PANEL_MARGIN, MERCHANT_DRAWER_WIDTH } from "$lib/constants";
+
+// The map's one panel-card definition: desktop floating card (drawer
+// sizing, max-height leaving the attribution corner uncovered, fly-in,
+// sticky header) — full-screen sheet below md for hosts that render
+// there. MerchantDrawerDesktop and AddPlaceFormPanel both wear it; a
+// consumer supplies the header row and body as snippets and keeps its
+// own behavior (focus, keys, history).
+type Props = {
+	label: string;
+	role?: "dialog";
+	// Desktop left offset in px — the drawer animates it with the list
+	// panel; static hosts take the default margin.
+	left?: number;
+	// A nested view (the drawer's boost screen) underlines the header.
+	headerBorder?: boolean;
+	element?: HTMLElement;
+	header: Snippet;
+	children: Snippet;
+};
+let {
+	label,
+	role,
+	left = MAP_PANEL_MARGIN,
+	headerBorder = false,
+	element = $bindable(),
+	header,
+	children,
+}: Props = $props();
+
+// Mount-time is fine: a mid-session viewport-class change would only
+// soften the entry animation, nothing else.
+const desktop = window.matchMedia("(min-width: 768px)").matches;
+</script>
+
+<section
+	bind:this={element}
+	aria-label={label}
+	{role}
+	in:fly={desktop
+		? { x: -MERCHANT_DRAWER_WIDTH, duration: 300 }
+		: { y: 200, duration: 300 }}
+	class="absolute inset-0 z-[1002] overflow-y-auto bg-white md:inset-auto md:top-3 md:left-(--panel-left) md:max-h-[calc(100%-0.75rem-max(3rem,env(safe-area-inset-bottom)))] md:w-full md:max-w-(--panel-w) md:rounded-lg md:shadow-lg md:transition-[left] md:duration-200 dark:bg-dark"
+	style="--panel-left: {left}px; --panel-w: {MERCHANT_DRAWER_WIDTH}px"
+>
+	<div
+		class="sticky top-0 z-10 flex items-center justify-between rounded-t-lg bg-white p-2 dark:bg-dark {headerBorder
+			? 'border-b border-gray-300 dark:border-white/95'
+			: ''}"
+	>
+		{@render header()}
+	</div>
+
+	{@render children()}
+</section>

--- a/src/routes/map/components/MerchantDrawerDesktop.svelte
+++ b/src/routes/map/components/MerchantDrawerDesktop.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMount, tick } from "svelte";
+import { tick } from "svelte";
 import { fly } from "svelte/transition";
 
 import BoostContent from "$components/BoostContent.svelte";
@@ -28,34 +28,40 @@ import { isUpToDate as checkUpToDate } from "$lib/verification";
 import { invalidateAll } from "$app/navigation";
 
 // ?issues worklist (#921): show the merchant's derived-issue row.
-export let showIssues = false;
+type Props = { showIssues?: boolean };
+let { showIssues = false }: Props = $props();
 
-// Derive state from centralized store
-$: isOpen = $merchantDrawer.isOpen;
-$: merchantId = $merchantDrawer.merchantId;
-$: drawerView = $merchantDrawer.drawerView;
-$: merchant = $merchantDrawer.merchant;
-$: fetchingMerchant = $merchantDrawer.isLoading;
-$: listIsOpen = $merchantList.isOpen;
+// Derive state from the centralized store
+const isOpen = $derived($merchantDrawer.isOpen);
+const merchantId = $derived($merchantDrawer.merchantId);
+const drawerView = $derived($merchantDrawer.drawerView);
+const merchant = $derived($merchantDrawer.merchant);
+const fetchingMerchant = $derived($merchantDrawer.isLoading);
+const listIsOpen = $derived($merchantList.isOpen);
 
 // Calculate drawer position based on list panel state
-$: drawerLeft = listIsOpen
-	? MAP_PANEL_MARGIN + MERCHANT_LIST_WIDTH + PANEL_DRAWER_GAP
-	: MAP_PANEL_MARGIN;
+const drawerLeft = $derived(
+	listIsOpen
+		? MAP_PANEL_MARGIN + MERCHANT_LIST_WIDTH + PANEL_DRAWER_GAP
+		: MAP_PANEL_MARGIN,
+);
 
 // Focus management - move focus to drawer when it opens
-let drawerElement: HTMLDivElement;
-$: if (isOpen && drawerElement) {
-	tick().then(() => {
-		const closeBtn = drawerElement.querySelector("button");
-		closeBtn?.focus();
-	});
-}
+let drawerElement = $state<HTMLDivElement>();
+$effect(() => {
+	if (isOpen && drawerElement) {
+		const el = drawerElement;
+		tick().then(() => {
+			const closeBtn = el.querySelector("button");
+			closeBtn?.focus();
+		});
+	}
+});
 
-$: isUpToDate = checkUpToDate(merchant);
-$: isBoosted = checkBoosted(merchant);
+const isUpToDate = $derived(checkUpToDate(merchant));
+const isBoosted = $derived(checkBoosted(merchant));
 
-let boostLoading = false;
+let boostLoading = $state(false);
 const setBoostLoading = (loading: boolean) => {
 	boostLoading = loading;
 };
@@ -72,10 +78,12 @@ const goBack = () => {
 	merchantDrawer.setView("details");
 };
 
-$: if (drawerView !== "boost" && $boost !== undefined) {
-	clearBoostState();
-	boostLoading = false;
-}
+$effect(() => {
+	if (drawerView !== "boost" && $boost !== undefined) {
+		clearBoostState();
+		boostLoading = false;
+	}
+});
 
 const handleBoost = () => boostMerchant(merchant, merchantId, setBoostLoading);
 const handleBoostComplete = () =>
@@ -94,21 +102,18 @@ function handleKeydown(event: KeyboardEvent) {
 	}
 }
 
-onMount(() => {
-	window.addEventListener("keydown", handleKeydown);
-	return () => {
-		window.removeEventListener("keydown", handleKeydown);
-	};
+$effect(() => {
+	if (drawerView === "boost" && merchant) {
+		ensureBoostData(merchant, $boost);
+	}
 });
-
-$: if (drawerView === "boost" && merchant) {
-	ensureBoostData(merchant, $boost);
-}
 
 export function openDrawer(id: number) {
 	merchantDrawer.open(id, "details");
 }
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 {#if isOpen}
 	<!-- Floating drawer card - no backdrop, keep map interactive -->
@@ -130,7 +135,7 @@ export function openDrawer(id: number) {
 			{#if drawerView !== 'details'}
 				<!-- Back button for nested views -->
 				<button
-					on:click={goBack}
+					onclick={goBack}
 					class="flex items-center space-x-2 text-primary transition-colors hover:text-link dark:text-white dark:hover:text-link"
 				>
 					<Icon w="20" h="20" icon="arrow_back" type="material" />

--- a/src/routes/map/components/MerchantDrawerDesktop.svelte
+++ b/src/routes/map/components/MerchantDrawerDesktop.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { tick } from "svelte";
-import { fly } from "svelte/transition";
 
 import BoostContent from "$components/BoostContent.svelte";
 import CloseButton from "$components/CloseButton.svelte";
@@ -8,7 +7,6 @@ import Icon from "$components/Icon.svelte";
 import MerchantDetailsContent from "$components/MerchantDetailsContent.svelte";
 import {
 	MAP_PANEL_MARGIN,
-	MERCHANT_DRAWER_WIDTH,
 	MERCHANT_LIST_WIDTH,
 	PANEL_DRAWER_GAP,
 } from "$lib/constants";
@@ -25,6 +23,7 @@ import { merchantList } from "$lib/merchantListStore";
 import { boost, resetBoost } from "$lib/store";
 import { isUpToDate as checkUpToDate } from "$lib/verification";
 
+import MapPanelShell from "./MapPanelShell.svelte";
 import { invalidateAll } from "$app/navigation";
 
 // ?issues worklist (#921): show the merchant's derived-issue row.
@@ -47,7 +46,7 @@ const drawerLeft = $derived(
 );
 
 // Focus management - move focus to drawer when it opens
-let drawerElement = $state<HTMLDivElement>();
+let drawerElement = $state<HTMLElement>();
 $effect(() => {
 	if (isOpen && drawerElement) {
 		const el = drawerElement;
@@ -117,21 +116,17 @@ export function openDrawer(id: number) {
 
 {#if isOpen}
 	<!-- Floating drawer card - no backdrop, keep map interactive -->
-	<!-- Position offset by MERCHANT_LIST_WIDTH when list panel is open -->
-	<div
-		bind:this={drawerElement}
-		in:fly={{ x: -MERCHANT_DRAWER_WIDTH, duration: 300 }}
-		class="absolute top-3 z-[1002] max-h-[calc(100%-0.75rem-max(3rem,env(safe-area-inset-bottom)))] w-full overflow-y-auto rounded-lg bg-white shadow-lg transition-[left] duration-200 dark:bg-dark"
-		style="left: {drawerLeft}px; max-width: {MERCHANT_DRAWER_WIDTH}px"
+	<!-- Position offset by MERCHANT_LIST_WIDTH when list panel is open;
+	     this variant only mounts ≥md, so the shell's mobile face never
+	     shows here. -->
+	<MapPanelShell
+		bind:element={drawerElement}
+		label={$_("mapDrawer.merchantDetails")}
 		role="dialog"
-		aria-label={$_("mapDrawer.merchantDetails")}
+		left={drawerLeft}
+		headerBorder={drawerView !== "details"}
 	>
-		<div
-			class="sticky top-0 z-10 flex items-center justify-between rounded-t-lg bg-white p-2 dark:bg-dark {drawerView !==
-			'details'
-				? 'border-b border-gray-300 dark:border-white/95'
-				: ''}"
-		>
+		{#snippet header()}
 			{#if drawerView !== 'details'}
 				<!-- Back button for nested views -->
 				<button
@@ -149,7 +144,7 @@ export function openDrawer(id: number) {
 				<div></div>
 			{/if}
 			<CloseButton on:click={closeDrawer} ariaLabel={$_("mapDrawer.closeMerchantDetails")} />
-		</div>
+		{/snippet}
 
 		{#if !merchant && fetchingMerchant}
 			<!-- Loading skeleton -->
@@ -189,5 +184,5 @@ export function openDrawer(id: number) {
 				{/if}
 			</div>
 		{/if}
-	</div>
+	</MapPanelShell>
 {/if}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -95,12 +95,15 @@ export async function waitForMarkersToLoad(
 	// Poll a global hook /map exposes — `window.__mapPlacesCount` is set
 	// (with the rendered feature count) inside syncPlacesToSource each
 	// time the source is refreshed. The hook is a no-op in prod; tests
-	// pin against it.
+	// pin against it. waitForFunction's SECOND parameter is the page-
+	// function arg — the options object goes third, or the timeout
+	// silently falls back to actionTimeout (5s locally).
 	await page.waitForFunction(
 		() =>
 			(window as unknown as { __mapPlacesCount?: number }).__mapPlacesCount !==
 			undefined &&
 			(window as unknown as { __mapPlacesCount: number }).__mapPlacesCount > 0,
+		undefined,
 		{ timeout: MARKER_LOAD_TIMEOUT }
 	);
 }


### PR DESCRIPTION
## What

Queued follow-up from the #1333 review ("we have a merchant drawer — why not reuse that style instead of reinventing?"): the map gets **one** panel-card definition instead of two hand-synced copies.

1. **`test(helpers)`** — found while verifying: `waitForFunction`'s second parameter is the page-function *argument*, so the marker-wait's `{ timeout: 60000 }` was never applied and every map spec ran against the 5s local `actionTimeout`. Options moved to the third parameter — this was the suite's flake source.
2. **`refactor(map)`** — `MerchantDrawerDesktop` converted to runes mode (it is *not* a #1208 hand-conversion hotspot): `$props`/`$state`/`$derived`, the three independent reactive statements become effects, window keydown via `svelte:window`, event attributes. `openDrawer` export and legacy-child interop unchanged. Ticks its box in #1208.
3. **`refactor(map)`** — **`MapPanelShell`**: positioning (left CSS var — the drawer still animates it with the list panel), drawer sizing, the attribution-sparing max-height, fly-in, sticky header; header/body as snippets, `role`/`headerBorder`/`element` for the drawer's dialog semantics, nested-view border and focus management. Both consumers adopt it; below `md` it's the full-screen sheet only mobile-rendering hosts show (the drawer never mounts there).

Deliberately out of scope: `MerchantDrawerMobile`'s peek/gesture sheet — a genuinely different widget.

## Testing

- 26 e2e specs across both consumers green (map-drawer, map-add-form, placement dedupe, the three add-location suites); map-drawer 7/7 twice in a row after the timeout fix
- Drawer and form panel verified visually against the dev server — byte-equivalent card
- svelte-check / tsc / biome clean, 748 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Map panels now share a consistent layout and behavior across the map experience.
  - Panels display as floating cards on desktop and full-screen sheets on smaller screens.
  - Headers remain visible while scrolling through panel content.
  - The add-location form and merchant details panel now use the same panel presentation.

- **Bug Fixes**
  - Improved reliability when waiting for map markers to finish loading during automated checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->