### PR TITLE
style(add-location): replace unicode carets with the icon idioms #1134

### DIFF
--- a/src/components/add-location/AddLocationForm.svelte
+++ b/src/components/add-location/AddLocationForm.svelte
@@ -367,11 +367,17 @@ onMount(() => {
 	<div>
 		<button
 			type="button"
-			class="text-sm font-semibold text-link hover:text-hover focus:outline-link"
+			class="flex items-center gap-1 text-sm font-semibold text-link hover:text-hover focus:outline-link"
 			aria-expanded={showMoreDetails}
 			onclick={() => (showMoreDetails = !showMoreDetails)}
 		>
-			{showMoreDetails ? '▾' : '▸'}
+			<Icon
+				type="material"
+				icon="expand_more"
+				w="16"
+				h="16"
+				class={showMoreDetails ? 'rotate-180' : ''}
+			/>
 			{$_('addLocation.moreDetailsToggle')}
 		</button>
 	</div>
@@ -438,12 +444,18 @@ onMount(() => {
 			     the grid on re-open. -->
 			<button
 				type="button"
-				class="text-sm font-semibold text-link hover:text-hover focus:outline-link"
+				class="flex items-center gap-1 text-sm font-semibold text-link hover:text-hover focus:outline-link"
 				aria-expanded={showHoursEditor}
 				aria-controls="opening-hours-editor"
 				onclick={() => (showHoursEditor = !showHoursEditor)}
 			>
-				{showHoursEditor ? '▾' : '▸'}
+				<Icon
+					type="material"
+					icon="expand_more"
+					w="16"
+					h="16"
+					class={showHoursEditor ? 'rotate-180' : ''}
+				/>
 				{$_('addLocation.hoursToggle')}
 			</button>
 			{#if !showHoursEditor && hoursValue}

--- a/src/routes/map/components/AddPlaceMode.svelte
+++ b/src/routes/map/components/AddPlaceMode.svelte
@@ -6,6 +6,7 @@ import type {
 } from "maplibre-gl";
 import { tick } from "svelte";
 
+import Icon from "$components/Icon.svelte";
 import PlacementPinIcon from "$components/PlacementPinIcon.svelte";
 import { trackEvent } from "$lib/analytics";
 import {
@@ -475,8 +476,13 @@ $effect(() => {
 							>
 							<span class="shrink-0 text-sm text-body dark:text-offwhite"
 								>{Math.round(distanceM)} m
-								<span class="ml-1 font-semibold text-link"
-									>{$_("map.placement.nearbyUpdate")}<span aria-hidden="true"> ›</span></span
+								<span class="ml-1 inline-flex items-center font-semibold text-link"
+									>{$_("map.placement.nearbyUpdate")}<Icon
+										type="material"
+										icon="chevron_right"
+										w="14"
+										h="14"
+									/></span
 								></span
 							>
 						</a>


### PR DESCRIPTION
## What

Follow-up from the identity-chip redesign: an app-wide audit of unicode caret glyphs, replacing them where they stand in for an established icon idiom.

- The form's two disclosure toggles ("Add more details", "Set opening hours"): `▾/▸` → the `expand_more` icon with rotate-on-open (the TaggerTools/MerchantIssuesRow idiom)
- The dedupe interrupt's "Update ›": text chevron → the `chevron_right` icon (the IssueFilterChips/MerchantListItem idiom)

**Deliberately left**: the leaderboard tables' `▲/▼` sort indicators — a different semantic (sort direction, not disclosure), aria-hidden, and consistent across both header components. Happy to convert them too if preferred.

## Testing

- Accessible names unchanged, so all 8 related e2e specs pass unmodified
- svelte-check / tsc / biome clean; verified visually against the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)