### PR TITLE
refactor(auth): LoginForm to runes + shared AuthTextField #1326

### DIFF
--- a/src/components/auth/AuthTextField.svelte
+++ b/src/components/auth/AuthTextField.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+import type { Snippet } from "svelte";
+
+// The auth forms' shared label + input row (#1326): LoginForm,
+// SignupForm and the nsec field all repeated this markup. Rest props
+// flow to the input (minlength, placeholder, autocorrect, …) and
+// `inputClass` appends per-field styling (the nsec field's mono face);
+// an optional child snippet renders below the input for hints.
+type Props = {
+	id: string;
+	label: string;
+	value?: string;
+	type?: "text" | "password";
+	inputClass?: string;
+	children?: Snippet;
+	[key: string]: unknown;
+};
+let {
+	id,
+	label,
+	value = $bindable(""),
+	type = "text",
+	inputClass = "",
+	children,
+	...rest
+}: Props = $props();
+
+const inputClasses = $derived(
+	`w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-primary dark:border-white/20 dark:bg-dark dark:text-white ${inputClass}`,
+);
+</script>
+
+<div>
+	<label
+		for={id}
+		class="mb-1 block text-sm font-semibold text-primary dark:text-white"
+	>
+		{label}
+	</label>
+	<!-- Two static-typed inputs: Svelte forbids bind:value alongside a
+	     dynamic type attribute. -->
+	{#if type === 'password'}
+		<input {id} type="password" bind:value class={inputClasses} {...rest} />
+	{:else}
+		<input {id} type="text" bind:value class={inputClasses} {...rest} />
+	{/if}
+	{#if children}
+		{@render children()}
+	{/if}
+</div>

--- a/src/components/auth/LoginForm.svelte
+++ b/src/components/auth/LoginForm.svelte
@@ -13,17 +13,20 @@ import { errToast } from "$lib/utils";
 // Caller receives the new session after a successful login. This keeps the
 // form reusable: /login navigates, the save-flow modal completes a pending
 // save, both without baking navigation/save logic into the form.
-export let onSuccess: (session: Session) => void | Promise<void>;
+type Props = {
+	onSuccess: (session: Session) => void | Promise<void>;
+	// When true, render without the "Don't have an account?" link (e.g.
+	// inside a modal that already frames the login choice).
+	compact?: boolean;
+};
+let { onSuccess, compact = false }: Props = $props();
 
-// When true, render without the "Don't have an account?" link (e.g. inside
-// a modal that already frames the login choice).
-export let compact = false;
+let username = $state("");
+let password = $state("");
+let loading = $state(false);
 
-let username = "";
-let password = "";
-let loading = false;
-
-async function handleSubmit() {
+async function handleSubmit(event: SubmitEvent) {
+	event.preventDefault();
 	if (!username.trim() || !password) return;
 	loading = true;
 
@@ -58,7 +61,7 @@ async function handleSubmit() {
 }
 </script>
 
-<form on:submit|preventDefault={handleSubmit} class="space-y-4">
+<form onsubmit={handleSubmit} class="space-y-4">
 	<div>
 		<label
 			for="login-username"
@@ -105,10 +108,7 @@ async function handleSubmit() {
 {#if !compact}
 	<p class="mt-4 text-center text-sm text-body dark:text-white/70">
 		{$_("login.noAccount")}
-		<TextLink
-			link="/signup"
-			on:click={() => trackEvent("login_create_account_click")}
-		>
+		<TextLink link="/signup" onclick={() => trackEvent("login_create_account_click")}>
 			{$_("login.createAccount")}
 		</TextLink>
 	</p>

--- a/src/components/auth/LoginForm.svelte
+++ b/src/components/auth/LoginForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { get } from "svelte/store";
 
+import AuthTextField from "$components/auth/AuthTextField.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
 import TextLink from "$components/TextLink.svelte";
 import { trackEvent } from "$lib/analytics";
@@ -62,39 +63,22 @@ async function handleSubmit(event: SubmitEvent) {
 </script>
 
 <form onsubmit={handleSubmit} class="space-y-4">
-	<div>
-		<label
-			for="login-username"
-			class="mb-1 block text-sm font-semibold text-primary dark:text-white"
-		>
-			{$_("login.username")}
-		</label>
-		<input
-			id="login-username"
-			type="text"
-			bind:value={username}
-			autocomplete="username"
-			maxlength="100"
-			class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-primary dark:border-white/20 dark:bg-dark dark:text-white"
-		/>
-	</div>
+	<AuthTextField
+		id="login-username"
+		label={$_("login.username")}
+		bind:value={username}
+		autocomplete="username"
+		maxlength="100"
+	/>
 
-	<div>
-		<label
-			for="login-password"
-			class="mb-1 block text-sm font-semibold text-primary dark:text-white"
-		>
-			{$_("login.password")}
-		</label>
-		<input
-			id="login-password"
-			type="password"
-			bind:value={password}
-			autocomplete="current-password"
-			maxlength="200"
-			class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-primary dark:border-white/20 dark:bg-dark dark:text-white"
-		/>
-	</div>
+	<AuthTextField
+		id="login-password"
+		label={$_("login.password")}
+		type="password"
+		bind:value={password}
+		autocomplete="current-password"
+		maxlength="200"
+	/>
 
 	<PrimaryButton
 		type="submit"

--- a/src/components/auth/NostrLoginForm.svelte
+++ b/src/components/auth/NostrLoginForm.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { get } from "svelte/store";
 
+import AuthTextField from "$components/auth/AuthTextField.svelte";
 import api from "$lib/axios";
 import { _ } from "$lib/i18n";
 import type { SignedAuthEvent } from "$lib/nostr";
@@ -130,14 +131,9 @@ async function loginWithNsec(event: SubmitEvent) {
 
 {#if showNsecInput}
 	<form onsubmit={loginWithNsec} class="space-y-2">
-		<label
-			for="nsec"
-			class="block text-sm font-semibold text-primary dark:text-white"
-		>
-			{$_("login.nsecLabel")}
-		</label>
-		<input
+		<AuthTextField
 			id="nsec"
+			label={$_("login.nsecLabel")}
 			type="password"
 			bind:value={nsec}
 			placeholder="nsec1..."
@@ -145,7 +141,7 @@ async function loginWithNsec(event: SubmitEvent) {
 			autocorrect="off"
 			autocapitalize="off"
 			spellcheck="false"
-			class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-primary dark:border-white/20 dark:bg-dark dark:text-white"
+			inputClass="font-mono text-sm"
 		/>
 		<p class="text-xs text-body dark:text-white/50">
 			{$_("login.nsecWarning")}

--- a/src/components/auth/SignupForm.svelte
+++ b/src/components/auth/SignupForm.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import AuthTextField from "$components/auth/AuthTextField.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
 import { trackEvent } from "$lib/analytics";
 import { _ } from "$lib/i18n";
@@ -46,43 +47,27 @@ async function handleSubmit(event: SubmitEvent) {
 </script>
 
 <form onsubmit={handleSubmit} class="space-y-4">
-	<div>
-		<label
-			for="signup-username"
-			class="mb-1 block text-sm font-semibold text-primary dark:text-white"
-		>
-			{$_("signup.username")}
-		</label>
-		<input
-			id="signup-username"
-			type="text"
-			bind:value={username}
-			autocomplete="username"
-			maxlength="100"
-			class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-primary dark:border-white/20 dark:bg-dark dark:text-white"
-		/>
-	</div>
+	<AuthTextField
+		id="signup-username"
+		label={$_("signup.username")}
+		bind:value={username}
+		autocomplete="username"
+		maxlength="100"
+	/>
 
-	<div>
-		<label
-			for="signup-password"
-			class="mb-1 block text-sm font-semibold text-primary dark:text-white"
-		>
-			{$_("signup.password")}
-		</label>
-		<input
-			id="signup-password"
-			type="password"
-			bind:value={password}
-			autocomplete="new-password"
-			minlength={PASSWORD_MIN_LENGTH}
-			maxlength={PASSWORD_MAX_LENGTH}
-			class="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-primary dark:border-white/20 dark:bg-dark dark:text-white"
-		/>
+	<AuthTextField
+		id="signup-password"
+		label={$_("signup.password")}
+		type="password"
+		bind:value={password}
+		autocomplete="new-password"
+		minlength={PASSWORD_MIN_LENGTH}
+		maxlength={PASSWORD_MAX_LENGTH}
+	>
 		<p class="mt-1 text-xs text-body dark:text-white/50">
 			{$_("signup.passwordHint", { values: { min: PASSWORD_MIN_LENGTH } })}
 		</p>
-	</div>
+	</AuthTextField>
 
 	<PrimaryButton
 		type="submit"


### PR DESCRIPTION
## What

Closes #1326, in its two agreed steps:

1. **`LoginForm` → runes mode** (own commit): `$props` with `compact`, `$state` fields, `onsubmit` with `preventDefault` in the handler, the tracked signup link via TextLink's restProps `onclick` (the SaveAuthPrompt interop). Ticks the LoginForm box in #1208. Slightly overdue since #1339 embedded the form inside the runes add-location flow.
2. **`AuthTextField` extraction**: the shared label + input row used by `LoginForm`, `SignupForm` and `NostrLoginForm`'s nsec field. Rest props flow to the input (minlength, placeholder, autocorrect…), `inputClass` carries the nsec field's mono face, and an optional child snippet renders hints below (signup's password hint). Internally two static-typed inputs, since Svelte forbids `bind:value` with a dynamic `type`.

Per the issue, the login/signup **page-level** duplication (init/hydrate/goto) stays until a third auth page forces the question.

## Testing

- svelte-check / tsc / biome clean, 752 unit tests
- The add-location inline sign-in e2e (which renders LoginForm + the nsec form) passes unmodified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent shared text fields across login, signup, and secure-key authentication forms.
  - Preserved field hints, validation settings, password masking, autocomplete behavior, and specialized styling.

- **Refactor**
  - Updated the login form to use the latest component interaction patterns.
  - Consolidated repeated authentication form markup for a more consistent interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->