### PR TITLE
ci: point devs to pnpm icons:generate when the bundle check fails

### DIFF
--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -39,4 +39,7 @@ jobs:
       - name: Verify the icon bundle is up to date
         run: |
           pnpm run icons:generate
-          git diff --exit-code src/lib/icons/generated
+          if ! git diff --exit-code src/lib/icons/generated; then
+            echo "::error title=Icon bundle out of date::A new <Icon> usage or materialExceptions entry changed the generated icons (diff above). Fix: run 'pnpm icons:generate' locally and commit src/lib/icons/generated/."
+            exit 1
+          fi

--- a/.github/workflows/format-and-lint.yml
+++ b/.github/workflows/format-and-lint.yml
@@ -39,7 +39,12 @@ jobs:
       - name: Verify the icon bundle is up to date
         run: |
           pnpm run icons:generate
-          if ! git diff --exit-code src/lib/icons/generated; then
+          # Capture the exact status: git diff --exit-code returns 1 for a real
+          # diff (stale bundle) but other codes (e.g. 128) for a git failure —
+          # only the former should point the dev at `icons:generate`.
+          status=0
+          git diff --exit-code src/lib/icons/generated || status=$?
+          if [ "$status" -eq 1 ]; then
             echo "::error title=Icon bundle out of date::A new <Icon> usage or materialExceptions entry changed the generated icons (diff above). Fix: run 'pnpm icons:generate' locally and commit src/lib/icons/generated/."
-            exit 1
           fi
+          exit "$status"


### PR DESCRIPTION
**Does this PR address a related issue?**

Follow-up to #1353 (the offline icon bundle). No separate issue.

**A description of the changes proposed in the pull request**

The `format-and-lint` icon-bundle freshness check regenerates the bundle and `git diff --exit-code`s it. On a mismatch it printed the diff and exited 1 with no guidance, so a contributor who hit it in CI (rather than reading `AGENTS.md`) had no cue what to do. This adds a GitHub error annotation on failure naming the fix: run `pnpm icons:generate` and commit `src/lib/icons/generated/`. The diff still prints above it, so they see both what changed and how to resolve it.

Surfaced by the events PR (#1351), where a new `<Icon icon="event">` changed the generated bundle.

**Screenshots**

n/a (CI-only).

**Additional context**

The annotation uses the `::error::` workflow command, so it shows at the top of the run and inline on the PR. The check stays deterministic from the committed vocabulary and pinned icon-set packages, so it only fires on a genuine stale bundle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Developer Experience**
  - Improved CI feedback when generated icon files are out of date.
  - Error messages now explain how to regenerate the icon bundle and commit the updated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->