### PR TITLE
feat(tagger-onboarding): link the tagger guide from the intro #1368

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -53,7 +53,8 @@ export type EventName =
 	| "add_place_nearby_continue"
 	| "add_place_nearby_candidate_click"
 	| "add_place_address_prefill"
-	| "add_place_address_jump";
+	| "add_place_address_jump"
+	| "tagger_onboarding_guide_click";
 
 declare global {
 	interface Window {

--- a/src/routes/tagger-onboarding/+page.svelte
+++ b/src/routes/tagger-onboarding/+page.svelte
@@ -8,6 +8,7 @@ import FormSuccess from "$components/FormSuccess.svelte";
 import Icon from "$components/Icon.svelte";
 import HeaderPlaceholder from "$components/layout/HeaderPlaceholder.svelte";
 import PrimaryButton from "$components/PrimaryButton.svelte";
+import { trackEvent } from "$lib/analytics";
 import { _ } from "$lib/i18n";
 import { theme } from "$lib/theme";
 import { errToast } from "$lib/utils";
@@ -116,9 +117,25 @@ onMount(async () => {
 			Become a Tagger
 		</h2>
 
-		<p class="mb-10 w-full text-center text-primary dark:text-white">
+		<p class="mb-4 w-full text-center text-primary dark:text-white">
 			Taggers are volunteers who help keep BTC Map data accurate by verifying locations and adding
 			new merchants. Fill out this form to get started with the onboarding process.
+		</p>
+
+		<!-- Hardcoded English like the surrounding intro copy (only the form
+		     labels on this page are localized). -->
+		<p class="mb-10 w-full text-center text-sm text-body dark:text-offwhite">
+			New to tagging? The
+			<a
+				href="https://join.btcmap.org/"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="font-semibold text-link hover:text-hover"
+				on:click={() => trackEvent('tagger_onboarding_guide_click')}
+			>
+				tagger guide
+			</a>
+			walks you through your first edits.
 		</p>
 
 		<form on:submit={submitForm} class="w-full space-y-5 text-primary dark:text-white">


### PR DESCRIPTION
**Does this PR address a related issue?**

Part of #1368 (second placement, per its note) — does not close it; #1369 does.

**A description of the changes proposed in the pull request**

One line under the Become a Tagger intro: "New to tagging? The tagger guide walks you through your first edits" → https://join.btcmap.org/ (new tab, `noopener noreferrer`). The application form asks for commitment before showing what the work looks like — the guide is the actual onboarding material, so it belongs right where people decide to apply.

- New analytics event `tagger_onboarding_guide_click`.
- The line is hardcoded English like the surrounding intro copy (only the form labels on this page are localized) — noted in a code comment.
- Trivial edit, so no runes conversion of this legacy page (per the boy-scout rule's exception); it stays on the #1208 list.

**Screenshots**

(attached below)

**Additional context**

Independent of the #1367/#1369 stack — branches off main; whichever lands last trivially rebases the `EventName` union tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


![tagger-onboarding](https://github.com/user-attachments/assets/111f08fb-5d9e-4443-aef8-ffb31c0ca0dd)
